### PR TITLE
ci: GitHub Actions CI/CD 파이프라인 구축 (#23)

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -1,0 +1,99 @@
+name: CI/CD
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  # CI: 빌드 + 최소 테스트 (PR/푸시 공통, 전 모듈)
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+      - uses: gradle/actions/setup-gradle@v4
+      - name: Build + test
+        run: ./gradlew build
+      - name: Strip plain jars
+        if: github.event_name == 'push'
+        run: find . -name '*-plain.jar' -delete
+      - name: Upload boot jars
+        if: github.event_name == 'push'
+        uses: actions/upload-artifact@v4
+        with:
+          name: boot-jars
+          path: |
+            detector/build/libs/*.jar
+            responder/build/libs/*.jar
+            archiver/build/libs/*.jar
+
+  # 이미지 빌드 + GHCR 푸시 (main 푸시에만, 모듈별 matrix)
+  image:
+    needs: build
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      matrix:
+        module: [detector, responder, archiver]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          name: boot-jars
+      - id: vars
+        run: echo "image_base=ghcr.io/${IMAGE,,}" >> "$GITHUB_OUTPUT"
+        env:
+          IMAGE: ${{ github.repository }}/${{ matrix.module }}
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ matrix.module }}
+          push: true
+          tags: |
+            ${{ steps.vars.outputs.image_base }}:${{ github.sha }}
+            ${{ steps.vars.outputs.image_base }}:latest
+
+  # CD: Kubernetes 배포 (main 푸시에만, 전 모듈)
+  deploy:
+    needs: image
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: azure/setup-kubectl@v4
+      - name: Configure kubeconfig
+        run: |
+          mkdir -p "$HOME/.kube"
+          echo "${{ secrets.KUBE_CONFIG }}" | base64 -d > "$HOME/.kube/config"
+      - name: Deploy
+        env:
+          REPO: ${{ github.repository }}
+          SHA: ${{ github.sha }}
+          NS: edrdog
+        run: |
+          # 앱 매니페스트만 적용 (인프라/ kind-cluster.yaml 제외)
+          kubectl apply -f k8s/00-namespace.yaml
+          kubectl apply -n "$NS" \
+            -f k8s/detector.yaml \
+            -f k8s/responder.yaml \
+            -f k8s/archiver.yaml
+          for m in detector responder archiver; do
+            kubectl set image deployment/$m "$m=ghcr.io/${REPO,,}/$m:${SHA}" -n "$NS"
+          done
+          for m in detector responder archiver; do
+            kubectl rollout status deployment/$m -n "$NS" --timeout=120s
+          done

--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,9 @@ Thumbs.db
 !.omc/skills/
 CLAUDE.md
 
+# ===== 로컬 설계 노트 =====
+edr-notes.md
+
 # ===== Misc =====
 *.tmp
 *.bak

--- a/archiver/Dockerfile
+++ b/archiver/Dockerfile
@@ -1,0 +1,6 @@
+FROM eclipse-temurin:21-jre
+WORKDIR /app
+# CI가 build/libs 에 boot jar 하나만 남겨 전달 (plain jar 는 제거됨)
+COPY build/libs/*.jar app.jar
+EXPOSE 8083
+ENTRYPOINT ["java", "-jar", "/app/app.jar"]

--- a/archiver/build.gradle
+++ b/archiver/build.gradle
@@ -1,0 +1,6 @@
+// Archiver — events 를 별도 컨슈머 그룹(archiver)으로 소비해 ClickHouse 에 적재 (detector 와 독립)
+dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter-web'   // RestClient (ClickHouse HTTP)
+    implementation 'org.springframework.kafka:spring-kafka'
+    implementation 'com.fasterxml.jackson.core:jackson-databind'        // events JSON 역직렬화 + JSONEachRow 직렬화
+}

--- a/archiver/src/main/java/com/edrdog/archiver/ArchiverApplication.java
+++ b/archiver/src/main/java/com/edrdog/archiver/ArchiverApplication.java
@@ -1,0 +1,13 @@
+package com.edrdog.archiver;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+/** events 를 소비해 ClickHouse 에 적재하는 archiver 서비스 (detector 와 독립). */
+@SpringBootApplication
+public class ArchiverApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(ArchiverApplication.class, args);
+    }
+}

--- a/archiver/src/main/java/com/edrdog/archiver/EventListener.java
+++ b/archiver/src/main/java/com/edrdog/archiver/EventListener.java
@@ -1,0 +1,25 @@
+package com.edrdog.archiver;
+
+import com.edrdog.archiver.clickhouse.ClickHouseWriter;
+import com.edrdog.archiver.dto.Event;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+/**
+ * events 토픽을 archiver 컨슈머 그룹으로 소비해 ClickHouse 에 적재하는 리스너.
+ * detector 와 별도 그룹이라 같은 이벤트를 독립적으로 모두 받는다. 적재는 ClickHouseWriter 에 위임.
+ */
+@Component
+public class EventListener {
+
+    private final ClickHouseWriter writer;
+
+    public EventListener(ClickHouseWriter writer) {
+        this.writer = writer;
+    }
+
+    @KafkaListener(topics = "${edrdog.kafka.events-topic}", groupId = "${spring.kafka.consumer.group-id}")
+    public void onEvent(Event event) {
+        writer.insert(event);
+    }
+}

--- a/archiver/src/main/java/com/edrdog/archiver/clickhouse/ClickHouseWriter.java
+++ b/archiver/src/main/java/com/edrdog/archiver/clickhouse/ClickHouseWriter.java
@@ -1,0 +1,78 @@
+package com.edrdog.archiver.clickhouse;
+
+import com.edrdog.archiver.dto.Event;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.annotation.PostConstruct;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+/**
+ * ClickHouse HTTP(8123) 로 events 를 적재하고, 부팅 시 테이블 스키마를 보장한다.
+ * 쿼리는 POST 본문 첫 줄에, 데이터(JSONEachRow)는 그 다음 줄부터 실어 URL 인코딩을 피한다.
+ */
+@Component
+public class ClickHouseWriter {
+
+    private static final Logger log = LoggerFactory.getLogger(ClickHouseWriter.class);
+
+    private final RestClient client;
+    private final ObjectMapper mapper;
+    private final String table;
+
+    public ClickHouseWriter(
+            @Value("${edrdog.clickhouse.url}") String url,
+            @Value("${edrdog.clickhouse.database}") String database,
+            @Value("${edrdog.clickhouse.user}") String user,
+            @Value("${edrdog.clickhouse.password}") String password,
+            @Value("${edrdog.clickhouse.table}") String table,
+            ObjectMapper mapper) {
+        this.table = table;
+        this.mapper = mapper;
+        this.client = RestClient.builder()
+                .baseUrl(url)
+                .defaultHeader("X-ClickHouse-User", user)
+                .defaultHeader("X-ClickHouse-Key", password)
+                .defaultHeader("X-ClickHouse-Database", database)
+                .build();
+    }
+
+    /** 부팅 시 events 테이블 생성 (개발용: 매 기동마다 IF NOT EXISTS). */
+    @PostConstruct
+    void ensureSchema() {
+        execute("""
+                CREATE TABLE IF NOT EXISTS %s (
+                    host String,
+                    type LowCardinality(String),
+                    ts UInt64,
+                    process String,
+                    parent String,
+                    cmdline String,
+                    dest_ip String,
+                    dest_port UInt16,
+                    ingested_at DateTime64(3) DEFAULT now64(3)
+                ) ENGINE = MergeTree
+                ORDER BY (host, ts)
+                """.formatted(table));
+        log.info("ClickHouse 스키마 준비 완료: {}", table);
+    }
+
+    /** 이벤트 한 건을 events 테이블에 적재. */
+    public void insert(Event event) {
+        String body = "INSERT INTO " + table + " FORMAT JSONEachRow\n"
+                + EventRow.toJson(event, mapper);
+        execute(body);
+    }
+
+    private void execute(String sql) {
+        client.post()
+                .uri("/")
+                .contentType(MediaType.TEXT_PLAIN)
+                .body(sql)
+                .retrieve()
+                .toBodilessEntity();
+    }
+}

