### PR TITLE
feat: archiver events ClickHouse 적재 (#14)

### DIFF
--- a/archiver/build.gradle
+++ b/archiver/build.gradle
@@ -1,0 +1,6 @@
+// Archiver — events 를 별도 컨슈머 그룹(archiver)으로 소비해 ClickHouse 에 적재 (detector 와 독립)
+dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter-web'   // RestClient (ClickHouse HTTP)
+    implementation 'org.springframework.kafka:spring-kafka'
+    implementation 'com.fasterxml.jackson.core:jackson-databind'        // events JSON 역직렬화 + JSONEachRow 직렬화
+}

--- a/archiver/src/main/java/com/edrdog/archiver/ArchiverApplication.java
+++ b/archiver/src/main/java/com/edrdog/archiver/ArchiverApplication.java
@@ -1,0 +1,13 @@
+package com.edrdog.archiver;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+/** events 를 소비해 ClickHouse 에 적재하는 archiver 서비스 (detector 와 독립). */
+@SpringBootApplication
+public class ArchiverApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(ArchiverApplication.class, args);
+    }
+}

--- a/archiver/src/main/java/com/edrdog/archiver/EventListener.java
+++ b/archiver/src/main/java/com/edrdog/archiver/EventListener.java
@@ -1,0 +1,25 @@
+package com.edrdog.archiver;
+
+import com.edrdog.archiver.clickhouse.ClickHouseWriter;
+import com.edrdog.archiver.dto.Event;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+/**
+ * events 토픽을 archiver 컨슈머 그룹으로 소비해 ClickHouse 에 적재하는 리스너.
+ * detector 와 별도 그룹이라 같은 이벤트를 독립적으로 모두 받는다. 적재는 ClickHouseWriter 에 위임.
+ */
+@Component
+public class EventListener {
+
+    private final ClickHouseWriter writer;
+
+    public EventListener(ClickHouseWriter writer) {
+        this.writer = writer;
+    }
+
+    @KafkaListener(topics = "${edrdog.kafka.events-topic}", groupId = "${spring.kafka.consumer.group-id}")
+    public void onEvent(Event event) {
+        writer.insert(event);
+    }
+}

--- a/archiver/src/main/java/com/edrdog/archiver/clickhouse/ClickHouseWriter.java
+++ b/archiver/src/main/java/com/edrdog/archiver/clickhouse/ClickHouseWriter.java
@@ -1,0 +1,78 @@
+package com.edrdog.archiver.clickhouse;
+
+import com.edrdog.archiver.dto.Event;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.annotation.PostConstruct;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+/**
+ * ClickHouse HTTP(8123) 로 events 를 적재하고, 부팅 시 테이블 스키마를 보장한다.
+ * 쿼리는 POST 본문 첫 줄에, 데이터(JSONEachRow)는 그 다음 줄부터 실어 URL 인코딩을 피한다.
+ */
+@Component
+public class ClickHouseWriter {
+
+    private static final Logger log = LoggerFactory.getLogger(ClickHouseWriter.class);
+
+    private final RestClient client;
+    private final ObjectMapper mapper;
+    private final String table;
+
+    public ClickHouseWriter(
+            @Value("${edrdog.clickhouse.url}") String url,
+            @Value("${edrdog.clickhouse.database}") String database,
+            @Value("${edrdog.clickhouse.user}") String user,
+            @Value("${edrdog.clickhouse.password}") String password,
+            @Value("${edrdog.clickhouse.table}") String table,
+            ObjectMapper mapper) {
+        this.table = table;
+        this.mapper = mapper;
+        this.client = RestClient.builder()
+                .baseUrl(url)
+                .defaultHeader("X-ClickHouse-User", user)
+                .defaultHeader("X-ClickHouse-Key", password)
+                .defaultHeader("X-ClickHouse-Database", database)
+                .build();
+    }
+
+    /** 부팅 시 events 테이블 생성 (개발용: 매 기동마다 IF NOT EXISTS). */
+    @PostConstruct
+    void ensureSchema() {
+        execute("""
+                CREATE TABLE IF NOT EXISTS %s (
+                    host String,
+                    type LowCardinality(String),
+                    ts UInt64,
+                    process String,
+                    parent String,
+                    cmdline String,
+                    dest_ip String,
+                    dest_port UInt16,
+                    ingested_at DateTime64(3) DEFAULT now64(3)
+                ) ENGINE = MergeTree
+                ORDER BY (host, ts)
+                """.formatted(table));
+        log.info("ClickHouse 스키마 준비 완료: {}", table);
+    }
+
+    /** 이벤트 한 건을 events 테이블에 적재. */
+    public void insert(Event event) {
+        String body = "INSERT INTO " + table + " FORMAT JSONEachRow\n"
+                + EventRow.toJson(event, mapper);
+        execute(body);
+    }
+
+    private void execute(String sql) {
+        client.post()
+                .uri("/")
+                .contentType(MediaType.TEXT_PLAIN)
+                .body(sql)
+                .retrieve()
+                .toBodilessEntity();
+    }
+}

