### PR TITLE
feat: Swagger 이벤트 발행 API + 판정 결과 조회

### DIFF
--- a/detector/build.gradle
+++ b/detector/build.gradle
@@ -1,8 +1,10 @@
 // Detector — Kafka Streams 로 엔드포인트 이벤트 상관분석 (group: detector)
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter'
+    implementation 'org.springframework.boot:spring-boot-starter-web'    // 데모용 이벤트 발행/조회 REST + Swagger 호스팅
     implementation 'org.springframework.kafka:spring-kafka'
     implementation 'org.apache.kafka:kafka-streams'
     implementation 'com.fasterxml.jackson.core:jackson-databind'   // 이벤트 JSON serde
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.9'  // Swagger UI (/swagger-ui.html)
     testImplementation 'org.apache.kafka:kafka-streams-test-utils' // TopologyTestDriver
 }

--- a/detector/src/main/java/com/edrdog/detector/api/EventProducer.java
+++ b/detector/src/main/java/com/edrdog/detector/api/EventProducer.java
@@ -1,0 +1,34 @@
+package com.edrdog.detector.api;
+
+import com.edrdog.detector.dto.Event;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Service;
+
+/**
+ * events 토픽으로 이벤트를 발행한다 (데모용 주입 경로).
+ * 토폴로지가 JSON 페이로드로 소비하므로 value 를 JSON 문자열로 직렬화하고 key 는 host 로 보낸다.
+ */
+@Service
+public class EventProducer {
+
+    private final KafkaTemplate<String, String> template;
+    private final String eventsTopic;
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    public EventProducer(KafkaTemplate<String, String> template,
+                         @Value("${edrdog.kafka.events-topic}") String eventsTopic) {
+        this.template = template;
+        this.eventsTopic = eventsTopic;
+    }
+
+    /** 이벤트 1건 발행. host 를 파티션 키로 사용해 같은 호스트 이벤트 순서를 보존. */
+    public void publish(Event event) {
+        try {
+            template.send(eventsTopic, event.host(), mapper.writeValueAsString(event));
+        } catch (Exception e) {
+            throw new RuntimeException("이벤트 발행 실패", e);
+        }
+    }
+}

--- a/detector/src/main/java/com/edrdog/detector/api/IngestController.java
+++ b/detector/src/main/java/com/edrdog/detector/api/IngestController.java
@@ -1,0 +1,71 @@
+package com.edrdog.detector.api;
+
+import com.edrdog.detector.dto.Alert;
+import com.edrdog.detector.dto.Event;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * 데모용 이벤트 발행/조회 REST. Swagger UI(/swagger-ui.html)에서 호출하면
+ * events 발행 → detector 상관분석 → alerts → (responder 권장조치) 흐름을 눈으로 확인할 수 있다.
+ */
+@RestController
+@RequestMapping("/api")
+@Tag(name = "ingest", description = "이벤트 발행 및 판정 결과 조회 (데모)")
+public class IngestController {
+
+    private final EventProducer producer;
+    private final RecentAlerts recentAlerts;
+
+    public IngestController(EventProducer producer, RecentAlerts recentAlerts) {
+        this.producer = producer;
+        this.recentAlerts = recentAlerts;
+    }
+
+    @Operation(summary = "이벤트 1건 발행", description = "임의 이벤트를 events 토픽으로 발행한다. 단일 이벤트는 보통 alert 를 만들지 않는다(시퀀스 필요).")
+    @PostMapping("/events")
+    public ResponseEntity<Event> publish(@RequestBody Event event) {
+        producer.publish(event);
+        return ResponseEntity.accepted().body(event);
+    }
+
+    @Operation(summary = "공격 시나리오 발행",
+            description = "룰을 확실히 트리거하는 2-이벤트 시퀀스를 발행한다. name: process-chain(T1059/HIGH) 또는 download-exec(T1105/CRITICAL).")
+    @PostMapping("/events/scenario/{name}")
+    public ResponseEntity<Map<String, Object>> publishScenario(
+            @PathVariable String name,
+            @RequestParam(defaultValue = "demo-host-01") String host) {
+        if (!Scenarios.isSupported(name)) {
+            return ResponseEntity.badRequest().body(Map.of(
+                    "error", "미지원 시나리오: " + name,
+                    "supported", List.of(Scenarios.PROCESS_CHAIN, Scenarios.DOWNLOAD_EXEC)));
+        }
+        // 발행 시각 기준으로 윈도우 안 시퀀스 생성 (판정은 이벤트 ts 필드로 상관)
+        long baseTs = System.currentTimeMillis();
+        List<Event> events = Scenarios.build(name, host, baseTs);
+        events.forEach(producer::publish);
+        return ResponseEntity.accepted().body(Map.of(
+                "scenario", name,
+                "host", host,
+                "published", events,
+                "hint", "GET /api/alerts/recent 로 권장조치 확인 (전파에 약간의 지연)"));
+    }
+
+    @Operation(summary = "최근 판정 결과 조회", description = "detector 가 발행한 최근 alert 목록. action 필드가 권장조치(notify/kill/isolate).")
+    @GetMapping("/alerts/recent")
+    public List<Alert> recentAlerts() {
+        return recentAlerts.list();
+    }
+}