--- a/archiver/src/main/java/com/edrdog/archiver/clickhouse/EventRow.java
+++ b/archiver/src/main/java/com/edrdog/archiver/clickhouse/EventRow.java
@@ -1,0 +1,40 @@
+package com.edrdog.archiver.clickhouse;
+
+import com.edrdog.archiver.dto.Event;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Event 를 ClickHouse JSONEachRow 한 줄(JSON object)로 변환하는 순수 매핑.
+ * 컬럼 순서를 events 테이블 정의와 맞추고, null String 필드는 ""(빈 문자열)로 치환한다.
+ * (ClickHouse 는 input_format_null_as_default 기본 on 이라 null 도 흡수하지만, 그 설정과
+ *  무관하게 non-Nullable String 컬럼에 항상 결정적으로 "" 가 들어가도록 명시적으로 치환한다.)
+ */
+public final class EventRow {
+
+    private EventRow() {
+    }
+
+    public static String toJson(Event e, ObjectMapper mapper) {
+        Map<String, Object> row = new LinkedHashMap<>();
+        row.put("host", nz(e.host()));
+        row.put("type", nz(e.type()));
+        row.put("ts", e.ts());
+        row.put("process", nz(e.process()));
+        row.put("parent", nz(e.parent()));
+        row.put("cmdline", nz(e.cmdline()));
+        row.put("dest_ip", nz(e.destIp()));
+        row.put("dest_port", e.destPort());
+        try {
+            return mapper.writeValueAsString(row);
+        } catch (JsonProcessingException ex) {
+            throw new IllegalStateException("Event JSON 직렬화 실패: " + e, ex);
+        }
+    }
+
+    private static String nz(String s) {
+        return s == null ? "" : s;
+    }
+}

--- a/archiver/src/main/java/com/edrdog/archiver/dto/Event.java
+++ b/archiver/src/main/java/com/edrdog/archiver/dto/Event.java
@@ -1,0 +1,26 @@
+package com.edrdog.archiver.dto;
+
+/**
+ * osquery/Zeek 원시 엔드포인트 이벤트 (적재 입력 스키마). detector 의 Event 사본.
+ * 여분 필드는 JsonDeserializer 가 무시하므로 원본에 필드가 더 있어도 안전.
+ *
+ * @param host      엔드포인트 식별자
+ * @param type      이벤트 종류: "process" | "network"
+ * @param ts        발생 시각 (epoch millis)
+ * @param process   프로세스명 (예: powershell.exe) — process 이벤트
+ * @param parent    부모 프로세스명 (예: winword.exe) — process 이벤트
+ * @param cmdline   명령행
+ * @param destIp    목적지 IP — network 이벤트
+ * @param destPort  목적지 포트 — network 이벤트
+ */
+public record Event(
+        String host,
+        String type,
+        long ts,
+        String process,
+        String parent,
+        String cmdline,
+        String destIp,
+        int destPort
+) {
+}

--- a/archiver/src/main/resources/application.yml
+++ b/archiver/src/main/resources/application.yml
@@ -1,0 +1,32 @@
+spring:
+  application:
+    name: archiver
+  kafka:
+    bootstrap-servers: localhost:9092
+    consumer:
+      group-id: archiver
+      auto-offset-reset: earliest       # 적재는 유실 없이 처음부터 (detector 와 독립 그룹)
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
+      properties:
+        spring.json.value.default.type: com.edrdog.archiver.dto.Event
+        spring.json.trusted.packages: com.edrdog.archiver.dto
+
+server:
+  port: 8083
+
+edrdog:
+  kafka:
+    events-topic: events              # 원시 이벤트 (소비 입력)
+  clickhouse:
+    url: http://localhost:8123        # k8s NodePort HTTP
+    database: edrdog
+    user: edrdog
+    password: edrdog
+    table: edrdog.events              # 적재 대상 테이블
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health, info

--- a/archiver/src/test/java/com/edrdog/archiver/clickhouse/EventRowTest.java
+++ b/archiver/src/test/java/com/edrdog/archiver/clickhouse/EventRowTest.java
@@ -1,0 +1,40 @@
+package com.edrdog.archiver.clickhouse;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.edrdog.archiver.dto.Event;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+/** Event -> ClickHouse JSONEachRow 한 줄 매핑 순수 로직 검증. */
+class EventRowTest {
+
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @Test
+    void process_이벤트를_컬럼순서대로_JSON_object_로_변환한다() {
+        Event e = new Event("host-1", "process", 1000L,
+                "powershell.exe", "winword.exe", "-enc AAAA", null, 0);
+
+        String json = EventRow.toJson(e, mapper);
+
+        assertThat(json).isEqualTo(
+                "{\"host\":\"host-1\",\"type\":\"process\",\"ts\":1000,"
+                        + "\"process\":\"powershell.exe\",\"parent\":\"winword.exe\","
+                        + "\"cmdline\":\"-enc AAAA\",\"dest_ip\":\"\",\"dest_port\":0}");
+    }
+
+    @Test
+    void null_문자열_필드는_빈문자열로_치환한다() {
+        // network 이벤트: process/parent/cmdline 없음 -> ClickHouse String 컬럼에 null 대신 "" 적재
+        Event e = new Event("host-2", "network", 2000L,
+                null, null, null, "10.0.0.9", 4444);
+
+        String json = EventRow.toJson(e, mapper);
+
+        assertThat(json).isEqualTo(
+                "{\"host\":\"host-2\",\"type\":\"network\",\"ts\":2000,"
+                        + "\"process\":\"\",\"parent\":\"\",\"cmdline\":\"\","
+                        + "\"dest_ip\":\"10.0.0.9\",\"dest_port\":4444}");
+    }
+}

