### PR TITLE
feat: detector 상관분석 판정 및 alerts 발행 (#11)

### DIFF
--- a/detector/src/main/java/com/edrdog/detector/dto/Alert.java
+++ b/detector/src/main/java/com/edrdog/detector/dto/Alert.java
@@ -1,0 +1,40 @@
+package com.edrdog.detector.dto;
+
+import java.util.List;
+
+/**
+ * 상관분석 판정 결과 (alerts 토픽 발행 스키마).
+ *
+ * @param host     엔드포인트 식별자
+ * @param ruleId   매칭된 룰 식별자 (예: SUSPICIOUS_PROCESS_CHAIN)
+ * @param mitre    MITRE ATT&CK 기법 태그 (예: T1059)
+ * @param severity 심각도: HIGH | CRITICAL
+ * @param action   권고 대응: notify | kill | isolate (severity 매핑)
+ * @param ts       판정을 완성시킨 트리거 이벤트 시각 (epoch millis)
+ * @param matched  판정 근거가 된 이벤트 요약들
+ */
+public record Alert(
+        String host,
+        String ruleId,
+        String mitre,
+        String severity,
+        String action,
+        long ts,
+        List<String> matched
+) {
+    public static final String SEV_HIGH = "HIGH";
+    public static final String SEV_CRITICAL = "CRITICAL";
+
+    public static final String ACTION_NOTIFY = "notify";
+    public static final String ACTION_KILL = "kill";
+    public static final String ACTION_ISOLATE = "isolate";
+
+    /** severity → 권고 대응 매핑. CRITICAL 은 격리, HIGH 는 프로세스 종료, 그 외는 알림. */
+    public static String actionFor(String severity) {
+        return switch (severity) {
+            case SEV_CRITICAL -> ACTION_ISOLATE;
+            case SEV_HIGH -> ACTION_KILL;
+            default -> ACTION_NOTIFY;
+        };
+    }
+}

--- a/detector/src/main/java/com/edrdog/detector/dto/Event.java
+++ b/detector/src/main/java/com/edrdog/detector/dto/Event.java
@@ -1,0 +1,28 @@
+package com.edrdog.detector.dto;
+
+/**
+ * osquery/Zeek 원시 엔드포인트 이벤트 (판정 입력 스키마).
+ * host 를 상관분석 키로 사용. 여분 필드는 JsonSerde 가 무시하므로 원본에 필드가 더 있어도 안전.
+ *
+ * @param host      엔드포인트 식별자 (상관분석 키)
+ * @param type      이벤트 종류: "process" | "network"
+ * @param ts        발생 시각 (epoch millis) — event-time 윈도우 판정 기준
+ * @param process   프로세스명 (예: powershell.exe) — process 이벤트
+ * @param parent    부모 프로세스명 (예: winword.exe) — process 이벤트
+ * @param cmdline   명령행
+ * @param destIp    목적지 IP — network 이벤트
+ * @param destPort  목적지 포트 — network 이벤트
+ */
+public record Event(
+        String host,
+        String type,
+        long ts,
+        String process,
+        String parent,
+        String cmdline,
+        String destIp,
+        int destPort
+) {
+    public static final String TYPE_PROCESS = "process";
+    public static final String TYPE_NETWORK = "network";
+}

--- a/detector/src/main/java/com/edrdog/detector/kafkastreams/config/KafkaStreamsConfig.java
+++ b/detector/src/main/java/com/edrdog/detector/kafkastreams/config/KafkaStreamsConfig.java
@@ -1,11 +1,11 @@
-package com.edrdog.detector.global;
+package com.edrdog.detector.kafkastreams.config;
 
 import org.springframework.context.annotation.Configuration;
 import org.springframework.kafka.annotation.EnableKafkaStreams;
 
 /**
  * Kafka Streams 활성화. bootstrap-servers/application-id/serde 는 application.yml 에서 주입.
- * NOTE: 토폴로지(상관분석)를 이식하기 전엔 빈 토폴로지라 앱 실행 시 에러날 수 있음 — 스키마 설계 후 이식.
+ * 토폴로지는 DetectionTopology 가 StreamsBuilder 주입으로 등록한다.
  */
 @Configuration
 @EnableKafkaStreams

--- a/detector/src/main/java/com/edrdog/detector/kafkastreams/serde/JsonSerde.java
+++ b/detector/src/main/java/com/edrdog/detector/kafkastreams/serde/JsonSerde.java
@@ -1,4 +1,4 @@
-package com.edrdog.detector.global;
+package com.edrdog.detector.kafkastreams.serde;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/detector/src/main/java/com/edrdog/detector/kafkastreams/topology/CorrelationProcessor.java
+++ b/detector/src/main/java/com/edrdog/detector/kafkastreams/topology/CorrelationProcessor.java
@@ -1,0 +1,60 @@
+package com.edrdog.detector.kafkastreams.topology;
+
+import com.edrdog.detector.dto.Alert;
+import com.edrdog.detector.dto.Event;
+import com.edrdog.detector.rule.Rules;
+import org.apache.kafka.streams.processor.api.Processor;
+import org.apache.kafka.streams.processor.api.ProcessorContext;
+import org.apache.kafka.streams.processor.api.Record;
+import org.apache.kafka.streams.state.KeyValueStore;
+
+/**
+ * host(key) 별 이벤트 버퍼를 유지하며 시퀀스 상관분석을 수행.
+ * 각 이벤트마다: 윈도우 밖 선행 이벤트 제거 → 룰 판정 → 현재 이벤트 버퍼 적재 → 매칭 시 Alert 발행.
+ * event-time(이벤트 ts) 기준이라 결정적 — TopologyTestDriver 로 재현 가능.
+ */
+public class CorrelationProcessor implements Processor<String, Event, String, Alert> {
+
+    static final String STORE = "event-buffer";
+
+    private final long windowMs;
+    private KeyValueStore<String, EventBuffer> store;
+    private ProcessorContext<String, Alert> ctx;
+
+    public CorrelationProcessor(long windowMs) {
+        this.windowMs = windowMs;
+    }
+
+    @Override
+    public void init(ProcessorContext<String, Alert> context) {
+        this.ctx = context;
+        this.store = context.getStateStore(STORE);
+    }
+
+    @Override
+    public void process(Record<String, Event> record) {
+        Event current = record.value();
+        if (current == null || record.key() == null) {
+            return;
+        }
+        String host = record.key();
+
+        EventBuffer buffer = store.get(host);
+        if (buffer == null) {
+            buffer = new EventBuffer();
+        }
+        // 윈도우 밖(현재 이벤트 기준) 선행 이벤트 제거
+        buffer.events.removeIf(prev -> current.ts() - prev.ts() > windowMs);
+
+        // 선행 버퍼 + 현재 이벤트 상관 판정
+        Rules.evaluate(buffer.events, current).ifPresent(alert ->
+                ctx.forward(record.withKey(host).withValue(alert)));
+
+        // 현재 이벤트 적재 (상한 초과 시 가장 오래된 것부터 제거)
+        buffer.events.add(current);
+        while (buffer.events.size() > EventBuffer.MAX) {
+            buffer.events.remove(0);
+        }
+        store.put(host, buffer);
+    }
+}

--- a/detector/src/main/java/com/edrdog/detector/kafkastreams/topology/DetectionTopology.java
+++ b/detector/src/main/java/com/edrdog/detector/kafkastreams/topology/DetectionTopology.java
@@ -1,0 +1,60 @@
+package com.edrdog.detector.kafkastreams.topology;
+
+import com.edrdog.detector.dto.Alert;
+import com.edrdog.detector.dto.Event;
+import com.edrdog.detector.kafkastreams.serde.JsonSerde;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.kstream.Consumed;
+import org.apache.kafka.streams.kstream.Produced;
+import org.apache.kafka.streams.kstream.Repartitioned;
+import org.apache.kafka.streams.state.KeyValueStore;
+import org.apache.kafka.streams.state.StoreBuilder;
+import org.apache.kafka.streams.state.Stores;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+/**
+ * events → 상관분석 → alerts 토폴로지 정의.
+ * 입력 이벤트를 host 로 rekey 한 뒤 host 별 상태 저장소 기반으로 시퀀스 상관분석하여 alert 발행.
+ */
+@Component
+public class DetectionTopology {
+
+    /** 상관 윈도우: 이 시간 안의 선행 이벤트만 시퀀스로 인정. */
+    public static final long WINDOW_MS = 5 * 60 * 1000L;
+
+    private final String eventsTopic;
+    private final String alertsTopic;
+
+    public DetectionTopology(
+            @Value("${edrdog.kafka.events-topic}") String eventsTopic,
+            @Value("${edrdog.kafka.alerts-topic}") String alertsTopic) {
+        this.eventsTopic = eventsTopic;
+        this.alertsTopic = alertsTopic;
+    }
+
+    /** Spring Kafka Streams 가 주입하는 StreamsBuilder 에 파이프라인 등록. */
+    @Autowired
+    public void buildPipeline(StreamsBuilder builder) {
+        build(builder, eventsTopic, alertsTopic, WINDOW_MS);
+    }
+
+    /** 순수 토폴로지 구성 (TopologyTestDriver 테스트에서 직접 호출). */
+    public static void build(StreamsBuilder builder, String eventsTopic, String alertsTopic, long windowMs) {
+        StoreBuilder<KeyValueStore<String, EventBuffer>> storeBuilder = Stores.keyValueStoreBuilder(
+                Stores.persistentKeyValueStore(CorrelationProcessor.STORE),
+                Serdes.String(),
+                new JsonSerde<>(EventBuffer.class));
+        builder.addStateStore(storeBuilder);
+
+        builder.stream(eventsTopic, Consumed.with(Serdes.String(), new JsonSerde<>(Event.class)))
+                .selectKey((key, event) -> event == null ? null : event.host())
+                // host 기준 재분배 — 같은 host 이벤트를 한 태스크/스토어로 모아 상태 분할 방지
+                .repartition(Repartitioned.with(Serdes.String(), new JsonSerde<>(Event.class))
+                        .withName("events-by-host"))
+                .process(() -> new CorrelationProcessor(windowMs), CorrelationProcessor.STORE)
+                .to(alertsTopic, Produced.with(Serdes.String(), new JsonSerde<>(Alert.class)));
+    }
+}

--- a/detector/src/main/java/com/edrdog/detector/kafkastreams/topology/EventBuffer.java
+++ b/detector/src/main/java/com/edrdog/detector/kafkastreams/topology/EventBuffer.java
@@ -1,0 +1,18 @@
+package com.edrdog.detector.kafkastreams.topology;
+
+import com.edrdog.detector.dto.Event;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * host 별 최근 이벤트 버퍼 (state store 값). 윈도우 밖 이벤트는 프로세서가 pruning 한다.
+ * Jackson 직렬화를 위해 public 필드 + 기본 생성자 사용.
+ */
+public class EventBuffer {
+
+    /** 최대 보관 개수 — 폭주 host 로부터 상태 크기를 방어. */
+    public static final int MAX = 200;
+
+    public List<Event> events = new ArrayList<>();
+}

--- a/detector/src/main/java/com/edrdog/detector/rule/Rules.java
+++ b/detector/src/main/java/com/edrdog/detector/rule/Rules.java
@@ -1,0 +1,127 @@
+package com.edrdog.detector.rule;
+
+import com.edrdog.detector.dto.Alert;
+import com.edrdog.detector.dto.Event;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * 시퀀스 상관분석 룰 판정 (순수 로직). 버퍼(prior)는 프로세서가 윈도우로 정리한 뒤 넘겨준다.
+ * 각 룰은 버퍼의 선행 이벤트 + 현재 이벤트를 상관하여 판정한다.
+ */
+public final class Rules {
+
+    private Rules() {
+    }
+
+    /** office 계열 앱 — 이 앱이 shell 을 자식으로 띄우면 매크로/문서 기반 침투 의심. */
+    private static final Set<String> OFFICE_APPS = Set.of(
+            "winword.exe", "excel.exe", "powerpnt.exe", "outlook.exe");
+
+    /** 인터프리터/스크립트 shell — office 자식으로 뜨면 위험. */
+    private static final Set<String> SHELLS = Set.of(
+            "powershell.exe", "cmd.exe", "wscript.exe", "cscript.exe", "mshta.exe");
+
+    /** 다운로드로 간주하는 목적지 포트 (HTTP/HTTPS 계열). */
+    private static final Set<Integer> DOWNLOAD_PORTS = Set.of(80, 443, 8080);
+
+    /** baseline: 알려진 정상 프로세스 — 룰에 걸려도 오탐이므로 억제. */
+    private static final Set<String> BASELINE_SAFE = Set.of(
+            "onedrive.exe", "teams.exe", "gupdate.exe", "msedgeupdate.exe", "update.exe");
+
+    /**
+     * 현재 이벤트가 선행 버퍼와 상관되어 룰을 완성하면 Alert 반환. 여러 룰 매칭 시 가장 심각한 것 채택.
+     */
+    public static Optional<Alert> evaluate(List<Event> prior, Event current) {
+        if (current == null || current.host() == null) {
+            return Optional.empty();
+        }
+        // 더 심각한 R2(CRITICAL) 를 먼저 시도
+        Optional<Alert> r2 = downloadAndExecute(prior, current);
+        if (r2.isPresent()) {
+            return r2;
+        }
+        return suspiciousProcessChain(prior, current);
+    }
+
+    /** R1 T1059: 버퍼의 office앱 exec → 그 office앱을 부모로 shell 실행. */
+    private static Optional<Alert> suspiciousProcessChain(List<Event> prior, Event current) {
+        if (!isProcess(current)) {
+            return Optional.empty();
+        }
+        String child = lower(current.process());
+        String parent = lower(current.parent());
+        if (!in(SHELLS, child) || !in(OFFICE_APPS, parent) || isBaseline(child)) {
+            return Optional.empty();
+        }
+        // 시퀀스: 그 office앱(부모)의 exec 이벤트가 버퍼에 선행해야 함
+        Optional<Event> officeExec = prior.stream()
+                .filter(Rules::isProcess)
+                .filter(e -> parent.equals(lower(e.process())))
+                .findFirst();
+        if (officeExec.isEmpty()) {
+            return Optional.empty();
+        }
+        return Optional.of(new Alert(
+                current.host(),
+                "SUSPICIOUS_PROCESS_CHAIN",
+                "T1059",
+                Alert.SEV_HIGH,
+                Alert.actionFor(Alert.SEV_HIGH),
+                current.ts(),
+                List.of(summary(officeExec.get()), summary(current))));
+    }
+
+    /** R2 T1105+T1204: 버퍼의 network 다운로드 → 이후 process 실행. */
+    private static Optional<Alert> downloadAndExecute(List<Event> prior, Event current) {
+        if (!isProcess(current) || isBaseline(lower(current.process()))) {
+            return Optional.empty();
+        }
+        Optional<Event> download = prior.stream()
+                .filter(Rules::isNetwork)
+                .filter(e -> DOWNLOAD_PORTS.contains(e.destPort()))
+                .findFirst();
+        if (download.isEmpty()) {
+            return Optional.empty();
+        }
+        return Optional.of(new Alert(
+                current.host(),
+                "DOWNLOAD_AND_EXECUTE",
+                "T1105+T1204",
+                Alert.SEV_CRITICAL,
+                Alert.actionFor(Alert.SEV_CRITICAL),
+                current.ts(),
+                List.of(summary(download.get()), summary(current))));
+    }
+
+    private static boolean isProcess(Event e) {
+        return Event.TYPE_PROCESS.equals(e.type());
+    }
+
+    private static boolean isNetwork(Event e) {
+        return Event.TYPE_NETWORK.equals(e.type());
+    }
+
+    /** null 안전한 집합 포함 검사 (immutable Set 은 contains(null) 시 NPE). */
+    private static boolean in(Set<String> set, String value) {
+        return value != null && set.contains(value);
+    }
+
+    private static boolean isBaseline(String process) {
+        return in(BASELINE_SAFE, process);
+    }
+
+    private static String lower(String s) {
+        return s == null ? null : s.toLowerCase();
+    }
+
+    /** 근거 이벤트를 사람이 읽을 요약으로. */
+    private static String summary(Event e) {
+        if (isNetwork(e)) {
+            return "network " + e.destIp() + ":" + e.destPort();
+        }
+        return "process " + e.process() + " (parent " + e.parent() + ")";
+    }
+}

--- a/detector/src/test/java/com/edrdog/detector/kafkastreams/topology/DetectionTopologyTest.java
+++ b/detector/src/test/java/com/edrdog/detector/kafkastreams/topology/DetectionTopologyTest.java
@@ -1,0 +1,100 @@
+package com.edrdog.detector.kafkastreams.topology;
+
+import com.edrdog.detector.dto.Alert;
+import com.edrdog.detector.dto.Event;
+import com.edrdog.detector.kafkastreams.serde.JsonSerde;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.TestInputTopic;
+import org.apache.kafka.streams.TestOutputTopic;
+import org.apache.kafka.streams.TopologyTestDriver;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Properties;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** events → alerts 토폴로지 end-to-end 판정 검증 (TopologyTestDriver). */
+class DetectionTopologyTest {
+
+    private static final String EVENTS = "events";
+    private static final String ALERTS = "alerts";
+
+    private TopologyTestDriver driver;
+    private TestInputTopic<String, Event> events;
+    private TestOutputTopic<String, Alert> alerts;
+
+    @BeforeEach
+    void setUp() {
+        StreamsBuilder builder = new StreamsBuilder();
+        DetectionTopology.build(builder, EVENTS, ALERTS, DetectionTopology.WINDOW_MS);
+
+        Properties props = new Properties();
+        props.put("application.id", "detector-test");
+        props.put("bootstrap.servers", "dummy:9092");
+
+        driver = new TopologyTestDriver(builder.build(), props);
+        events = driver.createInputTopic(EVENTS, Serdes.String().serializer(),
+                new JsonSerde<>(Event.class).serializer());
+        alerts = driver.createOutputTopic(ALERTS, Serdes.String().deserializer(),
+                new JsonSerde<>(Alert.class).deserializer());
+    }
+
+    @AfterEach
+    void tearDown() {
+        driver.close();
+    }
+
+    private Event process(String host, String proc, String parent, long ts) {
+        return new Event(host, Event.TYPE_PROCESS, ts, proc, parent, proc, null, 0);
+    }
+
+    private Event network(String host, int destPort, long ts) {
+        return new Event(host, Event.TYPE_NETWORK, ts, null, null, null, "203.0.113.9", destPort);
+    }
+
+    @Test
+    @DisplayName("office → shell 시퀀스 → alerts 에 T1059 1건 발행")
+    void processChain_emitsAlert() {
+        events.pipeInput("k", process("host-1", "winword.exe", "explorer.exe", 1000));
+        events.pipeInput("k", process("host-1", "powershell.exe", "winword.exe", 2000));
+
+        assertThat(alerts.getQueueSize()).isEqualTo(1);
+        var record = alerts.readKeyValue();
+        assertThat(record.key).isEqualTo("host-1");
+        assertThat(record.value.ruleId()).isEqualTo("SUSPICIOUS_PROCESS_CHAIN");
+        assertThat(record.value.action()).isEqualTo(Alert.ACTION_KILL);
+    }
+
+    @Test
+    @DisplayName("network 다운로드 → 실행 시퀀스 → alerts 에 CRITICAL 발행")
+    void downloadExecute_emitsAlert() {
+        events.pipeInput("k", network("host-2", 443, 1000));
+        events.pipeInput("k", process("host-2", "evil.exe", "cmd.exe", 2000));
+
+        assertThat(alerts.getQueueSize()).isEqualTo(1);
+        assertThat(alerts.readValue().severity()).isEqualTo(Alert.SEV_CRITICAL);
+    }
+
+    @Test
+    @DisplayName("host 가 다르면 상관되지 않아 미판정")
+    void differentHosts_noAlert() {
+        events.pipeInput("k", process("host-A", "winword.exe", "explorer.exe", 1000));
+        events.pipeInput("k", process("host-B", "powershell.exe", "winword.exe", 2000));
+
+        assertThat(alerts.isEmpty()).isTrue();
+    }
+
+    @Test
+    @DisplayName("윈도우 밖 선행 이벤트는 시퀀스에서 제외되어 미판정")
+    void outsideWindow_noAlert() {
+        events.pipeInput("k", process("host-3", "winword.exe", "explorer.exe", 1000));
+        long past = 1000 + DetectionTopology.WINDOW_MS + 1;
+        events.pipeInput("k", process("host-3", "powershell.exe", "winword.exe", past));
+
+        assertThat(alerts.isEmpty()).isTrue();
+    }
+}

--- a/detector/src/test/java/com/edrdog/detector/rule/RulesTest.java
+++ b/detector/src/test/java/com/edrdog/detector/rule/RulesTest.java
@@ -1,0 +1,114 @@
+package com.edrdog.detector.rule;
+
+import com.edrdog.detector.dto.Alert;
+import com.edrdog.detector.dto.Event;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** 상관분석 룰 판정 순수 로직 테스트. 버퍼는 이미 윈도우로 정리됐다고 가정(윈도우 판정은 프로세서 책임). */
+class RulesTest {
+
+    private static final String HOST = "host-1";
+
+    private Event process(String proc, String parent, long ts) {
+        return new Event(HOST, Event.TYPE_PROCESS, ts, proc, parent, proc + " args", null, 0);
+    }
+
+    private Event network(String destIp, int destPort, long ts) {
+        return new Event(HOST, Event.TYPE_NETWORK, ts, null, null, null, destIp, destPort);
+    }
+
+    @Test
+    @DisplayName("R1: office앱 exec 후 그 자식으로 shell 실행 → SUSPICIOUS_PROCESS_CHAIN(T1059, HIGH, kill)")
+    void r1_officeThenShell_alerts() {
+        List<Event> buffer = List.of(process("winword.exe", "explorer.exe", 1000));
+        Event current = process("powershell.exe", "winword.exe", 2000);
+
+        Optional<Alert> alert = Rules.evaluate(buffer, current);
+
+        assertThat(alert).isPresent();
+        Alert a = alert.get();
+        assertThat(a.host()).isEqualTo(HOST);
+        assertThat(a.ruleId()).isEqualTo("SUSPICIOUS_PROCESS_CHAIN");
+        assertThat(a.mitre()).isEqualTo("T1059");
+        assertThat(a.severity()).isEqualTo(Alert.SEV_HIGH);
+        assertThat(a.action()).isEqualTo(Alert.ACTION_KILL);
+        assertThat(a.ts()).isEqualTo(2000);
+        assertThat(a.matched()).hasSize(2);
+    }
+
+    @Test
+    @DisplayName("R1 음성: shell 이지만 부모가 office앱이 아니면 미판정")
+    void r1_shellWithNonOfficeParent_noAlert() {
+        List<Event> buffer = List.of(process("explorer.exe", "userinit.exe", 1000));
+        Event current = process("powershell.exe", "explorer.exe", 2000);
+
+        assertThat(Rules.evaluate(buffer, current)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("R1 음성: 부모가 office앱이지만 그 office앱 exec 가 버퍼에 없으면 미판정(시퀀스 미완성)")
+    void r1_noOfficeExecInBuffer_noAlert() {
+        List<Event> buffer = List.of();
+        Event current = process("powershell.exe", "winword.exe", 2000);
+
+        assertThat(Rules.evaluate(buffer, current)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("R2: network 다운로드 후 같은 host 에서 process 실행 → DOWNLOAD_AND_EXECUTE(T1105+T1204, CRITICAL, isolate)")
+    void r2_downloadThenExecute_alerts() {
+        List<Event> buffer = List.of(network("203.0.113.9", 443, 1000));
+        Event current = process("evil.exe", "cmd.exe", 2000);
+
+        Optional<Alert> alert = Rules.evaluate(buffer, current);
+
+        assertThat(alert).isPresent();
+        Alert a = alert.get();
+        assertThat(a.ruleId()).isEqualTo("DOWNLOAD_AND_EXECUTE");
+        assertThat(a.mitre()).isEqualTo("T1105+T1204");
+        assertThat(a.severity()).isEqualTo(Alert.SEV_CRITICAL);
+        assertThat(a.action()).isEqualTo(Alert.ACTION_ISOLATE);
+        assertThat(a.ts()).isEqualTo(2000);
+        assertThat(a.matched()).hasSize(2);
+    }
+
+    @Test
+    @DisplayName("R2 음성: network 이벤트의 포트가 다운로드 포트가 아니면 미판정")
+    void r2_nonDownloadPort_noAlert() {
+        List<Event> buffer = List.of(network("203.0.113.9", 22, 1000));
+        Event current = process("evil.exe", "cmd.exe", 2000);
+
+        assertThat(Rules.evaluate(buffer, current)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("baseline: 알려진 정상 프로세스는 다운로드 후 실행이어도 억제")
+    void baseline_knownBenignProcess_suppressed() {
+        List<Event> buffer = List.of(network("203.0.113.9", 443, 1000));
+        Event current = process("onedrive.exe", "explorer.exe", 2000);
+
+        assertThat(Rules.evaluate(buffer, current)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("두 룰 동시 매칭 시 더 심각한 CRITICAL(R2) 채택")
+    void bothMatch_pickMostSevere() {
+        List<Event> buffer = List.of(
+                process("winword.exe", "explorer.exe", 900),
+                network("203.0.113.9", 443, 1000)
+        );
+        Event current = process("powershell.exe", "winword.exe", 2000);
+
+        Optional<Alert> alert = Rules.evaluate(buffer, current);
+
+        assertThat(alert).isPresent();
+        assertThat(alert.get().severity()).isEqualTo(Alert.SEV_CRITICAL);
+        assertThat(alert.get().ruleId()).isEqualTo("DOWNLOAD_AND_EXECUTE");
+    }
+}


### PR DESCRIPTION
## 개요
`events` 소비 → host별 시퀀스 상관분석 판정 → `alerts` 발행. Closes #11

## 구성 (계층별)
- **dto/** — `Event`(판정 입력), `Alert`(발행, severity→action 매핑)
- **rule/** — `Rules` 순수 판정 로직
- **kafkastreams/** — `config`(KafkaStreamsConfig), `serde`(JsonSerde), `topology`(DetectionTopology, CorrelationProcessor, EventBuffer)

## 탐지 룰
| ruleId | MITRE | 시퀀스 | severity | action |
|---|---|---|---|---|
| SUSPICIOUS_PROCESS_CHAIN | T1059 | office앱 exec → 그 자식으로 shell 실행 | HIGH | kill |
| DOWNLOAD_AND_EXECUTE | T1105+T1204 | network 다운로드 → 이후 process 실행 | CRITICAL | isolate |

- host별 state store 버퍼 + 5분 event-time 윈도우로 시퀀스 상관
- host 기준 재분배로 멀티 파티션에서도 상태 분할 방지
- baseline 으로 알려진 정상 프로세스 오탐 억제

## 테스트 (TDD)
- `RulesTest` 7건 — 순수 판정 로직
- `DetectionTopologyTest` 4건 — TopologyTestDriver end-to-end
- 전체 11건 통과, 빌드 성공

## 커밋
계층별 3개 커밋(dto → rule → kafkastreams), 각 커밋 독립 컴파일.