--- a/detector/src/main/java/com/edrdog/detector/api/RecentAlerts.java
+++ b/detector/src/main/java/com/edrdog/detector/api/RecentAlerts.java
@@ -1,0 +1,47 @@
+package com.edrdog.detector.api;
+
+import com.edrdog.detector.dto.Alert;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ConcurrentLinkedDeque;
+
+/**
+ * alerts 토픽을 구독해 최근 판정 결과를 메모리에 보관한다 (조회 엔드포인트용).
+ * detector 가 발행한 alert 를 그대로 되읽어 GET /api/alerts/recent 로 노출 = 발행→판정 결과 확인 루프.
+ * responder 와는 별도 컨슈머 그룹이라 서로 간섭하지 않는다.
+ */
+@Component
+public class RecentAlerts {
+
+    private static final Logger log = LoggerFactory.getLogger(RecentAlerts.class);
+    private static final int MAX = 50;
+
+    private final ObjectMapper mapper = new ObjectMapper()
+            .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+    private final ConcurrentLinkedDeque<Alert> recent = new ConcurrentLinkedDeque<>();
+
+    @KafkaListener(topics = "${edrdog.kafka.alerts-topic}", groupId = "detector-alerts-view")
+    public void onAlert(String payload) {
+        try {
+            Alert alert = mapper.readValue(payload, Alert.class);
+            recent.addFirst(alert);
+            while (recent.size() > MAX) {
+                recent.pollLast();
+            }
+        } catch (Exception e) {
+            log.warn("alert 파싱 실패: {}", payload, e);
+        }
+    }
+
+    /** 최신순 최근 alert 목록 (스냅샷). */
+    public List<Alert> list() {
+        return new ArrayList<>(recent);
+    }
+}

