### PR TITLE
feat: responder 권장 조치 dry-run (#12)

### DIFF
--- a/responder/build.gradle
+++ b/responder/build.gradle
@@ -1,0 +1,6 @@
+// Responder — alerts 를 소비해 권장 조치를 dry-run(표시만)으로 로그 출력 (group: responder)
+dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter'
+    implementation 'org.springframework.kafka:spring-kafka'
+    implementation 'com.fasterxml.jackson.core:jackson-databind'   // alerts JSON 역직렬화
+}

--- a/responder/src/main/java/com/edrdog/responder/AlertListener.java
+++ b/responder/src/main/java/com/edrdog/responder/AlertListener.java
@@ -1,0 +1,30 @@
+package com.edrdog.responder;
+
+import com.edrdog.responder.dto.Alert;
+import com.edrdog.responder.response.ResponsePlanner;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+/**
+ * alerts 토픽을 소비해 권장 조치를 dry-run 으로 표시(로그)만 하는 리스너.
+ * 판정/쿨다운은 ResponsePlanner(순수 로직)에 위임하고, 여기서는 소비와 로그 출력만 담당한다.
+ */
+@Component
+public class AlertListener {
+
+    private static final Logger log = LoggerFactory.getLogger(AlertListener.class);
+
+    private final ResponsePlanner planner;
+
+    public AlertListener(@Value("${edrdog.responder.cooldown-ms}") long cooldownMs) {
+        this.planner = new ResponsePlanner(cooldownMs);
+    }
+
+    @KafkaListener(topics = "${edrdog.kafka.alerts-topic}", groupId = "${spring.kafka.consumer.group-id}")
+    public void onAlert(Alert alert) {
+        planner.plan(alert).ifPresent(log::info);
+    }
+}

--- a/responder/src/main/java/com/edrdog/responder/ResponderApplication.java
+++ b/responder/src/main/java/com/edrdog/responder/ResponderApplication.java
@@ -1,0 +1,13 @@
+package com.edrdog.responder;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+/** alerts 를 소비해 권장 조치를 dry-run 으로 표시하는 responder 서비스. */
+@SpringBootApplication
+public class ResponderApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(ResponderApplication.class, args);
+    }
+}

--- a/responder/src/main/java/com/edrdog/responder/dto/Alert.java
+++ b/responder/src/main/java/com/edrdog/responder/dto/Alert.java
@@ -1,0 +1,29 @@
+package com.edrdog.responder.dto;
+
+import java.util.List;
+
+/**
+ * detector 가 alerts 토픽에 발행하는 판정 결과 (responder 소비용 사본).
+ * 소비자는 자기 관점의 스키마 사본을 갖는다. 여분 필드는 JsonDeserializer 가 무시한다.
+ *
+ * @param host     엔드포인트 식별자
+ * @param ruleId   매칭된 룰 식별자 (예: SUSPICIOUS_PROCESS_CHAIN)
+ * @param mitre    MITRE ATT&CK 기법 태그 (예: T1059)
+ * @param severity 심각도: HIGH | CRITICAL
+ * @param action   권고 대응: notify | kill | isolate
+ * @param ts       판정을 완성시킨 트리거 이벤트 시각 (epoch millis)
+ * @param matched  판정 근거가 된 이벤트 요약들
+ */
+public record Alert(
+        String host,
+        String ruleId,
+        String mitre,
+        String severity,
+        String action,
+        long ts,
+        List<String> matched
+) {
+    public static final String ACTION_NOTIFY = "notify";
+    public static final String ACTION_KILL = "kill";
+    public static final String ACTION_ISOLATE = "isolate";
+}

--- a/responder/src/main/java/com/edrdog/responder/response/Cooldown.java
+++ b/responder/src/main/java/com/edrdog/responder/response/Cooldown.java
@@ -1,0 +1,28 @@
+package com.edrdog.responder.response;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * 키별 마지막 표시 시각을 기억해 윈도우 안 중복 표시를 억제하는 순수 로직.
+ * 시각(nowMs)은 호출자가 주입한다 (벽시계 대신 alert 이벤트 시각 사용 → 결정적).
+ */
+public class Cooldown {
+
+    private final long windowMs;
+    private final Map<String, Long> lastShown = new HashMap<>();
+
+    public Cooldown(long windowMs) {
+        this.windowMs = windowMs;
+    }
+
+    /** 키가 윈도우 밖이면 통과시키고 시각을 갱신, 윈도우 안이면 억제. */
+    public boolean allow(String key, long nowMs) {
+        Long last = lastShown.get(key);
+        if (last != null && nowMs - last < windowMs) {
+            return false;
+        }
+        lastShown.put(key, nowMs);
+        return true;
+    }
+}