--- a/detector/Dockerfile
+++ b/detector/Dockerfile
@@ -1,0 +1,6 @@
+FROM eclipse-temurin:21-jre
+WORKDIR /app
+# CI가 build/libs 에 boot jar 하나만 남겨 전달 (plain jar 는 제거됨)
+COPY build/libs/*.jar app.jar
+EXPOSE 8081
+ENTRYPOINT ["java", "-jar", "/app/app.jar"]

--- a/detector/build.gradle
+++ b/detector/build.gradle
@@ -1,8 +1,10 @@
 // Detector — Kafka Streams 로 엔드포인트 이벤트 상관분석 (group: detector)
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter'
+    implementation 'org.springframework.boot:spring-boot-starter-web'    // 데모용 이벤트 발행/조회 REST + Swagger 호스팅
     implementation 'org.springframework.kafka:spring-kafka'
     implementation 'org.apache.kafka:kafka-streams'
     implementation 'com.fasterxml.jackson.core:jackson-databind'   // 이벤트 JSON serde
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.9'  // Swagger UI (/swagger-ui.html)
     testImplementation 'org.apache.kafka:kafka-streams-test-utils' // TopologyTestDriver
 }

--- a/detector/src/main/java/com/edrdog/detector/api/EventProducer.java
+++ b/detector/src/main/java/com/edrdog/detector/api/EventProducer.java
@@ -1,0 +1,34 @@
+package com.edrdog.detector.api;
+
+import com.edrdog.detector.dto.Event;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Service;
+
+/**
+ * events 토픽으로 이벤트를 발행한다 (데모용 주입 경로).
+ * 토폴로지가 JSON 페이로드로 소비하므로 value 를 JSON 문자열로 직렬화하고 key 는 host 로 보낸다.
+ */
+@Service
+public class EventProducer {
+
+    private final KafkaTemplate<String, String> template;
+    private final String eventsTopic;
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    public EventProducer(KafkaTemplate<String, String> template,
+                         @Value("${edrdog.kafka.events-topic}") String eventsTopic) {
+        this.template = template;
+        this.eventsTopic = eventsTopic;
+    }
+
+    /** 이벤트 1건 발행. host 를 파티션 키로 사용해 같은 호스트 이벤트 순서를 보존. */
+    public void publish(Event event) {
+        try {
+            template.send(eventsTopic, event.host(), mapper.writeValueAsString(event));
+        } catch (Exception e) {
+            throw new RuntimeException("이벤트 발행 실패", e);
+        }
+    }
+}

--- a/detector/src/main/java/com/edrdog/detector/api/IngestController.java
+++ b/detector/src/main/java/com/edrdog/detector/api/IngestController.java
@@ -1,0 +1,71 @@
+package com.edrdog.detector.api;
+
+import com.edrdog.detector.dto.Alert;
+import com.edrdog.detector.dto.Event;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * 데모용 이벤트 발행/조회 REST. Swagger UI(/swagger-ui.html)에서 호출하면
+ * events 발행 → detector 상관분석 → alerts → (responder 권장조치) 흐름을 눈으로 확인할 수 있다.
+ */
+@RestController
+@RequestMapping("/api")
+@Tag(name = "ingest", description = "이벤트 발행 및 판정 결과 조회 (데모)")
+public class IngestController {
+
+    private final EventProducer producer;
+    private final RecentAlerts recentAlerts;
+
+    public IngestController(EventProducer producer, RecentAlerts recentAlerts) {
+        this.producer = producer;
+        this.recentAlerts = recentAlerts;
+    }
+
+    @Operation(summary = "이벤트 1건 발행", description = "임의 이벤트를 events 토픽으로 발행한다. 단일 이벤트는 보통 alert 를 만들지 않는다(시퀀스 필요).")
+    @PostMapping("/events")
+    public ResponseEntity<Event> publish(@RequestBody Event event) {
+        producer.publish(event);
+        return ResponseEntity.accepted().body(event);
+    }
+
+    @Operation(summary = "공격 시나리오 발행",
+            description = "룰을 확실히 트리거하는 2-이벤트 시퀀스를 발행한다. name: process-chain(T1059/HIGH) 또는 download-exec(T1105/CRITICAL).")
+    @PostMapping("/events/scenario/{name}")
+    public ResponseEntity<Map<String, Object>> publishScenario(
+            @PathVariable String name,
+            @RequestParam(defaultValue = "demo-host-01") String host) {
+        if (!Scenarios.isSupported(name)) {
+            return ResponseEntity.badRequest().body(Map.of(
+                    "error", "미지원 시나리오: " + name,
+                    "supported", List.of(Scenarios.PROCESS_CHAIN, Scenarios.DOWNLOAD_EXEC)));
+        }
+        // 발행 시각 기준으로 윈도우 안 시퀀스 생성 (판정은 이벤트 ts 필드로 상관)
+        long baseTs = System.currentTimeMillis();
+        List<Event> events = Scenarios.build(name, host, baseTs);
+        events.forEach(producer::publish);
+        return ResponseEntity.accepted().body(Map.of(
+                "scenario", name,
+                "host", host,
+                "published", events,
+                "hint", "GET /api/alerts/recent 로 권장조치 확인 (전파에 약간의 지연)"));
+    }
+
+    @Operation(summary = "최근 판정 결과 조회", description = "detector 가 발행한 최근 alert 목록. action 필드가 권장조치(notify/kill/isolate).")
+    @GetMapping("/alerts/recent")
+    public List<Alert> recentAlerts() {
+        return recentAlerts.list();
+    }
+}

--- a/detector/src/main/java/com/edrdog/detector/api/RecentAlerts.java
+++ b/detector/src/main/java/com/edrdog/detector/api/RecentAlerts.java
@@ -1,0 +1,47 @@
+package com.edrdog.detector.api;
+
+import com.edrdog.detector.dto.Alert;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ConcurrentLinkedDeque;
+
+/**
+ * alerts 토픽을 구독해 최근 판정 결과를 메모리에 보관한다 (조회 엔드포인트용).
+ * detector 가 발행한 alert 를 그대로 되읽어 GET /api/alerts/recent 로 노출 = 발행→판정 결과 확인 루프.
+ * responder 와는 별도 컨슈머 그룹이라 서로 간섭하지 않는다.
+ */
+@Component
+public class RecentAlerts {
+
+    private static final Logger log = LoggerFactory.getLogger(RecentAlerts.class);
+    private static final int MAX = 50;
+
+    private final ObjectMapper mapper = new ObjectMapper()
+            .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+    private final ConcurrentLinkedDeque<Alert> recent = new ConcurrentLinkedDeque<>();
+
+    @KafkaListener(topics = "${edrdog.kafka.alerts-topic}", groupId = "detector-alerts-view")
+    public void onAlert(String payload) {
+        try {
+            Alert alert = mapper.readValue(payload, Alert.class);
+            recent.addFirst(alert);
+            while (recent.size() > MAX) {
+                recent.pollLast();
+            }
+        } catch (Exception e) {
+            log.warn("alert 파싱 실패: {}", payload, e);
+        }
+    }
+
+    /** 최신순 최근 alert 목록 (스냅샷). */
+    public List<Alert> list() {
+        return new ArrayList<>(recent);
+    }
+}