--- a/detector/src/main/java/com/edrdog/detector/api/Scenarios.java
+++ b/detector/src/main/java/com/edrdog/detector/api/Scenarios.java
@@ -1,0 +1,64 @@
+package com.edrdog.detector.api;
+
+import com.edrdog.detector.dto.Event;
+
+import java.util.List;
+
+/**
+ * 데모용 공격 시나리오 팩토리 (순수 함수).
+ * 각 시나리오는 detector 룰을 확실히 트리거하도록 같은 host + 윈도우 안(1초 간격) 2개 이벤트를 순서대로 만든다.
+ * baseTs 를 인자로 받아 결정적 — 테스트로 재현 가능.
+ */
+public final class Scenarios {
+
+    private Scenarios() {
+    }
+
+    /** 지원 시나리오 이름. */
+    public static final String PROCESS_CHAIN = "process-chain";   // R1 T1059 (HIGH)
+    public static final String DOWNLOAD_EXEC = "download-exec";   // R2 T1105+T1204 (CRITICAL)
+
+    public static boolean isSupported(String name) {
+        return PROCESS_CHAIN.equals(name) || DOWNLOAD_EXEC.equals(name);
+    }
+
+    /**
+     * 이름에 해당하는 이벤트 시퀀스 생성. 미지원 이름은 IllegalArgumentException.
+     *
+     * @param name   시나리오 이름 (process-chain | download-exec)
+     * @param host   엔드포인트 식별자 (상관분석 키)
+     * @param baseTs 첫 이벤트 시각 (epoch millis) — 두 번째는 +1000ms
+     */
+    public static List<Event> build(String name, String host, long baseTs) {
+        return switch (name) {
+            case PROCESS_CHAIN -> processChain(host, baseTs);
+            case DOWNLOAD_EXEC -> downloadExec(host, baseTs);
+            default -> throw new IllegalArgumentException(
+                    "미지원 시나리오: " + name + " (지원: " + PROCESS_CHAIN + ", " + DOWNLOAD_EXEC + ")");
+        };
+    }
+
+    /** office 앱 실행 → 그 앱을 부모로 shell 실행 (매크로 침투 패턴). */
+    private static List<Event> processChain(String host, long baseTs) {
+        return List.of(
+                process(host, baseTs, "winword.exe", "explorer.exe", "\"C:\\docs\\invoice.docm\""),
+                process(host, baseTs + 1000, "powershell.exe", "winword.exe",
+                        "powershell -enc SQBFAFgA..."));
+    }
+
+    /** 다운로드 포트 아웃바운드 → 이후 프로세스 실행 (download-and-execute 패턴). */
+    private static List<Event> downloadExec(String host, long baseTs) {
+        return List.of(
+                network(host, baseTs, "185.220.101.5", 443),
+                process(host, baseTs + 1000, "update32.exe", "explorer.exe",
+                        "C:\\Users\\Public\\update32.exe"));
+    }
+
+    private static Event process(String host, long ts, String proc, String parent, String cmdline) {
+        return new Event(host, Event.TYPE_PROCESS, ts, proc, parent, cmdline, null, 0);
+    }
+
+    private static Event network(String host, long ts, String destIp, int destPort) {
+        return new Event(host, Event.TYPE_NETWORK, ts, null, null, null, destIp, destPort);
+    }
+}

--- a/detector/src/main/resources/application.yml
+++ b/detector/src/main/resources/application.yml
@@ -8,6 +8,15 @@ spring:
       properties:
         default.key.serde: org.apache.kafka.common.serialization.Serdes$StringSerde
         default.value.serde: org.apache.kafka.common.serialization.Serdes$StringSerde
+    # 데모 발행 경로: events 로 JSON 문자열 전송
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.apache.kafka.common.serialization.StringSerializer
+    # 조회 경로: alerts 를 되읽어 최근 판정 결과 보관 (RecentAlerts)
+    consumer:
+      auto-offset-reset: latest
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
 
 server:
   port: 8081