--- a/responder/src/main/java/com/edrdog/responder/response/ResponsePlanner.java
+++ b/responder/src/main/java/com/edrdog/responder/response/ResponsePlanner.java
@@ -1,0 +1,45 @@
+package com.edrdog.responder.response;
+
+import com.edrdog.responder.dto.Alert;
+
+import java.util.Optional;
+
+/**
+ * alert 의 권고 action 을 사람이 읽을 dry-run 조치 텍스트로 변환하는 순수 로직.
+ * 실제 실행은 하지 않으며(표시만), host+action 단위로 쿨다운을 적용한다.
+ */
+public class ResponsePlanner {
+
+    private final Cooldown cooldown;
+
+    public ResponsePlanner(long cooldownMs) {
+        this.cooldown = new Cooldown(cooldownMs);
+    }
+
+    /** 쿨다운을 통과하면 dry-run 표시 줄을 반환, 억제되거나 입력이 불완전하면 비어 있음. */
+    public Optional<String> plan(Alert alert) {
+        if (alert == null || alert.host() == null || alert.action() == null) {
+            return Optional.empty();
+        }
+        String key = alert.host() + "|" + alert.action();
+        if (!cooldown.allow(key, alert.ts())) {
+            return Optional.empty();
+        }
+        return Optional.of(format(alert));
+    }
+
+    /** action → 권장 조치 텍스트. 알 수 없는 action 은 알림으로 처리. */
+    static String label(String action) {
+        return switch (action) {
+            case Alert.ACTION_KILL -> "프로세스 종료 권장";
+            case Alert.ACTION_ISOLATE -> "호스트 격리 권장";
+            default -> "알림 권장";
+        };
+    }
+
+    /** trigger=response 로 태깅된 dry-run 한 줄. 실제 실행은 없음을 명시. */
+    static String format(Alert alert) {
+        return String.format("[DRY-RUN] trigger=response host=%s rule=%s action=%s → %s (실행 안 함)",
+                alert.host(), alert.ruleId(), alert.action(), label(alert.action()));
+    }
+}

--- a/responder/src/main/resources/application.yml
+++ b/responder/src/main/resources/application.yml
@@ -1,0 +1,28 @@
+spring:
+  application:
+    name: responder
+  kafka:
+    bootstrap-servers: localhost:9092
+    consumer:
+      group-id: responder
+      auto-offset-reset: latest
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
+      properties:
+        spring.json.value.default.type: com.edrdog.responder.dto.Alert
+        spring.json.trusted.packages: com.edrdog.responder.dto
+
+server:
+  port: 8082
+
+edrdog:
+  kafka:
+    alerts-topic: alerts        # detector 가 발행한 판정 결과 (소비 입력)
+  responder:
+    cooldown-ms: 60000          # 같은 host+action 중복 표시 억제 창
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health, info

--- a/responder/src/test/java/com/edrdog/responder/response/CooldownTest.java
+++ b/responder/src/test/java/com/edrdog/responder/response/CooldownTest.java
@@ -1,0 +1,42 @@
+package com.edrdog.responder.response;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** 같은 키의 중복 표시를 윈도우 동안 억제하는 쿨다운 순수 로직 검증. */
+class CooldownTest {
+
+    @Test
+    @DisplayName("첫 호출은 통과")
+    void firstAllow() {
+        Cooldown cooldown = new Cooldown(60_000);
+        assertThat(cooldown.allow("host-1|kill", 1_000)).isTrue();
+    }
+
+    @Test
+    @DisplayName("윈도우 안 같은 키 재호출은 억제")
+    void withinWindow_suppressed() {
+        Cooldown cooldown = new Cooldown(60_000);
+        cooldown.allow("host-1|kill", 1_000);
+        assertThat(cooldown.allow("host-1|kill", 60_000)).isFalse();
+    }
+
+    @Test
+    @DisplayName("윈도우 경과 후 같은 키는 다시 통과")
+    void afterWindow_allowed() {
+        Cooldown cooldown = new Cooldown(60_000);
+        cooldown.allow("host-1|kill", 1_000);
+        assertThat(cooldown.allow("host-1|kill", 61_000)).isTrue();
+    }
+
+    @Test
+    @DisplayName("키가 다르면 서로 독립적으로 통과")
+    void differentKeys_independent() {
+        Cooldown cooldown = new Cooldown(60_000);
+        cooldown.allow("host-1|kill", 1_000);
+        assertThat(cooldown.allow("host-1|isolate", 1_000)).isTrue();
+        assertThat(cooldown.allow("host-2|kill", 1_000)).isTrue();
+    }
+}