--- a/detector/src/main/java/com/edrdog/detector/api/Scenarios.java
+++ b/detector/src/main/java/com/edrdog/detector/api/Scenarios.java
@@ -1,0 +1,64 @@
+package com.edrdog.detector.api;
+
+import com.edrdog.detector.dto.Event;
+
+import java.util.List;
+
+/**
+ * 데모용 공격 시나리오 팩토리 (순수 함수).
+ * 각 시나리오는 detector 룰을 확실히 트리거하도록 같은 host + 윈도우 안(1초 간격) 2개 이벤트를 순서대로 만든다.
+ * baseTs 를 인자로 받아 결정적 — 테스트로 재현 가능.
+ */
+public final class Scenarios {
+
+    private Scenarios() {
+    }
+
+    /** 지원 시나리오 이름. */
+    public static final String PROCESS_CHAIN = "process-chain";   // R1 T1059 (HIGH)
+    public static final String DOWNLOAD_EXEC = "download-exec";   // R2 T1105+T1204 (CRITICAL)
+
+    public static boolean isSupported(String name) {
+        return PROCESS_CHAIN.equals(name) || DOWNLOAD_EXEC.equals(name);
+    }
+
+    /**
+     * 이름에 해당하는 이벤트 시퀀스 생성. 미지원 이름은 IllegalArgumentException.
+     *
+     * @param name   시나리오 이름 (process-chain | download-exec)
+     * @param host   엔드포인트 식별자 (상관분석 키)
+     * @param baseTs 첫 이벤트 시각 (epoch millis) — 두 번째는 +1000ms
+     */
+    public static List<Event> build(String name, String host, long baseTs) {
+        return switch (name) {
+            case PROCESS_CHAIN -> processChain(host, baseTs);
+            case DOWNLOAD_EXEC -> downloadExec(host, baseTs);
+            default -> throw new IllegalArgumentException(
+                    "미지원 시나리오: " + name + " (지원: " + PROCESS_CHAIN + ", " + DOWNLOAD_EXEC + ")");
+        };
+    }
+
+    /** office 앱 실행 → 그 앱을 부모로 shell 실행 (매크로 침투 패턴). */
+    private static List<Event> processChain(String host, long baseTs) {
+        return List.of(
+                process(host, baseTs, "winword.exe", "explorer.exe", "\"C:\\docs\\invoice.docm\""),
+                process(host, baseTs + 1000, "powershell.exe", "winword.exe",
+                        "powershell -enc SQBFAFgA..."));
+    }
+
+    /** 다운로드 포트 아웃바운드 → 이후 프로세스 실행 (download-and-execute 패턴). */
+    private static List<Event> downloadExec(String host, long baseTs) {
+        return List.of(
+                network(host, baseTs, "185.220.101.5", 443),
+                process(host, baseTs + 1000, "update32.exe", "explorer.exe",
+                        "C:\\Users\\Public\\update32.exe"));
+    }
+
+    private static Event process(String host, long ts, String proc, String parent, String cmdline) {
+        return new Event(host, Event.TYPE_PROCESS, ts, proc, parent, cmdline, null, 0);
+    }
+
+    private static Event network(String host, long ts, String destIp, int destPort) {
+        return new Event(host, Event.TYPE_NETWORK, ts, null, null, null, destIp, destPort);
+    }
+}

--- a/detector/src/main/resources/application.yml
+++ b/detector/src/main/resources/application.yml
@@ -8,6 +8,15 @@ spring:
       properties:
         default.key.serde: org.apache.kafka.common.serialization.Serdes$StringSerde
         default.value.serde: org.apache.kafka.common.serialization.Serdes$StringSerde
+    # 데모 발행 경로: events 로 JSON 문자열 전송
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.apache.kafka.common.serialization.StringSerializer
+    # 조회 경로: alerts 를 되읽어 최근 판정 결과 보관 (RecentAlerts)
+    consumer:
+      auto-offset-reset: latest
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
 
 server:
   port: 8081