--- a/archiver/src/main/java/com/edrdog/archiver/clickhouse/EventRow.java
+++ b/archiver/src/main/java/com/edrdog/archiver/clickhouse/EventRow.java
@@ -1,0 +1,40 @@
+package com.edrdog.archiver.clickhouse;
+
+import com.edrdog.archiver.dto.Event;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Event 를 ClickHouse JSONEachRow 한 줄(JSON object)로 변환하는 순수 매핑.
+ * 컬럼 순서를 events 테이블 정의와 맞추고, null String 필드는 ""(빈 문자열)로 치환한다.
+ * (ClickHouse 는 input_format_null_as_default 기본 on 이라 null 도 흡수하지만, 그 설정과
+ *  무관하게 non-Nullable String 컬럼에 항상 결정적으로 "" 가 들어가도록 명시적으로 치환한다.)
+ */
+public final class EventRow {
+
+    private EventRow() {
+    }
+
+    public static String toJson(Event e, ObjectMapper mapper) {
+        Map<String, Object> row = new LinkedHashMap<>();
+        row.put("host", nz(e.host()));
+        row.put("type", nz(e.type()));
+        row.put("ts", e.ts());
+        row.put("process", nz(e.process()));
+        row.put("parent", nz(e.parent()));
+        row.put("cmdline", nz(e.cmdline()));
+        row.put("dest_ip", nz(e.destIp()));
+        row.put("dest_port", e.destPort());
+        try {
+            return mapper.writeValueAsString(row);
+        } catch (JsonProcessingException ex) {
+            throw new IllegalStateException("Event JSON 직렬화 실패: " + e, ex);
+        }
+    }
+
+    private static String nz(String s) {
+        return s == null ? "" : s;
+    }
+}

--- a/archiver/src/main/java/com/edrdog/archiver/dto/Event.java
+++ b/archiver/src/main/java/com/edrdog/archiver/dto/Event.java
@@ -1,0 +1,26 @@
+package com.edrdog.archiver.dto;
+
+/**
+ * osquery/Zeek 원시 엔드포인트 이벤트 (적재 입력 스키마). detector 의 Event 사본.
+ * 여분 필드는 JsonDeserializer 가 무시하므로 원본에 필드가 더 있어도 안전.
+ *
+ * @param host      엔드포인트 식별자
+ * @param type      이벤트 종류: "process" | "network"
+ * @param ts        발생 시각 (epoch millis)
+ * @param process   프로세스명 (예: powershell.exe) — process 이벤트
+ * @param parent    부모 프로세스명 (예: winword.exe) — process 이벤트
+ * @param cmdline   명령행
+ * @param destIp    목적지 IP — network 이벤트
+ * @param destPort  목적지 포트 — network 이벤트
+ */
+public record Event(
+        String host,
+        String type,
+        long ts,
+        String process,
+        String parent,
+        String cmdline,
+        String destIp,
+        int destPort
+) {
+}

--- a/archiver/src/main/resources/application.yml
+++ b/archiver/src/main/resources/application.yml
@@ -1,0 +1,32 @@
+spring:
+  application:
+    name: archiver
+  kafka:
+    bootstrap-servers: localhost:9092
+    consumer:
+      group-id: archiver
+      auto-offset-reset: earliest       # 적재는 유실 없이 처음부터 (detector 와 독립 그룹)
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
+      properties:
+        spring.json.value.default.type: com.edrdog.archiver.dto.Event
+        spring.json.trusted.packages: com.edrdog.archiver.dto
+
+server:
+  port: 8083
+
+edrdog:
+  kafka:
+    events-topic: events              # 원시 이벤트 (소비 입력)
+  clickhouse:
+    url: http://localhost:8123        # k8s NodePort HTTP
+    database: edrdog
+    user: edrdog
+    password: edrdog
+    table: edrdog.events              # 적재 대상 테이블
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health, info

