### PR TITLE
chore: kind(k8s) 로컬 인프라 - Kafka(events/alerts) + ClickHouse

### DIFF
--- a/k8s/00-namespace.yaml
+++ b/k8s/00-namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: edrdog
+  labels:
+    app.kubernetes.io/part-of: edrdog

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -1,0 +1,46 @@
+# EDRdog 로컬 인프라 (k8s / kind)
+
+모든 모듈의 전제. kind 클러스터에 Kafka(토픽 `events`/`alerts`) + ClickHouse 를 띄운다.
+호스트에서 도는 Spring 서비스가 NodePort 매핑으로 접근한다.
+
+## 기동
+
+```bash
+kind create cluster --config k8s/kind-cluster.yaml   # 클러스터 생성 (name: edrdog)
+# kind-cluster.yaml 은 kind 전용이라 apply 대상에서 제외 (아래는 실제 매니페스트만)
+kubectl apply -f k8s/00-namespace.yaml -f k8s/kafka.yaml -f k8s/clickhouse.yaml
+kubectl -n edrdog get pods                            # Running 확인
+```
+
+## 접속
+
+| 대상 | 호스트 주소 | 비고 |
+|---|---|---|
+| Kafka | `localhost:9092` | detector 등 (EXTERNAL 리스너) |
+| ClickHouse HTTP | `http://localhost:8123` | user/pw/db = `edrdog` |
+| ClickHouse native | `localhost:9000` | JDBC/드라이버용 |
+
+클러스터 내부(파드 간) Kafka 주소: `kafka.edrdog.svc.cluster.local:9094`
+
+## 확인
+
+```bash
+# 토픽 목록 (events / alerts 있어야 함)
+kubectl -n edrdog exec deploy/kafka -- \
+  /opt/kafka/bin/kafka-topics.sh --bootstrap-server localhost:9094 --list
+
+# ClickHouse ping
+curl http://localhost:8123/ping     # -> Ok.
+```
+
+## 종료
+
+```bash
+kind delete cluster --name edrdog    # 클러스터째 삭제 (데이터 emptyDir 라 함께 소멸)
+```
+
+## 메모
+
+- 개발용이라 **영속성 없음**(emptyDir). 파드 재시작 시 데이터 소멸.
+- ClickHouse **테이블 스키마는 이후 이슈**에서 (여기선 `edrdog` DB 만 준비).
+- watchdog 클러스터와 호스트 포트(9092/8123/9000)가 겹치므로 **동시 실행 불가**.

--- a/k8s/clickhouse.yaml
+++ b/k8s/clickhouse.yaml
@@ -1,0 +1,65 @@
+# ClickHouse — 이벤트 저장·조회(archiver/api-server). 개발용, 영속성 없음(emptyDir).
+# 스키마(테이블)는 이후 이슈에서. 여기서는 edrdog DB 만 준비.
+#   HTTP   8123 -> host localhost:8123
+#   native 9000 -> host localhost:9000
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: clickhouse
+  namespace: edrdog
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: clickhouse
+  template:
+    metadata:
+      labels:
+        app: clickhouse
+    spec:
+      containers:
+        - name: clickhouse
+          image: clickhouse/clickhouse-server:24.8
+          ports:
+            - containerPort: 8123  # HTTP
+            - containerPort: 9000  # native TCP
+          env:
+            - name: CLICKHOUSE_DB
+              value: edrdog
+            - name: CLICKHOUSE_USER
+              value: edrdog
+            - name: CLICKHOUSE_PASSWORD
+              value: edrdog
+            - name: CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT
+              value: "1"
+          readinessProbe:
+            httpGet:
+              path: /ping
+              port: 8123
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          resources:
+            requests:
+              cpu: 250m
+              memory: 512Mi
+            limits:
+              memory: 2Gi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: clickhouse
+  namespace: edrdog
+spec:
+  type: NodePort
+  selector:
+    app: clickhouse
+  ports:
+    - name: http
+      port: 8123
+      targetPort: 8123
+      nodePort: 30123
+    - name: native
+      port: 9000
+      targetPort: 9000
+      nodePort: 30900