--- a/detector/src/test/java/com/edrdog/detector/api/ScenariosTest.java
+++ b/detector/src/test/java/com/edrdog/detector/api/ScenariosTest.java
@@ -1,0 +1,69 @@
+package com.edrdog.detector.api;
+
+import com.edrdog.detector.dto.Alert;
+import com.edrdog.detector.dto.Event;
+import com.edrdog.detector.rule.Rules;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * 시나리오가 실제로 룰을 트리거하는지 검증 (Rules 로 직접 판정).
+ * 시퀀스의 마지막 이벤트가 트리거이며, 선행 이벤트를 버퍼로 넣어 평가한다.
+ */
+class ScenariosTest {
+
+    private static final String HOST = "demo-host-01";
+
+    /** 마지막 이벤트를 current, 나머지를 prior 버퍼로 넣어 판정. */
+    private static Optional<Alert> detect(List<Event> events) {
+        List<Event> prior = events.subList(0, events.size() - 1);
+        Event current = events.get(events.size() - 1);
+        return Rules.evaluate(prior, current);
+    }
+
+    @Test
+    void process_chain_시나리오는_T1059_HIGH_를_트리거한다() {
+        List<Event> events = Scenarios.build(Scenarios.PROCESS_CHAIN, HOST, 1_000_000L);
+
+        Optional<Alert> alert = detect(events);
+
+        assertThat(alert).isPresent();
+        assertThat(alert.get().ruleId()).isEqualTo("SUSPICIOUS_PROCESS_CHAIN");
+        assertThat(alert.get().mitre()).isEqualTo("T1059");
+        assertThat(alert.get().severity()).isEqualTo(Alert.SEV_HIGH);
+        assertThat(alert.get().action()).isEqualTo(Alert.ACTION_KILL);
+        assertThat(alert.get().host()).isEqualTo(HOST);
+    }
+
+    @Test
+    void download_exec_시나리오는_T1105_CRITICAL_을_트리거한다() {
+        List<Event> events = Scenarios.build(Scenarios.DOWNLOAD_EXEC, HOST, 1_000_000L);
+
+        Optional<Alert> alert = detect(events);
+
+        assertThat(alert).isPresent();
+        assertThat(alert.get().ruleId()).isEqualTo("DOWNLOAD_AND_EXECUTE");
+        assertThat(alert.get().severity()).isEqualTo(Alert.SEV_CRITICAL);
+        assertThat(alert.get().action()).isEqualTo(Alert.ACTION_ISOLATE);
+    }
+
+    @Test
+    void 두_이벤트는_같은_host_와_윈도우_안_순서를_가진다() {
+        List<Event> events = Scenarios.build(Scenarios.PROCESS_CHAIN, HOST, 1_000_000L);
+
+        assertThat(events).hasSize(2);
+        assertThat(events).allMatch(e -> HOST.equals(e.host()));
+        assertThat(events.get(1).ts() - events.get(0).ts()).isEqualTo(1000L);
+    }
+
+    @Test
+    void 미지원_시나리오는_예외() {
+        assertThatThrownBy(() -> Scenarios.build("nope", HOST, 0L))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+}

--- a/k8s/00-namespace.yaml
+++ b/k8s/00-namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: edrdog
+  labels:
+    app.kubernetes.io/part-of: edrdog

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -1,0 +1,46 @@
+# EDRdog 로컬 인프라 (k8s / kind)
+
+모든 모듈의 전제. kind 클러스터에 Kafka(토픽 `events`/`alerts`) + ClickHouse 를 띄운다.
+호스트에서 도는 Spring 서비스가 NodePort 매핑으로 접근한다.
+
+## 기동
+
+```bash
+kind create cluster --config k8s/kind-cluster.yaml   # 클러스터 생성 (name: edrdog)
+# kind-cluster.yaml 은 kind 전용이라 apply 대상에서 제외 (아래는 실제 매니페스트만)
+kubectl apply -f k8s/00-namespace.yaml -f k8s/kafka.yaml -f k8s/clickhouse.yaml
+kubectl -n edrdog get pods                            # Running 확인
+```
+
+## 접속
+
+| 대상 | 호스트 주소 | 비고 |
+|---|---|---|
+| Kafka | `localhost:9092` | detector 등 (EXTERNAL 리스너) |
+| ClickHouse HTTP | `http://localhost:8123` | user/pw/db = `edrdog` |
+| ClickHouse native | `localhost:9000` | JDBC/드라이버용 |
+
+클러스터 내부(파드 간) Kafka 주소: `kafka.edrdog.svc.cluster.local:9094`
+
+## 확인
+
+```bash
+# 토픽 목록 (events / alerts 있어야 함)
+kubectl -n edrdog exec deploy/kafka -- \
+  /opt/kafka/bin/kafka-topics.sh --bootstrap-server localhost:9094 --list
+
+# ClickHouse ping
+curl http://localhost:8123/ping     # -> Ok.
+```
+
+## 종료
+
+```bash
+kind delete cluster --name edrdog    # 클러스터째 삭제 (데이터 emptyDir 라 함께 소멸)
+```
+
+## 메모
+
+- 개발용이라 **영속성 없음**(emptyDir). 파드 재시작 시 데이터 소멸.
+- ClickHouse **테이블 스키마는 이후 이슈**에서 (여기선 `edrdog` DB 만 준비).
+- watchdog 클러스터와 호스트 포트(9092/8123/9000)가 겹치므로 **동시 실행 불가**.

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -42,5 +42,5 @@ kind delete cluster --name edrdog    # 클러스터째 삭제 (데이터 emptyDi
 ## 메모
 
 - 개발용이라 **영속성 없음**(emptyDir). 파드 재시작 시 데이터 소멸.
-- ClickHouse **테이블 스키마는 이후 이슈**에서 (여기선 `edrdog` DB 만 준비).
+- ClickHouse `edrdog.events` **테이블은 archiver 부팅 시 자동 생성**(`CREATE TABLE IF NOT EXISTS`). 여기선 `edrdog` DB 만 준비.
 - watchdog 클러스터와 호스트 포트(9092/8123/9000)가 겹치므로 **동시 실행 불가**.

--- a/k8s/archiver.yaml
+++ b/k8s/archiver.yaml
@@ -1,0 +1,61 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: archiver
+  namespace: edrdog
+  labels:
+    app: archiver
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: archiver
+  template:
+    metadata:
+      labels:
+        app: archiver
+    spec:
+      containers:
+        - name: archiver
+          # 배포 시 CI 가 kubectl set image 로 실제 태그(:<sha>) 주입
+          image: ghcr.io/2026-siheung-bootcamp-team-i/backend/archiver:latest
+          ports:
+            - containerPort: 8083
+          env:
+            - name: SPRING_KAFKA_BOOTSTRAP_SERVERS
+              value: "kafka:9094"
+            - name: EDRDOG_CLICKHOUSE_URL
+              value: "http://clickhouse:8123"
+          readinessProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8083
+            initialDelaySeconds: 15
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8083
+            initialDelaySeconds: 30
+            periodSeconds: 20
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: archiver
+  namespace: edrdog
+  labels:
+    app: archiver
+spec:
+  selector:
+    app: archiver
+  ports:
+    - port: 80
+      targetPort: 8083

--- a/k8s/clickhouse.yaml
+++ b/k8s/clickhouse.yaml
@@ -1,0 +1,65 @@
+# ClickHouse — 이벤트 저장·조회(archiver/api-server). 개발용, 영속성 없음(emptyDir).
+# 스키마(테이블)는 이후 이슈에서. 여기서는 edrdog DB 만 준비.
+#   HTTP   8123 -> host localhost:8123
+#   native 9000 -> host localhost:9000
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: clickhouse
+  namespace: edrdog
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: clickhouse
+  template:
+    metadata:
+      labels:
+        app: clickhouse
+    spec:
+      containers:
+        - name: clickhouse
+          image: clickhouse/clickhouse-server:24.8
+          ports:
+            - containerPort: 8123  # HTTP
+            - containerPort: 9000  # native TCP
+          env:
+            - name: CLICKHOUSE_DB
+              value: edrdog
+            - name: CLICKHOUSE_USER
+              value: edrdog
+            - name: CLICKHOUSE_PASSWORD
+              value: edrdog
+            - name: CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT
+              value: "1"
+          readinessProbe:
+            httpGet:
+              path: /ping
+              port: 8123
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          resources:
+            requests:
+              cpu: 250m
+              memory: 512Mi
+            limits:
+              memory: 2Gi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: clickhouse
+  namespace: edrdog
+spec:
+  type: NodePort
+  selector:
+    app: clickhouse
+  ports:
+    - name: http
+      port: 8123
+      targetPort: 8123
+      nodePort: 30123
+    - name: native
+      port: 9000
+      targetPort: 9000
+      nodePort: 30900

--- a/k8s/detector.yaml
+++ b/k8s/detector.yaml
@@ -1,0 +1,60 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: detector
+  namespace: edrdog
+  labels:
+    app: detector
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: detector
+  template:
+    metadata:
+      labels:
+        app: detector
+    spec:
+      containers:
+        - name: detector
+          # 배포 시 CI 가 kubectl set image 로 실제 태그(:<sha>) 주입
+          image: ghcr.io/2026-siheung-bootcamp-team-i/backend/detector:latest
+          ports:
+            - containerPort: 8081
+          env:
+            # 실제 Kafka 주소로 교체 (ConfigMap 으로 분리해도 됨)
+            - name: SPRING_KAFKA_BOOTSTRAP_SERVERS
+              value: "kafka:9094"
+          readinessProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8081
+            initialDelaySeconds: 15
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8081
+            initialDelaySeconds: 30
+            periodSeconds: 20
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: detector
+  namespace: edrdog
+  labels:
+    app: detector
+spec:
+  selector:
+    app: detector
+  ports:
+    - port: 80
+      targetPort: 8081

--- a/k8s/kafka.yaml
+++ b/k8s/kafka.yaml
@@ -1,0 +1,117 @@
+# Kafka (KRaft, 단일 노드) — 개발용. 영속성 없음(emptyDir).
+# 리스너 2개:
+#   INTERNAL(9094) : 클러스터 내부용 -> kafka.edrdog.svc.cluster.local:9094
+#   EXTERNAL(9092) : 호스트용 (localhost:9092), NodePort 30092 로 노출
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kafka
+  namespace: edrdog
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: kafka
+  template:
+    metadata:
+      labels:
+        app: kafka
+    spec:
+      containers:
+        - name: kafka
+          image: apache/kafka:3.9.0
+          ports:
+            - containerPort: 9092  # EXTERNAL
+            - containerPort: 9094  # INTERNAL
+          env:
+            - name: KAFKA_NODE_ID
+              value: "1"
+            - name: KAFKA_PROCESS_ROLES
+              value: "broker,controller"
+            - name: KAFKA_CONTROLLER_QUORUM_VOTERS
+              value: "1@localhost:9093"
+            - name: KAFKA_LISTENERS
+              value: "CONTROLLER://:9093,INTERNAL://:9094,EXTERNAL://:9092"
+            - name: KAFKA_ADVERTISED_LISTENERS
+              value: "INTERNAL://kafka.edrdog.svc.cluster.local:9094,EXTERNAL://localhost:9092"
+            - name: KAFKA_LISTENER_SECURITY_PROTOCOL_MAP
+              value: "CONTROLLER:PLAINTEXT,INTERNAL:PLAINTEXT,EXTERNAL:PLAINTEXT"
+            - name: KAFKA_INTER_BROKER_LISTENER_NAME
+              value: "INTERNAL"
+            - name: KAFKA_CONTROLLER_LISTENER_NAMES
+              value: "CONTROLLER"
+            - name: KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR
+              value: "1"
+            - name: KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR
+              value: "1"
+            - name: KAFKA_TRANSACTION_STATE_LOG_MIN_ISR
+              value: "1"
+            - name: KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS
+              value: "0"
+          readinessProbe:
+            tcpSocket:
+              port: 9092
+            initialDelaySeconds: 15
+            periodSeconds: 10
+          resources:
+            requests:
+              cpu: 250m
+              memory: 512Mi
+            limits:
+              memory: 1Gi
+---
+# 클러스터 내부용 (INTERNAL 리스너)
+apiVersion: v1
+kind: Service
+metadata:
+  name: kafka
+  namespace: edrdog
+spec:
+  selector:
+    app: kafka
+  ports:
+    - name: internal
+      port: 9094
+      targetPort: 9094
+---
+# 호스트용 (EXTERNAL 리스너, NodePort -> kind -> localhost:9092)
+apiVersion: v1
+kind: Service
+metadata:
+  name: kafka-external
+  namespace: edrdog
+spec:
+  type: NodePort
+  selector:
+    app: kafka
+  ports:
+    - name: external
+      port: 9092
+      targetPort: 9092
+      nodePort: 30092
+---
+# 토픽 생성 Job — events / alerts (Issue #10 명시 요구)
+# kafka 준비 전 실행되면 실패하므로 OnFailure + backoffLimit 로 재시도.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: kafka-topic-init
+  namespace: edrdog
+spec:
+  backoffLimit: 10
+  template:
+    spec:
+      restartPolicy: OnFailure
+      containers:
+        - name: topic-init
+          image: apache/kafka:3.9.0
+          command: ["/bin/bash", "-c"]
+          args:
+            - |
+              BS=kafka.edrdog.svc.cluster.local:9094
+              /opt/kafka/bin/kafka-topics.sh --bootstrap-server $BS \
+                --create --if-not-exists --topic events --partitions 3 --replication-factor 1
+              /opt/kafka/bin/kafka-topics.sh --bootstrap-server $BS \
+                --create --if-not-exists --topic alerts --partitions 3 --replication-factor 1
+              echo "[topic-init] topics:"
+              /opt/kafka/bin/kafka-topics.sh --bootstrap-server $BS --list

--- a/k8s/kind-cluster.yaml
+++ b/k8s/kind-cluster.yaml
@@ -1,0 +1,21 @@
+# EDRdog 로컬 kind 클러스터 정의 (Issue #10)
+# 호스트에서 실행되는 Spring 서비스(detector 등)가 클러스터 안 인프라
+# (Kafka/ClickHouse)에 접근하도록 NodePort 를 호스트 포트로 매핑한다.
+#
+#   생성:  kind create cluster --config k8s/kind-cluster.yaml
+#   삭제:  kind delete cluster --name edrdog
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+name: edrdog
+nodes:
+  - role: control-plane
+    extraPortMappings:
+      - containerPort: 30092   # Kafka (EXTERNAL)    -> host localhost:9092
+        hostPort: 9092
+        protocol: TCP
+      - containerPort: 30123   # ClickHouse HTTP     -> host localhost:8123
+        hostPort: 8123
+        protocol: TCP
+      - containerPort: 30900   # ClickHouse native   -> host localhost:9000
+        hostPort: 9000
+        protocol: TCP

--- a/k8s/responder.yaml
+++ b/k8s/responder.yaml
@@ -1,0 +1,59 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: responder
+  namespace: edrdog
+  labels:
+    app: responder
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: responder
+  template:
+    metadata:
+      labels:
+        app: responder
+    spec:
+      containers:
+        - name: responder
+          # 배포 시 CI 가 kubectl set image 로 실제 태그(:<sha>) 주입
+          image: ghcr.io/2026-siheung-bootcamp-team-i/backend/responder:latest
+          ports:
+            - containerPort: 8082
+          env:
+            - name: SPRING_KAFKA_BOOTSTRAP_SERVERS
+              value: "kafka:9094"
+          readinessProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8082
+            initialDelaySeconds: 15
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8082
+            initialDelaySeconds: 30
+            periodSeconds: 20
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: responder
+  namespace: edrdog
+  labels:
+    app: responder
+spec:
+  selector:
+    app: responder
+  ports:
+    - port: 80
+      targetPort: 8082

--- a/responder/Dockerfile
+++ b/responder/Dockerfile
@@ -1,0 +1,6 @@
+FROM eclipse-temurin:21-jre
+WORKDIR /app
+# CI가 build/libs 에 boot jar 하나만 남겨 전달 (plain jar 는 제거됨)
+COPY build/libs/*.jar app.jar
+EXPOSE 8082
+ENTRYPOINT ["java", "-jar", "/app/app.jar"]

--- a/responder/build.gradle
+++ b/responder/build.gradle
@@ -1,0 +1,6 @@
+// Responder — alerts 를 소비해 권장 조치를 dry-run(표시만)으로 로그 출력 (group: responder)
+dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter'
+    implementation 'org.springframework.kafka:spring-kafka'
+    implementation 'com.fasterxml.jackson.core:jackson-databind'   // alerts JSON 역직렬화
+}

--- a/responder/src/main/java/com/edrdog/responder/AlertListener.java
+++ b/responder/src/main/java/com/edrdog/responder/AlertListener.java
@@ -1,0 +1,30 @@
+package com.edrdog.responder;
+
+import com.edrdog.responder.dto.Alert;
+import com.edrdog.responder.response.ResponsePlanner;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+/**
+ * alerts 토픽을 소비해 권장 조치를 dry-run 으로 표시(로그)만 하는 리스너.
+ * 판정/쿨다운은 ResponsePlanner(순수 로직)에 위임하고, 여기서는 소비와 로그 출력만 담당한다.
+ */
+@Component
+public class AlertListener {
+
+    private static final Logger log = LoggerFactory.getLogger(AlertListener.class);
+
+    private final ResponsePlanner planner;
+
+    public AlertListener(@Value("${edrdog.responder.cooldown-ms}") long cooldownMs) {
+        this.planner = new ResponsePlanner(cooldownMs);
+    }
+
+    @KafkaListener(topics = "${edrdog.kafka.alerts-topic}", groupId = "${spring.kafka.consumer.group-id}")
+    public void onAlert(Alert alert) {
+        planner.plan(alert).ifPresent(log::info);
+    }
+}

--- a/responder/src/main/java/com/edrdog/responder/ResponderApplication.java
+++ b/responder/src/main/java/com/edrdog/responder/ResponderApplication.java
@@ -1,0 +1,13 @@
+package com.edrdog.responder;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+/** alerts 를 소비해 권장 조치를 dry-run 으로 표시하는 responder 서비스. */
+@SpringBootApplication
+public class ResponderApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(ResponderApplication.class, args);
+    }
+}