--- a/detector/src/test/java/com/edrdog/detector/api/ScenariosTest.java
+++ b/detector/src/test/java/com/edrdog/detector/api/ScenariosTest.java
@@ -1,0 +1,69 @@
+package com.edrdog.detector.api;
+
+import com.edrdog.detector.dto.Alert;
+import com.edrdog.detector.dto.Event;
+import com.edrdog.detector.rule.Rules;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * 시나리오가 실제로 룰을 트리거하는지 검증 (Rules 로 직접 판정).
+ * 시퀀스의 마지막 이벤트가 트리거이며, 선행 이벤트를 버퍼로 넣어 평가한다.
+ */
+class ScenariosTest {
+
+    private static final String HOST = "demo-host-01";
+
+    /** 마지막 이벤트를 current, 나머지를 prior 버퍼로 넣어 판정. */
+    private static Optional<Alert> detect(List<Event> events) {
+        List<Event> prior = events.subList(0, events.size() - 1);
+        Event current = events.get(events.size() - 1);
+        return Rules.evaluate(prior, current);
+    }
+
+    @Test
+    void process_chain_시나리오는_T1059_HIGH_를_트리거한다() {
+        List<Event> events = Scenarios.build(Scenarios.PROCESS_CHAIN, HOST, 1_000_000L);
+
+        Optional<Alert> alert = detect(events);
+
+        assertThat(alert).isPresent();
+        assertThat(alert.get().ruleId()).isEqualTo("SUSPICIOUS_PROCESS_CHAIN");
+        assertThat(alert.get().mitre()).isEqualTo("T1059");
+        assertThat(alert.get().severity()).isEqualTo(Alert.SEV_HIGH);
+        assertThat(alert.get().action()).isEqualTo(Alert.ACTION_KILL);
+        assertThat(alert.get().host()).isEqualTo(HOST);
+    }
+
+    @Test
+    void download_exec_시나리오는_T1105_CRITICAL_을_트리거한다() {
+        List<Event> events = Scenarios.build(Scenarios.DOWNLOAD_EXEC, HOST, 1_000_000L);
+
+        Optional<Alert> alert = detect(events);
+
+        assertThat(alert).isPresent();
+        assertThat(alert.get().ruleId()).isEqualTo("DOWNLOAD_AND_EXECUTE");
+        assertThat(alert.get().severity()).isEqualTo(Alert.SEV_CRITICAL);
+        assertThat(alert.get().action()).isEqualTo(Alert.ACTION_ISOLATE);
+    }
+
+    @Test
+    void 두_이벤트는_같은_host_와_윈도우_안_순서를_가진다() {
+        List<Event> events = Scenarios.build(Scenarios.PROCESS_CHAIN, HOST, 1_000_000L);
+
+        assertThat(events).hasSize(2);
+        assertThat(events).allMatch(e -> HOST.equals(e.host()));
+        assertThat(events.get(1).ts() - events.get(0).ts()).isEqualTo(1000L);
+    }
+
+    @Test
+    void 미지원_시나리오는_예외() {
+        assertThatThrownBy(() -> Scenarios.build("nope", HOST, 0L))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+}


### PR DESCRIPTION
## 요약
Swagger UI에서 이벤트를 발행하면 detector 상관분석을 거쳐 권장조치까지 확인할 수 있는 데모/테스트 주입 경로를 detector에 추가한다.

## 변경 (커밋별)
- `chore` web/Swagger 의존성 + Kafka producer/consumer 설정
- `feat` events 토픽 발행 producer (`EventProducer`)
- `feat` 룰 트리거 데모 시나리오 + 테스트 (`Scenarios`)
- `feat` alerts 구독 최근 판정 결과 보관 (`RecentAlerts`, responder와 별도 컨슈머 그룹)
- `feat` 발행/조회 REST 컨트롤러 (`IngestController`)

## 엔드포인트
- `POST /api/events` — 임의 이벤트 1건 (단일 이벤트는 보통 alert 미발생, 시퀀스 필요)
- `POST /api/events/scenario/{name}` — 룰 확실히 트리거 (`process-chain` T1059/HIGH, `download-exec` T1105+T1204/CRITICAL)
- `GET /api/alerts/recent` — 판정 결과 + 권장조치(`notify`/`kill`/`isolate`) 조회

## 확인 방법
`./gradlew :detector:bootRun` → http://localhost:8081/swagger-ui/index.html
시나리오 발행 후 `/api/alerts/recent` 로 권장조치 확인. (로컬 Kafka 기동 상태에서 end-to-end 동작 검증 완료)

## 범위 밖
실수집(osquery→Kafka)은 별도. 이 API는 데모/테스트 주입용.

Closes #20