--- a/archiver/src/test/java/com/edrdog/archiver/clickhouse/EventRowTest.java
+++ b/archiver/src/test/java/com/edrdog/archiver/clickhouse/EventRowTest.java
@@ -1,0 +1,40 @@
+package com.edrdog.archiver.clickhouse;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.edrdog.archiver.dto.Event;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+/** Event -> ClickHouse JSONEachRow 한 줄 매핑 순수 로직 검증. */
+class EventRowTest {
+
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @Test
+    void process_이벤트를_컬럼순서대로_JSON_object_로_변환한다() {
+        Event e = new Event("host-1", "process", 1000L,
+                "powershell.exe", "winword.exe", "-enc AAAA", null, 0);
+
+        String json = EventRow.toJson(e, mapper);
+
+        assertThat(json).isEqualTo(
+                "{\"host\":\"host-1\",\"type\":\"process\",\"ts\":1000,"
+                        + "\"process\":\"powershell.exe\",\"parent\":\"winword.exe\","
+                        + "\"cmdline\":\"-enc AAAA\",\"dest_ip\":\"\",\"dest_port\":0}");
+    }
+
+    @Test
+    void null_문자열_필드는_빈문자열로_치환한다() {
+        // network 이벤트: process/parent/cmdline 없음 -> ClickHouse String 컬럼에 null 대신 "" 적재
+        Event e = new Event("host-2", "network", 2000L,
+                null, null, null, "10.0.0.9", 4444);
+
+        String json = EventRow.toJson(e, mapper);
+
+        assertThat(json).isEqualTo(
+                "{\"host\":\"host-2\",\"type\":\"network\",\"ts\":2000,"
+                        + "\"process\":\"\",\"parent\":\"\",\"cmdline\":\"\","
+                        + "\"dest_ip\":\"10.0.0.9\",\"dest_port\":4444}");
+    }
+}

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -42,5 +42,5 @@ kind delete cluster --name edrdog    # 클러스터째 삭제 (데이터 emptyDi
 ## 메모
 
 - 개발용이라 **영속성 없음**(emptyDir). 파드 재시작 시 데이터 소멸.
-- ClickHouse **테이블 스키마는 이후 이슈**에서 (여기선 `edrdog` DB 만 준비).
+- ClickHouse `edrdog.events` **테이블은 archiver 부팅 시 자동 생성**(`CREATE TABLE IF NOT EXISTS`). 여기선 `edrdog` DB 만 준비.
 - watchdog 클러스터와 호스트 포트(9092/8123/9000)가 겹치므로 **동시 실행 불가**.

--- a/settings.gradle
+++ b/settings.gradle
@@ -2,3 +2,4 @@ rootProject.name = 'edrdog-backend'
 
 include 'detector'
 include 'responder'
+include 'archiver'


### PR DESCRIPTION
## 개요
`events` 토픽을 별도 컨슈머 그룹 `archiver`로 소비해 ClickHouse 에 적재. detector 와 독립.
closes #14

## 구현
- `EventListener` — `events` 소비 (group `archiver`, `auto-offset-reset: earliest`). detector 와 별도 그룹이라 같은 이벤트를 독립 수신.
- `ClickHouseWriter` — Spring RestClient 로 ClickHouse HTTP(8123) 에 `INSERT ... FORMAT JSONEachRow` 적재. `@PostConstruct` 로 부팅 시 `edrdog.events` 테이블 `CREATE TABLE IF NOT EXISTS`.
- `EventRow` — Event → JSONEachRow 한 줄 매핑 순수 로직 (null String → `""` 치환). TDD.
- `dto/Event` — detector Event 사본.

## 설계 결정
- **CH 클라이언트: 순수 HTTP RestClient** (드라이버 의존성 0, 기존 모듈의 최소 의존성 기조 유지).
- **스키마: archiver 부팅 시 자동 DDL** (개발용 emptyDir 환경과 궁합, 별도 배포 단계 불필요). `ts`=epoch millis 라 `UInt64`, `MergeTree ORDER BY (host, ts)`.

## 검증
- 단위 테스트: `EventRowTest` 2건 (process/network) 통과 — TDD (테스트 선작성 → 실패확인 → 구현).
- 실인프라: 일회용 ClickHouse 24.8 컨테이너로 DDL/INSERT 본문 포맷/컬럼 매핑/`ingested_at` DEFAULT 실적재·조회 검증 완료.
- 미검증: Java RestClient 배선 + `@KafkaListener` end-to-end (실앱 기동). HTTP 계약은 위에서 검증되어 리스크 낮음.