--- a/responder/src/main/java/com/edrdog/responder/dto/Alert.java
+++ b/responder/src/main/java/com/edrdog/responder/dto/Alert.java
@@ -1,0 +1,29 @@
+package com.edrdog.responder.dto;
+
+import java.util.List;
+
+/**
+ * detector 가 alerts 토픽에 발행하는 판정 결과 (responder 소비용 사본).
+ * 소비자는 자기 관점의 스키마 사본을 갖는다. 여분 필드는 JsonDeserializer 가 무시한다.
+ *
+ * @param host     엔드포인트 식별자
+ * @param ruleId   매칭된 룰 식별자 (예: SUSPICIOUS_PROCESS_CHAIN)
+ * @param mitre    MITRE ATT&CK 기법 태그 (예: T1059)
+ * @param severity 심각도: HIGH | CRITICAL
+ * @param action   권고 대응: notify | kill | isolate
+ * @param ts       판정을 완성시킨 트리거 이벤트 시각 (epoch millis)
+ * @param matched  판정 근거가 된 이벤트 요약들
+ */
+public record Alert(
+        String host,
+        String ruleId,
+        String mitre,
+        String severity,
+        String action,
+        long ts,
+        List<String> matched
+) {
+    public static final String ACTION_NOTIFY = "notify";
+    public static final String ACTION_KILL = "kill";
+    public static final String ACTION_ISOLATE = "isolate";
+}