--- a/k8s/kafka.yaml
+++ b/k8s/kafka.yaml
@@ -1,0 +1,117 @@
+# Kafka (KRaft, 단일 노드) — 개발용. 영속성 없음(emptyDir).
+# 리스너 2개:
+#   INTERNAL(9094) : 클러스터 내부용 -> kafka.edrdog.svc.cluster.local:9094
+#   EXTERNAL(9092) : 호스트용 (localhost:9092), NodePort 30092 로 노출
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kafka
+  namespace: edrdog
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: kafka
+  template:
+    metadata:
+      labels:
+        app: kafka
+    spec:
+      containers:
+        - name: kafka
+          image: apache/kafka:3.9.0
+          ports:
+            - containerPort: 9092  # EXTERNAL
+            - containerPort: 9094  # INTERNAL
+          env:
+            - name: KAFKA_NODE_ID
+              value: "1"
+            - name: KAFKA_PROCESS_ROLES
+              value: "broker,controller"
+            - name: KAFKA_CONTROLLER_QUORUM_VOTERS
+              value: "1@localhost:9093"
+            - name: KAFKA_LISTENERS
+              value: "CONTROLLER://:9093,INTERNAL://:9094,EXTERNAL://:9092"
+            - name: KAFKA_ADVERTISED_LISTENERS
+              value: "INTERNAL://kafka.edrdog.svc.cluster.local:9094,EXTERNAL://localhost:9092"
+            - name: KAFKA_LISTENER_SECURITY_PROTOCOL_MAP
+              value: "CONTROLLER:PLAINTEXT,INTERNAL:PLAINTEXT,EXTERNAL:PLAINTEXT"
+            - name: KAFKA_INTER_BROKER_LISTENER_NAME
+              value: "INTERNAL"
+            - name: KAFKA_CONTROLLER_LISTENER_NAMES
+              value: "CONTROLLER"
+            - name: KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR
+              value: "1"
+            - name: KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR
+              value: "1"
+            - name: KAFKA_TRANSACTION_STATE_LOG_MIN_ISR
+              value: "1"
+            - name: KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS
+              value: "0"
+          readinessProbe:
+            tcpSocket:
+              port: 9092
+            initialDelaySeconds: 15
+            periodSeconds: 10
+          resources:
+            requests:
+              cpu: 250m
+              memory: 512Mi
+            limits:
+              memory: 1Gi
+---
+# 클러스터 내부용 (INTERNAL 리스너)
+apiVersion: v1
+kind: Service
+metadata:
+  name: kafka
+  namespace: edrdog
+spec:
+  selector:
+    app: kafka
+  ports:
+    - name: internal
+      port: 9094
+      targetPort: 9094
+---
+# 호스트용 (EXTERNAL 리스너, NodePort -> kind -> localhost:9092)
+apiVersion: v1
+kind: Service
+metadata:
+  name: kafka-external
+  namespace: edrdog
+spec:
+  type: NodePort
+  selector:
+    app: kafka
+  ports:
+    - name: external
+      port: 9092
+      targetPort: 9092
+      nodePort: 30092
+---
+# 토픽 생성 Job — events / alerts (Issue #10 명시 요구)
+# kafka 준비 전 실행되면 실패하므로 OnFailure + backoffLimit 로 재시도.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: kafka-topic-init
+  namespace: edrdog
+spec:
+  backoffLimit: 10
+  template:
+    spec:
+      restartPolicy: OnFailure
+      containers:
+        - name: topic-init
+          image: apache/kafka:3.9.0
+          command: ["/bin/bash", "-c"]
+          args:
+            - |
+              BS=kafka.edrdog.svc.cluster.local:9094
+              /opt/kafka/bin/kafka-topics.sh --bootstrap-server $BS \
+                --create --if-not-exists --topic events --partitions 3 --replication-factor 1
+              /opt/kafka/bin/kafka-topics.sh --bootstrap-server $BS \
+                --create --if-not-exists --topic alerts --partitions 3 --replication-factor 1
+              echo "[topic-init] topics:"
+              /opt/kafka/bin/kafka-topics.sh --bootstrap-server $BS --list

--- a/k8s/kind-cluster.yaml
+++ b/k8s/kind-cluster.yaml
@@ -1,0 +1,21 @@
+# EDRdog 로컬 kind 클러스터 정의 (Issue #10)
+# 호스트에서 실행되는 Spring 서비스(detector 등)가 클러스터 안 인프라
+# (Kafka/ClickHouse)에 접근하도록 NodePort 를 호스트 포트로 매핑한다.
+#
+#   생성:  kind create cluster --config k8s/kind-cluster.yaml
+#   삭제:  kind delete cluster --name edrdog
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+name: edrdog
+nodes:
+  - role: control-plane
+    extraPortMappings:
+      - containerPort: 30092   # Kafka (EXTERNAL)    -> host localhost:9092
+        hostPort: 9092
+        protocol: TCP
+      - containerPort: 30123   # ClickHouse HTTP     -> host localhost:8123
+        hostPort: 8123
+        protocol: TCP
+      - containerPort: 30900   # ClickHouse native   -> host localhost:9000
+        hostPort: 9000
+        protocol: TCP


### PR DESCRIPTION
## 개요
로컬 인프라를 **kind(k8s) 클러스터**로 기동. Kafka(토픽 `events`/`alerts`) + ClickHouse. 모든 모듈의 전제.

> 이슈엔 docker-compose로 적혀 있었으나, **배포도 클라우드 k8s로 갈 예정**이라 로컬부터 k8s(kind)로 통일. Deployment/Service 매니페스트는 배포 시 그대로 재활용(로컬 전용 부분만 overlay 교체).

## 변경 (`k8s/`)
- `kind-cluster.yaml` — 로컬 kind 클러스터 정의 (host 9092/8123/9000 매핑)
- `00-namespace.yaml` — `edrdog` 네임스페이스
- `kafka.yaml` — Kafka(KRaft 단일 노드) + `events`/`alerts` 토픽 생성 Job
- `clickhouse.yaml` — ClickHouse(`edrdog` DB)
- `README.md` — 기동/접속/종료 사용법

watchdog 골격 이식. 배포 안 쓰는 Grafana·OTel은 제외.

## 검증 (로컬 기동 완료)
- Kafka·ClickHouse 파드 Running, 토픽 생성 Job 성공
- 토픽 `events`/`alerts` 생성 확인
- ClickHouse `edrdog` DB 존재, `localhost:8123/ping` → `Ok.`
- 호스트 포트 9092/8123/9000 LISTEN (detector `localhost:9092` 접속 가능)

## 메모
- 개발용이라 영속성 없음(emptyDir). ClickHouse 테이블 스키마는 이후 이슈.

Closes #10