--- a/responder/src/test/java/com/edrdog/responder/response/ResponsePlannerTest.java
+++ b/responder/src/test/java/com/edrdog/responder/response/ResponsePlannerTest.java
@@ -1,0 +1,57 @@
+package com.edrdog.responder.response;
+
+import com.edrdog.responder.dto.Alert;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** alert → dry-run 조치 텍스트 매핑과 쿨다운 억제 검증 (순수 로직). */
+class ResponsePlannerTest {
+
+    private Alert alert(String host, String ruleId, String action, long ts) {
+        return new Alert(host, ruleId, "T1059", "HIGH", action, ts, List.of("evidence"));
+    }
+
+    @Test
+    @DisplayName("kill 은 프로세스 종료 권장 텍스트로, trigger=response 태깅되어 표시")
+    void kill_mapsToText() {
+        ResponsePlanner planner = new ResponsePlanner(60_000);
+        String line = planner.plan(alert("host-1", "SUSPICIOUS_PROCESS_CHAIN", Alert.ACTION_KILL, 1_000)).orElseThrow();
+
+        assertThat(line).contains("trigger=response");
+        assertThat(line).contains("host=host-1");
+        assertThat(line).contains("action=kill");
+        assertThat(line).contains("프로세스 종료 권장");
+    }
+
+    @Test
+    @DisplayName("isolate 는 호스트 격리 권장 텍스트로 표시")
+    void isolate_mapsToText() {
+        ResponsePlanner planner = new ResponsePlanner(60_000);
+        String line = planner.plan(alert("host-2", "DOWNLOAD_AND_EXECUTE", Alert.ACTION_ISOLATE, 1_000)).orElseThrow();
+
+        assertThat(line).contains("action=isolate");
+        assertThat(line).contains("호스트 격리 권장");
+    }
+
+    @Test
+    @DisplayName("같은 host+action 이 쿨다운 안에 다시 오면 표시 안 함")
+    void sameHostAction_withinCooldown_suppressed() {
+        ResponsePlanner planner = new ResponsePlanner(60_000);
+        planner.plan(alert("host-1", "R", Alert.ACTION_KILL, 1_000));
+
+        assertThat(planner.plan(alert("host-1", "R", Alert.ACTION_KILL, 30_000))).isEmpty();
+    }
+
+    @Test
+    @DisplayName("같은 host 라도 action 이 다르면 각각 표시")
+    void sameHost_differentAction_shown() {
+        ResponsePlanner planner = new ResponsePlanner(60_000);
+        planner.plan(alert("host-1", "R", Alert.ACTION_KILL, 1_000));
+
+        assertThat(planner.plan(alert("host-1", "R", Alert.ACTION_ISOLATE, 1_000))).isPresent();
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,4 @@
 rootProject.name = 'edrdog-backend'
 
 include 'detector'
+include 'responder'


### PR DESCRIPTION
## 개요
`alerts` 토픽을 소비해 룰의 권고 조치(프로세스 종료 / 호스트 격리)를 **dry-run(표시만)** 으로 로그 출력하는 responder 모듈. 실제 실행 없음, AI 아님. Closes #12

## 동작
- `@KafkaListener(alerts)` 로 소비 → 쿨다운 통과 시에만 로그 한 줄:
  ```
  [DRY-RUN] trigger=response host=host-1 rule=SUSPICIOUS_PROCESS_CHAIN action=kill → 프로세스 종료 권장 (실행 안 함)
  ```
- `kill` → 프로세스 종료 권장, `isolate` → 호스트 격리 권장
- **쿨다운**: 같은 `host+action` 은 60초 내 중복 표시 억제 (노이즈 방지)
- **태깅**: 출력에 `trigger=response`

## 설계
- 신규 `responder` 모듈 (Spring Boot + spring-kafka 소비자)
- `Alert` 스키마는 responder에 사본 보유 (소비자가 자기 관점 스키마를 가짐, detector 무수정)
- 쿨다운 / 조치 텍스트 매핑은 순수 로직으로 분리 → **TDD** (테스트 먼저 → red → 구현 → green)
- 리스너는 순수 로직에 위임하는 얇은 껍데기

## 테스트
- `CooldownTest`, `ResponsePlannerTest` 총 8개 통과
- `./gradlew build` 전체(detector·responder) 통과