--- a/responder/src/main/java/com/edrdog/responder/response/Cooldown.java
+++ b/responder/src/main/java/com/edrdog/responder/response/Cooldown.java
@@ -1,0 +1,28 @@
+package com.edrdog.responder.response;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * 키별 마지막 표시 시각을 기억해 윈도우 안 중복 표시를 억제하는 순수 로직.
+ * 시각(nowMs)은 호출자가 주입한다 (벽시계 대신 alert 이벤트 시각 사용 → 결정적).
+ */
+public class Cooldown {
+
+    private final long windowMs;
+    private final Map<String, Long> lastShown = new HashMap<>();
+
+    public Cooldown(long windowMs) {
+        this.windowMs = windowMs;
+    }
+
+    /** 키가 윈도우 밖이면 통과시키고 시각을 갱신, 윈도우 안이면 억제. */
+    public boolean allow(String key, long nowMs) {
+        Long last = lastShown.get(key);
+        if (last != null && nowMs - last < windowMs) {
+            return false;
+        }
+        lastShown.put(key, nowMs);
+        return true;
+    }
+}

--- a/responder/src/main/java/com/edrdog/responder/response/ResponsePlanner.java
+++ b/responder/src/main/java/com/edrdog/responder/response/ResponsePlanner.java
@@ -1,0 +1,45 @@
+package com.edrdog.responder.response;
+
+import com.edrdog.responder.dto.Alert;
+
+import java.util.Optional;
+
+/**
+ * alert 의 권고 action 을 사람이 읽을 dry-run 조치 텍스트로 변환하는 순수 로직.
+ * 실제 실행은 하지 않으며(표시만), host+action 단위로 쿨다운을 적용한다.
+ */
+public class ResponsePlanner {
+
+    private final Cooldown cooldown;
+
+    public ResponsePlanner(long cooldownMs) {
+        this.cooldown = new Cooldown(cooldownMs);
+    }
+
+    /** 쿨다운을 통과하면 dry-run 표시 줄을 반환, 억제되거나 입력이 불완전하면 비어 있음. */
+    public Optional<String> plan(Alert alert) {
+        if (alert == null || alert.host() == null || alert.action() == null) {
+            return Optional.empty();
+        }
+        String key = alert.host() + "|" + alert.action();
+        if (!cooldown.allow(key, alert.ts())) {
+            return Optional.empty();
+        }
+        return Optional.of(format(alert));
+    }
+
+    /** action → 권장 조치 텍스트. 알 수 없는 action 은 알림으로 처리. */
+    static String label(String action) {
+        return switch (action) {
+            case Alert.ACTION_KILL -> "프로세스 종료 권장";
+            case Alert.ACTION_ISOLATE -> "호스트 격리 권장";
+            default -> "알림 권장";
+        };
+    }
+
+    /** trigger=response 로 태깅된 dry-run 한 줄. 실제 실행은 없음을 명시. */
+    static String format(Alert alert) {
+        return String.format("[DRY-RUN] trigger=response host=%s rule=%s action=%s → %s (실행 안 함)",
+                alert.host(), alert.ruleId(), alert.action(), label(alert.action()));
+    }
+}

--- a/responder/src/main/resources/application.yml
+++ b/responder/src/main/resources/application.yml
@@ -1,0 +1,28 @@
+spring:
+  application:
+    name: responder
+  kafka:
+    bootstrap-servers: localhost:9092
+    consumer:
+      group-id: responder
+      auto-offset-reset: latest
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
+      properties:
+        spring.json.value.default.type: com.edrdog.responder.dto.Alert
+        spring.json.trusted.packages: com.edrdog.responder.dto
+
+server:
+  port: 8082
+
+edrdog:
+  kafka:
+    alerts-topic: alerts        # detector 가 발행한 판정 결과 (소비 입력)
+  responder:
+    cooldown-ms: 60000          # 같은 host+action 중복 표시 억제 창
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health, info

--- a/responder/src/test/java/com/edrdog/responder/response/CooldownTest.java
+++ b/responder/src/test/java/com/edrdog/responder/response/CooldownTest.java
@@ -1,0 +1,42 @@
+package com.edrdog.responder.response;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** 같은 키의 중복 표시를 윈도우 동안 억제하는 쿨다운 순수 로직 검증. */
+class CooldownTest {
+
+    @Test
+    @DisplayName("첫 호출은 통과")
+    void firstAllow() {
+        Cooldown cooldown = new Cooldown(60_000);
+        assertThat(cooldown.allow("host-1|kill", 1_000)).isTrue();
+    }
+
+    @Test
+    @DisplayName("윈도우 안 같은 키 재호출은 억제")
+    void withinWindow_suppressed() {
+        Cooldown cooldown = new Cooldown(60_000);
+        cooldown.allow("host-1|kill", 1_000);
+        assertThat(cooldown.allow("host-1|kill", 60_000)).isFalse();
+    }
+
+    @Test
+    @DisplayName("윈도우 경과 후 같은 키는 다시 통과")
+    void afterWindow_allowed() {
+        Cooldown cooldown = new Cooldown(60_000);
+        cooldown.allow("host-1|kill", 1_000);
+        assertThat(cooldown.allow("host-1|kill", 61_000)).isTrue();
+    }
+
+    @Test
+    @DisplayName("키가 다르면 서로 독립적으로 통과")
+    void differentKeys_independent() {
+        Cooldown cooldown = new Cooldown(60_000);
+        cooldown.allow("host-1|kill", 1_000);
+        assertThat(cooldown.allow("host-1|isolate", 1_000)).isTrue();
+        assertThat(cooldown.allow("host-2|kill", 1_000)).isTrue();
+    }
+}

--- a/responder/src/test/java/com/edrdog/responder/response/ResponsePlannerTest.java
+++ b/responder/src/test/java/com/edrdog/responder/response/ResponsePlannerTest.java
@@ -1,0 +1,57 @@
+package com.edrdog.responder.response;
+
+import com.edrdog.responder.dto.Alert;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** alert → dry-run 조치 텍스트 매핑과 쿨다운 억제 검증 (순수 로직). */
+class ResponsePlannerTest {
+
+    private Alert alert(String host, String ruleId, String action, long ts) {
+        return new Alert(host, ruleId, "T1059", "HIGH", action, ts, List.of("evidence"));
+    }
+
+    @Test
+    @DisplayName("kill 은 프로세스 종료 권장 텍스트로, trigger=response 태깅되어 표시")
+    void kill_mapsToText() {
+        ResponsePlanner planner = new ResponsePlanner(60_000);
+        String line = planner.plan(alert("host-1", "SUSPICIOUS_PROCESS_CHAIN", Alert.ACTION_KILL, 1_000)).orElseThrow();
+
+        assertThat(line).contains("trigger=response");
+        assertThat(line).contains("host=host-1");
+        assertThat(line).contains("action=kill");
+        assertThat(line).contains("프로세스 종료 권장");
+    }
+
+    @Test
+    @DisplayName("isolate 는 호스트 격리 권장 텍스트로 표시")
+    void isolate_mapsToText() {
+        ResponsePlanner planner = new ResponsePlanner(60_000);
+        String line = planner.plan(alert("host-2", "DOWNLOAD_AND_EXECUTE", Alert.ACTION_ISOLATE, 1_000)).orElseThrow();
+
+        assertThat(line).contains("action=isolate");
+        assertThat(line).contains("호스트 격리 권장");
+    }
+
+    @Test
+    @DisplayName("같은 host+action 이 쿨다운 안에 다시 오면 표시 안 함")
+    void sameHostAction_withinCooldown_suppressed() {
+        ResponsePlanner planner = new ResponsePlanner(60_000);
+        planner.plan(alert("host-1", "R", Alert.ACTION_KILL, 1_000));
+
+        assertThat(planner.plan(alert("host-1", "R", Alert.ACTION_KILL, 30_000))).isEmpty();
+    }
+
+    @Test
+    @DisplayName("같은 host 라도 action 이 다르면 각각 표시")
+    void sameHost_differentAction_shown() {
+        ResponsePlanner planner = new ResponsePlanner(60_000);
+        planner.plan(alert("host-1", "R", Alert.ACTION_KILL, 1_000));
+
+        assertThat(planner.plan(alert("host-1", "R", Alert.ACTION_ISOLATE, 1_000))).isPresent();
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,4 @@
 rootProject.name = 'edrdog-backend'
 
 include 'detector'
+include 'responder'

--- a/settings.gradle
+++ b/settings.gradle
@@ -2,3 +2,4 @@ rootProject.name = 'edrdog-backend'
 
 include 'detector'
 include 'responder'
+include 'archiver'


### PR DESCRIPTION
## 개요
빌드+최소테스트 → GHCR 이미지 → K8s 배포를 하나의 워크플로로 구성. Closes #23

## 변경
- `.github/workflows/cicd.yml`: build / image(matrix) / deploy 4-job
- `detector|responder|archiver/Dockerfile`: temurin:21-jre 기반
- `k8s/{detector,responder,archiver}.yaml`: Deployment + Service (edrdog ns)

## 인프라 연동
- Kafka 내부 서비스 `kafka:9094`, archiver는 `clickhouse:8123` 주입
- 배포는 앱 매니페스트만 적용 (kind-cluster.yaml 제외)

## 배포 전 필요
- GitHub Secret `KUBE_CONFIG` (base64 kubeconfig)
- GHCR는 GITHUB_TOKEN 자동 사용

## 검증
- `./gradlew build` 통과 (3개 모듈, 기존 테스트)
- k8s 매니페스트 `kubectl apply --dry-run=client` 통과