### PR TITLE
feat: alert 조회·트리아지 API (tenant 격리) (#36)

### DIFF
--- a/api-service/build.gradle
+++ b/api-service/build.gradle
@@ -4,6 +4,7 @@ dependencies {
     implementation 'com.fasterxml.jackson.core:jackson-databind'        // ClickHouse JSON 응답 파싱
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.9'  // Swagger UI (/swagger-ui.html)
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'    // auth: MySQL + JPA 저장소
+    implementation 'org.springframework.kafka:spring-kafka'             // alerts 토픽 소비 → MySQL 적재
     runtimeOnly 'com.mysql:mysql-connector-j'                           // auth: MySQL 드라이버
     implementation 'org.springframework.security:spring-security-crypto'      // auth: BCrypt 비밀번호 해시(필터체인 없이)
     testImplementation 'com.h2database:h2'                             // auth: 테스트용 임베디드 DB

--- a/api-service/src/main/java/com/edrdog/apiservice/alert/AlertId.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/alert/AlertId.java
@@ -1,0 +1,19 @@
+package com.edrdog.apiservice.alert;
+
+import java.nio.charset.StandardCharsets;
+import java.util.UUID;
+
+/**
+ * alert 의 결정적 id 생성(순수). tenantId|host|ruleId|ts 를 UUID v3(name-based)로 접어 만든다.
+ * 같은 판정이 재소비돼도 같은 id 가 나와 멱등 적재가 성립한다.
+ */
+public final class AlertId {
+
+    private AlertId() {
+    }
+
+    public static String of(String tenantId, String host, String ruleId, long ts) {
+        String seed = tenantId + "|" + host + "|" + ruleId + "|" + ts;
+        return UUID.nameUUIDFromBytes(seed.getBytes(StandardCharsets.UTF_8)).toString();
+    }
+}

--- a/api-service/src/main/java/com/edrdog/apiservice/alert/AlertIngestListener.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/alert/AlertIngestListener.java
@@ -1,0 +1,24 @@
+package com.edrdog.apiservice.alert;
+
+import com.edrdog.apiservice.alert.dto.Alert;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+/**
+ * alerts 토픽을 소비해 api-service 자기 MySQL 에 적재하는 리스너(얇게).
+ * 실제 격리·멱등 처리는 AlertService.ingest 가 담당한다.
+ */
+@Component
+public class AlertIngestListener {
+
+    private final AlertService service;
+
+    public AlertIngestListener(AlertService service) {
+        this.service = service;
+    }
+
+    @KafkaListener(topics = "${edrdog.kafka.alerts-topic}", groupId = "${spring.kafka.consumer.group-id}")
+    public void onAlert(Alert alert) {
+        service.ingest(alert);
+    }
+}

--- a/api-service/src/main/java/com/edrdog/apiservice/alert/AlertRecord.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/alert/AlertRecord.java
@@ -1,0 +1,143 @@
+package com.edrdog.apiservice.alert;
+
+import jakarta.persistence.CollectionTable;
+import jakarta.persistence.Column;
+import jakarta.persistence.ElementCollection;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.Table;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * 적재된 alert (MySQL). status 가 트리아지로 바뀌므로 불변 이벤트 스토어(ClickHouse)가 아닌 MySQL 에 둔다.
+ * id 는 tenantId|host|ruleId|ts 로 결정되어(AlertId) 재소비돼도 한 행만 남는다.
+ */
+@Entity
+@Table(name = "alerts")
+public class AlertRecord {
+
+    @Id
+    private String id;
+
+    @Column(name = "tenant_id", nullable = false)
+    private String tenantId;
+
+    @Column(nullable = false)
+    private String host;
+
+    @Column(nullable = false)
+    private String ruleId;
+
+    @Column
+    private String mitre;
+
+    @Column
+    private String severity;
+
+    @Column
+    private String action;
+
+    @Column(nullable = false)
+    private long ts;
+
+    @Column(nullable = false)
+    private String status;
+
+    @ElementCollection(fetch = FetchType.LAZY)
+    @CollectionTable(name = "alert_matched", joinColumns = @JoinColumn(name = "alert_id"))
+    @Column(name = "line")
+    @org.hibernate.annotations.BatchSize(size = 100)  // 목록 조회 시 matched N+1 완화(행별 SELECT → 배치 로딩)
+    private List<String> matched = new ArrayList<>();
+
+    @Column(nullable = false)
+    private Instant createdAt;
+
+    @Column(nullable = false)
+    private Instant updatedAt;
+
+    protected AlertRecord() {
+    }
+
+    private AlertRecord(String id, String tenantId, String host, String ruleId, String mitre,
+                        String severity, String action, long ts, String status,
+                        List<String> matched, Instant createdAt, Instant updatedAt) {
+        this.id = id;
+        this.tenantId = tenantId;
+        this.host = host;
+        this.ruleId = ruleId;
+        this.mitre = mitre;
+        this.severity = severity;
+        this.action = action;
+        this.ts = ts;
+        this.status = status;
+        this.matched = matched == null ? new ArrayList<>() : new ArrayList<>(matched);
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+    }
+
+    /** 신규 적재용. status 는 항상 open 으로 시작한다. */
+    public static AlertRecord open(String id, String tenantId, String host, String ruleId, String mitre,
+                                   String severity, String action, long ts, List<String> matched, Instant now) {
+        return new AlertRecord(id, tenantId, host, ruleId, mitre, severity, action, ts,
+                AlertStatus.OPEN, matched, now, now);
+    }
+
+    /** 트리아지로 status 를 갱신한다. */
+    public void triage(String status, Instant now) {
+        this.status = status;
+        this.updatedAt = now;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getTenantId() {
+        return tenantId;
+    }
+
+    public String getHost() {
+        return host;
+    }
+
+    public String getRuleId() {
+        return ruleId;
+    }
+
+    public String getMitre() {
+        return mitre;
+    }
+
+    public String getSeverity() {
+        return severity;
+    }
+
+    public String getAction() {
+        return action;
+    }
+
+    public long getTs() {
+        return ts;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public List<String> getMatched() {
+        return matched;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    public Instant getUpdatedAt() {
+        return updatedAt;
+    }
+}

--- a/api-service/src/main/java/com/edrdog/apiservice/alert/AlertRepository.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/alert/AlertRepository.java
@@ -1,0 +1,30 @@
+package com.edrdog.apiservice.alert;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+/**
+ * alert 저장소. tenant 는 항상 필수 조건으로 강제해 조직 격리를 지킨다("A사는 A사 것만").
+ * host/severity/status/from/to 는 옵션 필터로 null 이면 무시한다.
+ */
+public interface AlertRepository extends JpaRepository<AlertRecord, String> {
+
+    @Query("SELECT a FROM AlertRecord a WHERE a.tenantId = :tenantId "
+            + "AND (:host is null or a.host = :host) "
+            + "AND (:severity is null or a.severity = :severity) "
+            + "AND (:status is null or a.status = :status) "
+            + "AND (:from is null or a.ts >= :from) "
+            + "AND (:to is null or a.ts <= :to) "
+            + "ORDER BY a.ts DESC")
+    List<AlertRecord> search(@Param("tenantId") String tenantId,
+                             @Param("host") String host,
+                             @Param("severity") String severity,
+                             @Param("status") String status,
+                             @Param("from") Long from,
+                             @Param("to") Long to,
+                             Pageable pageable);
+}

--- a/api-service/src/main/java/com/edrdog/apiservice/alert/AlertService.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/alert/AlertService.java
@@ -1,0 +1,93 @@
+package com.edrdog.apiservice.alert;
+
+import com.edrdog.apiservice.alert.dto.Alert;
+import com.edrdog.apiservice.alert.web.AlertResponse;
+import com.edrdog.apiservice.auth.exception.AuthException;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+import java.util.List;
+
+/**
+ * alert 적재/조회/트리아지 로직. 리스너·컨트롤러는 얇게 두고 여기서 tenant 격리와 멱등 적재를 담당한다.
+ */
+@Service
+public class AlertService {
+
+    static final int DEFAULT_LIMIT = 100;
+    static final int MAX_LIMIT = 1000;
+
+    private final AlertRepository alerts;
+
+    public AlertService(AlertRepository alerts) {
+        this.alerts = alerts;
+    }
+
+    /**
+     * alert 를 적재한다. id 는 결정적(AlertId)이라 재소비돼도 한 행만 남는다.
+     * 이미 있으면 덮어쓰지 않는다(트리아지된 status 보존). tenantId 없는 alert 는 skip.
+     *
+     * 계약(주의): 조회 격리는 저장된 tenantId 를 로그인 유저의 tenant PK 문자열
+     * (String.valueOf(principal.tenantId())) 과 equals 비교한다. 따라서 detector 가
+     * 발행하는 alert.tenantId 는 반드시 api-service 의 tenant PK 문자열이어야 한다.
+     * (조직명/UUID 등 다른 표현이면 저장은 되지만 조회에서 매칭되지 않아 alert 가 안 보인다.)
+     */
+    @Transactional
+    public void ingest(Alert alert) {
+        if (alert == null || alert.tenantId() == null || alert.tenantId().isBlank()
+                || alert.host() == null || alert.ruleId() == null) {
+            return;
+        }
+        String id = AlertId.of(alert.tenantId(), alert.host(), alert.ruleId(), alert.ts());
+        if (alerts.existsById(id)) {
+            return;
+        }
+        AlertRecord record = AlertRecord.open(id, alert.tenantId(), alert.host(), alert.ruleId(),
+                alert.mitre(), alert.severity(), alert.action(), alert.ts(), alert.matched(), Instant.now());
+        alerts.save(record);
+    }
+
+    /** tenant 격리 하에 필터로 최신순 조회. limit 은 1..MAX 로 클램프. */
+    @Transactional(readOnly = true)
+    public List<AlertResponse> query(String tenantId, String host, String severity, String status,
+                                     Long from, Long to, Integer limit) {
+        Pageable page = PageRequest.of(0, clampLimit(limit));
+        return alerts.search(tenantId, host, severity, status, from, to, page).stream()
+                .map(AlertResponse::from)
+                .toList();
+    }
+
+    /** 단건 상세. 없거나 다른 tenant 것이면 404(존재 은닉). */
+    @Transactional(readOnly = true)
+    public AlertResponse get(String tenantId, String id) {
+        return AlertResponse.from(owned(tenantId, id));
+    }
+
+    /** 트리아지 갱신. status 검증(confirmed|false_positive) 후 소유 확인, 갱신 결과 반환. */
+    @Transactional
+    public AlertResponse triage(String tenantId, String id, String status) {
+        if (!AlertStatus.validTransition(status)) {
+            throw AuthException.invalidInput("허용되지 않는 status 입니다: " + status);
+        }
+        AlertRecord record = owned(tenantId, id);
+        record.triage(status, Instant.now());
+        return AlertResponse.from(record);
+    }
+
+    /** id 로 찾되 tenant 소유가 아니면 404 로 숨긴다(없는 것과 구분 불가). */
+    private AlertRecord owned(String tenantId, String id) {
+        return alerts.findById(id)
+                .filter(a -> a.getTenantId().equals(tenantId))
+                .orElseThrow(() -> AuthException.notFound("alert 를 찾을 수 없습니다"));
+    }
+
+    private static int clampLimit(Integer limit) {
+        if (limit == null || limit <= 0) {
+            return DEFAULT_LIMIT;
+        }
+        return Math.min(limit, MAX_LIMIT);
+    }
+}

--- a/api-service/src/main/java/com/edrdog/apiservice/alert/AlertStatus.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/alert/AlertStatus.java
@@ -1,0 +1,20 @@
+package com.edrdog.apiservice.alert;
+
+/**
+ * alert 트리아지 status 값과 검증(순수). open 은 적재 시 초기값이고,
+ * PATCH 로 바꿀 수 있는 값은 confirmed / false_positive 뿐이다.
+ */
+public final class AlertStatus {
+
+    public static final String OPEN = "open";
+    public static final String CONFIRMED = "confirmed";
+    public static final String FALSE_POSITIVE = "false_positive";
+
+    private AlertStatus() {
+    }
+
+    /** PATCH 로 허용되는 status 인지. confirmed / false_positive 만 true. */
+    public static boolean validTransition(String status) {
+        return CONFIRMED.equals(status) || FALSE_POSITIVE.equals(status);
+    }
+}

--- a/api-service/src/main/java/com/edrdog/apiservice/alert/dto/Alert.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/alert/dto/Alert.java
@@ -1,0 +1,28 @@
+package com.edrdog.apiservice.alert.dto;
+
+import java.util.List;
+
+/**
+ * alerts 토픽 소비 스키마 사본 (detector 발행 Alert 와 동일 필드).
+ * api-service 는 이 값을 자기 MySQL 에 적재해 조회/트리아지 API 로 서빙한다.
+ *
+ * @param host     엔드포인트 식별자
+ * @param ruleId   매칭된 룰 식별자
+ * @param mitre    MITRE ATT&CK 기법 태그
+ * @param severity 심각도
+ * @param action   권고 대응
+ * @param ts       판정 시각 (epoch millis)
+ * @param matched  판정 근거 이벤트 요약들
+ * @param tenantId 조직(tenant) 식별자 (문자열)
+ */
+public record Alert(
+        String host,
+        String ruleId,
+        String mitre,
+        String severity,
+        String action,
+        long ts,
+        List<String> matched,
+        String tenantId
+) {
+}

--- a/api-service/src/main/java/com/edrdog/apiservice/alert/web/AlertController.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/alert/web/AlertController.java
@@ -1,0 +1,88 @@
+package com.edrdog.apiservice.alert.web;
+
+import com.edrdog.apiservice.alert.AlertService;
+import com.edrdog.apiservice.auth.service.AuthService;
+import com.edrdog.apiservice.auth.service.Principal;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+/**
+ * alert 조회·트리아지 REST. 모든 요청은 세션 Bearer 토큰으로 인증하고 그 tenant 로만 격리한다
+ * (EventQueryController 와 동일 패턴). 남의 tenant alert 는 404 로 숨긴다.
+ */
+@RestController
+@RequestMapping("/api/alerts")
+@Tag(name = "alerts", description = "알림 조회 및 트리아지 (MySQL, tenant 격리)")
+public class AlertController {
+
+    private static final String BEARER_PREFIX = "Bearer ";
+
+    private final AlertService alerts;
+    private final AuthService auth;
+
+    public AlertController(AlertService alerts, AuthService auth) {
+        this.alerts = alerts;
+        this.auth = auth;
+    }
+
+    @Operation(summary = "알림 목록", description = "로그인 유저의 tenant 것만 host/severity/status/from/to 필터로 최신순 조회. limit 기본 100, 상한 1000.")
+    @GetMapping
+    public List<AlertResponse> list(
+            @RequestHeader(name = "Authorization", required = false) String authorization,
+            @RequestParam(required = false) String host,
+            @RequestParam(required = false) String severity,
+            @RequestParam(required = false) String status,
+            @RequestParam(required = false) Long from,
+            @RequestParam(required = false) Long to,
+            @RequestParam(required = false) Integer limit) {
+        String tenantId = currentTenantId(authorization);
+        return alerts.query(tenantId, host, severity, status, from, to, limit);
+    }
+
+    @Operation(summary = "알림 상세", description = "단건 상세(matched 포함). 남의 tenant 것이면 404.")
+    @GetMapping("/{id}")
+    public AlertResponse detail(
+            @RequestHeader(name = "Authorization", required = false) String authorization,
+            @PathVariable String id) {
+        String tenantId = currentTenantId(authorization);
+        return alerts.get(tenantId, id);
+    }
+
+    @Operation(summary = "알림 트리아지", description = "status 를 confirmed/false_positive 로 갱신. 잘못된 값 400, 남의 tenant 것 404.")
+    @PatchMapping("/{id}")
+    public AlertResponse triage(
+            @RequestHeader(name = "Authorization", required = false) String authorization,
+            @PathVariable String id,
+            @RequestBody TriageRequest request) {
+        String tenantId = currentTenantId(authorization);
+        return alerts.triage(tenantId, id, request.status());
+    }
+
+    /** Bearer 토큰을 검증해 현재 유저의 tenant 를 문자열로 반환. 토큰이 없거나 만료면 AuthService 가 401. */
+    private String currentTenantId(String authorization) {
+        Principal principal = auth.resolve(bearerToken(authorization));
+        return String.valueOf(principal.tenantId());
+    }
+
+    /** "Bearer " 접두어를 떼서 토큰만 반환. 없으면 null. */
+    private static String bearerToken(String authorization) {
+        if (authorization == null || !authorization.startsWith(BEARER_PREFIX)) {
+            return null;
+        }
+        return authorization.substring(BEARER_PREFIX.length()).trim();
+    }
+
+    /** PATCH 본문: 바꿀 status. */
+    public record TriageRequest(String status) {
+    }
+}

--- a/api-service/src/main/java/com/edrdog/apiservice/alert/web/AlertResponse.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/alert/web/AlertResponse.java
@@ -1,0 +1,25 @@
+package com.edrdog.apiservice.alert.web;
+
+import com.edrdog.apiservice.alert.AlertRecord;
+
+import java.util.List;
+
+/**
+ * alert 조회/상세/트리아지 응답. 목록과 상세가 같은 형태를 쓴다(matched 포함).
+ */
+public record AlertResponse(
+        String id,
+        String host,
+        String ruleId,
+        String mitre,
+        String severity,
+        String action,
+        long ts,
+        String status,
+        List<String> matched
+) {
+    public static AlertResponse from(AlertRecord r) {
+        return new AlertResponse(r.getId(), r.getHost(), r.getRuleId(), r.getMitre(),
+                r.getSeverity(), r.getAction(), r.getTs(), r.getStatus(), List.copyOf(r.getMatched()));
+    }
+}

--- a/api-service/src/main/java/com/edrdog/apiservice/security/ApiKeyPolicy.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/security/ApiKeyPolicy.java
@@ -13,6 +13,7 @@ public class ApiKeyPolicy {
             "/v3/api-docs",
             "/api/auth/",
             "/api/events",  // 조회는 세션 Bearer 로 인증하고 tenant 를 뽑는다(EventQueryController)
+            "/api/alerts",  // 알림 조회·트리아지도 세션 Bearer 로 인증(AlertController)
             "/api/internal/"  // 서비스 간 조회는 별도 X-Internal-Key 로 인증(TenantController), 프론트 키와 분리
     );
 

--- a/api-service/src/main/resources/application.yml
+++ b/api-service/src/main/resources/application.yml
@@ -9,11 +9,23 @@ spring:
     hibernate:
       ddl-auto: update
     open-in-view: false
+  kafka:
+    bootstrap-servers: ${KAFKA_BOOTSTRAP:localhost:9092}
+    consumer:
+      group-id: api-alerts
+      auto-offset-reset: latest
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
+      properties:
+        spring.json.value.default.type: com.edrdog.apiservice.alert.dto.Alert
+        spring.json.trusted.packages: com.edrdog.apiservice.alert.dto
 
 server:
   port: 8084
 
 edrdog:
+  kafka:
+    alerts-topic: alerts                 # detector 가 발행한 판정 결과 (소비 → MySQL 적재)
   api:
     key: ${EDRDOG_API_KEY:dev-api-key}   # 프론트가 X-API-Key 헤더로 보낼 값 (운영은 환경변수로 주입)
   internal:

--- a/api-service/src/test/java/com/edrdog/apiservice/alert/AlertIdTest.java
+++ b/api-service/src/test/java/com/edrdog/apiservice/alert/AlertIdTest.java
@@ -1,0 +1,28 @@
+package com.edrdog.apiservice.alert;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+/**
+ * 결정적 alert id 순수 로직. 같은 입력은 같은 id, 다른 입력은 다른 id 여야 멱등 적재가 성립한다.
+ */
+class AlertIdTest {
+
+    @Test
+    void 같은_입력은_같은_id() {
+        String a = AlertId.of("t1", "host-1", "RULE_A", 1000L);
+        String b = AlertId.of("t1", "host-1", "RULE_A", 1000L);
+        assertEquals(a, b);
+    }
+
+    @Test
+    void 필드가_다르면_id도_다르다() {
+        String base = AlertId.of("t1", "host-1", "RULE_A", 1000L);
+        assertNotEquals(base, AlertId.of("t2", "host-1", "RULE_A", 1000L));
+        assertNotEquals(base, AlertId.of("t1", "host-2", "RULE_A", 1000L));
+        assertNotEquals(base, AlertId.of("t1", "host-1", "RULE_B", 1000L));
+        assertNotEquals(base, AlertId.of("t1", "host-1", "RULE_A", 2000L));
+    }
+}

--- a/api-service/src/test/java/com/edrdog/apiservice/alert/AlertIngestTest.java
+++ b/api-service/src/test/java/com/edrdog/apiservice/alert/AlertIngestTest.java
@@ -1,0 +1,60 @@
+package com.edrdog.apiservice.alert;
+
+import com.edrdog.apiservice.alert.dto.Alert;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.domain.PageRequest;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * 적재 멱등성(H2). 같은 alert 를 두 번 소비해도 한 행만 남고,
+ * 이미 트리아지된(confirmed) alert 는 재소비돼도 open 으로 되돌아가지 않는다.
+ */
+@DataJpaTest
+class AlertIngestTest {
+
+    @Autowired
+    private AlertRepository alerts;
+
+    private AlertService service() {
+        return new AlertService(alerts);
+    }
+
+    private static Alert alert(String tenantId, long ts) {
+        return new Alert("h1", "RULE_A", "T1059", "HIGH", "notify", ts, List.of("m1"), tenantId);
+    }
+
+    @Test
+    void 같은_alert_두번_ingest_하면_한행() {
+        AlertService svc = service();
+        svc.ingest(alert("A", 100L));
+        svc.ingest(alert("A", 100L));
+
+        assertEquals(1, alerts.search("A", null, null, null, null, null, PageRequest.of(0, 10)).size());
+    }
+
+    @Test
+    void 이미_confirmed_면_재소비해도_open_으로_안돌아간다() {
+        AlertService svc = service();
+        svc.ingest(alert("A", 100L));
+        String id = AlertId.of("A", "h1", "RULE_A", 100L);
+        svc.triage("A", id, AlertStatus.CONFIRMED);
+
+        svc.ingest(alert("A", 100L));
+
+        assertEquals(AlertStatus.CONFIRMED, alerts.findById(id).orElseThrow().getStatus());
+    }
+
+    @Test
+    void tenantId_없으면_skip() {
+        AlertService svc = service();
+        svc.ingest(alert(null, 100L));
+        svc.ingest(alert("  ", 100L));
+
+        assertEquals(0, alerts.count());
+    }
+}

--- a/api-service/src/test/java/com/edrdog/apiservice/alert/AlertRepositoryTest.java
+++ b/api-service/src/test/java/com/edrdog/apiservice/alert/AlertRepositoryTest.java
@@ -1,0 +1,84 @@
+package com.edrdog.apiservice.alert;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import java.time.Instant;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * AlertRepository 슬라이스(H2). tenant 격리 + host/severity/status/시간범위 필터 + ts DESC + limit 확인.
+ */
+@DataJpaTest
+class AlertRepositoryTest {
+
+    @Autowired
+    private AlertRepository alerts;
+
+    private void seed(String tenantId, String host, String severity, String status, long ts) {
+        String id = AlertId.of(tenantId, host, "RULE_" + ts, ts);
+        AlertRecord r = AlertRecord.open(id, tenantId, host, "RULE_" + ts, "T1059",
+                severity, "notify", ts, List.of("m1"), Instant.now());
+        if (!status.equals(AlertStatus.OPEN)) {
+            r.triage(status, Instant.now());
+        }
+        alerts.save(r);
+    }
+
+    private static Pageable page(int limit) {
+        return PageRequest.of(0, limit);
+    }
+
+    @Test
+    void tenant_격리_다른조직_것은_안보인다() {
+        seed("A", "h1", "HIGH", AlertStatus.OPEN, 100L);
+        seed("B", "h1", "HIGH", AlertStatus.OPEN, 200L);
+
+        List<AlertRecord> a = alerts.search("A", null, null, null, null, null, page(10));
+        assertEquals(1, a.size());
+        assertEquals("A", a.get(0).getTenantId());
+    }
+
+    @Test
+    void host_severity_status_필터() {
+        seed("A", "h1", "HIGH", AlertStatus.OPEN, 100L);
+        seed("A", "h2", "CRITICAL", AlertStatus.CONFIRMED, 200L);
+
+        assertEquals(1, alerts.search("A", "h1", null, null, null, null, page(10)).size());
+        assertEquals(1, alerts.search("A", null, "CRITICAL", null, null, null, page(10)).size());
+        assertEquals(1, alerts.search("A", null, null, AlertStatus.CONFIRMED, null, null, page(10)).size());
+        assertTrue(alerts.search("A", "none", null, null, null, null, page(10)).isEmpty());
+    }
+
+    @Test
+    void 시간범위_필터() {
+        seed("A", "h1", "HIGH", AlertStatus.OPEN, 100L);
+        seed("A", "h1", "HIGH", AlertStatus.OPEN, 300L);
+
+        assertEquals(1, alerts.search("A", null, null, null, 200L, null, page(10)).size());
+        assertEquals(1, alerts.search("A", null, null, null, null, 200L, page(10)).size());
+        assertEquals(2, alerts.search("A", null, null, null, 100L, 300L, page(10)).size());
+    }
+
+    @Test
+    void ts_내림차순_그리고_limit() {
+        seed("A", "h1", "HIGH", AlertStatus.OPEN, 100L);
+        seed("A", "h1", "HIGH", AlertStatus.OPEN, 300L);
+        seed("A", "h1", "HIGH", AlertStatus.OPEN, 200L);
+
+        List<AlertRecord> all = alerts.search("A", null, null, null, null, null, page(10));
+        assertEquals(300L, all.get(0).getTs());
+        assertEquals(200L, all.get(1).getTs());
+        assertEquals(100L, all.get(2).getTs());
+
+        List<AlertRecord> limited = alerts.search("A", null, null, null, null, null, page(2));
+        assertEquals(2, limited.size());
+        assertEquals(300L, limited.get(0).getTs());
+    }
+}

--- a/api-service/src/test/java/com/edrdog/apiservice/alert/AlertStatusTest.java
+++ b/api-service/src/test/java/com/edrdog/apiservice/alert/AlertStatusTest.java
@@ -1,0 +1,27 @@
+package com.edrdog.apiservice.alert;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * 트리아지 status 검증 순수 로직. PATCH 로 허용되는 값은 confirmed / false_positive 뿐이다.
+ * open 은 초기값이라 PATCH 로 되돌릴 수 없다.
+ */
+class AlertStatusTest {
+
+    @Test
+    void 허용된_전이만_통과() {
+        assertTrue(AlertStatus.validTransition(AlertStatus.CONFIRMED));
+        assertTrue(AlertStatus.validTransition(AlertStatus.FALSE_POSITIVE));
+    }
+
+    @Test
+    void 초기값_open_과_알수없는_값은_거부() {
+        assertFalse(AlertStatus.validTransition(AlertStatus.OPEN));
+        assertFalse(AlertStatus.validTransition("deleted"));
+        assertFalse(AlertStatus.validTransition(null));
+        assertFalse(AlertStatus.validTransition(""));
+    }
+}

--- a/api-service/src/test/java/com/edrdog/apiservice/alert/web/AlertApiIntegrationTest.java
+++ b/api-service/src/test/java/com/edrdog/apiservice/alert/web/AlertApiIntegrationTest.java
@@ -1,0 +1,124 @@
+package com.edrdog.apiservice.alert.web;
+
+import com.edrdog.apiservice.alert.AlertId;
+import com.edrdog.apiservice.alert.AlertRecord;
+import com.edrdog.apiservice.alert.AlertRepository;
+import com.edrdog.apiservice.alert.AlertStatus;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.time.Instant;
+import java.util.List;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * 전체 컨텍스트를 띄워 alert API 배선(JPA, 라우팅, Bearer tenant 격리, 예외 핸들러)을 검증한다.
+ * 실 Kafka 브로커에 붙지 않도록 리스너 auto-startup 을 끄고, H2(replace=ANY)로 부팅한다.
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.ANY)
+@TestPropertySource(properties = "spring.kafka.listener.auto-startup=false")
+class AlertApiIntegrationTest {
+
+    @Autowired
+    private MockMvc mvc;
+
+    @Autowired
+    private ObjectMapper om;
+
+    @Autowired
+    private AlertRepository alerts;
+
+    private static String signupBody(String email) {
+        return "{\"email\":\"" + email + "\",\"password\":\"password1\"}";
+    }
+
+    /** 회원가입으로 토큰과 tenantId 를 받는다. */
+    private String[] signup(String email) throws Exception {
+        MvcResult res = mvc.perform(post("/api/auth/signup")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(signupBody(email)))
+                .andExpect(status().isCreated())
+                .andReturn();
+        var node = om.readTree(res.getResponse().getContentAsString());
+        return new String[]{node.get("token").asText(), node.get("tenantId").asText()};
+    }
+
+    private String seedAlert(String tenantId, String host, long ts) {
+        String id = AlertId.of(tenantId, host, "RULE_A", ts);
+        alerts.save(AlertRecord.open(id, tenantId, host, "RULE_A", "T1059",
+                "HIGH", "notify", ts, List.of("m1"), Instant.now()));
+        return id;
+    }
+
+    @Test
+    void 목록은_자기_tenant_것만_보인다() throws Exception {
+        String[] a = signup("a-list@edrdog.com");
+        String[] b = signup("b-list@edrdog.com");
+        seedAlert(a[1], "hostA", 100L);
+        seedAlert(b[1], "hostB", 200L);
+
+        mvc.perform(get("/api/alerts").header("Authorization", "Bearer " + a[0]))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(1))
+                .andExpect(jsonPath("$[0].host").value("hostA"));
+    }
+
+    @Test
+    void 남의_alert_상세는_404() throws Exception {
+        String[] a = signup("a-detail@edrdog.com");
+        String[] b = signup("b-detail@edrdog.com");
+        String bId = seedAlert(b[1], "hostB", 200L);
+
+        mvc.perform(get("/api/alerts/" + bId).header("Authorization", "Bearer " + a[0]))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void 자기_alert_트리아지는_200_잘못된_status_400() throws Exception {
+        String[] a = signup("a-triage@edrdog.com");
+        String id = seedAlert(a[1], "hostA", 100L);
+
+        mvc.perform(patch("/api/alerts/" + id).header("Authorization", "Bearer " + a[0])
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"status\":\"" + AlertStatus.CONFIRMED + "\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value(AlertStatus.CONFIRMED));
+
+        mvc.perform(patch("/api/alerts/" + id).header("Authorization", "Bearer " + a[0])
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"status\":\"deleted\"}"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void 남의_alert_트리아지는_404() throws Exception {
+        String[] a = signup("a-ptriage@edrdog.com");
+        String[] b = signup("b-ptriage@edrdog.com");
+        String bId = seedAlert(b[1], "hostB", 200L);
+
+        mvc.perform(patch("/api/alerts/" + bId).header("Authorization", "Bearer " + a[0])
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"status\":\"" + AlertStatus.CONFIRMED + "\"}"))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void 토큰_없으면_401() throws Exception {
+        mvc.perform(get("/api/alerts")).andExpect(status().isUnauthorized());
+    }
+}

--- a/api-service/src/test/java/com/edrdog/apiservice/auth/controller/AuthIntegrationTest.java
+++ b/api-service/src/test/java/com/edrdog/apiservice/auth/controller/AuthIntegrationTest.java
@@ -7,6 +7,7 @@ import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabas
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 
@@ -22,6 +23,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @SpringBootTest
 @AutoConfigureMockMvc
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.ANY)
+@TestPropertySource(properties = "spring.kafka.listener.auto-startup=false")
 class AuthIntegrationTest {
 
     @Autowired

--- a/api-service/src/test/java/com/edrdog/apiservice/tenant/TenantWebhookIntegrationTest.java
+++ b/api-service/src/test/java/com/edrdog/apiservice/tenant/TenantWebhookIntegrationTest.java
@@ -7,6 +7,7 @@ import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabas
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 
@@ -23,6 +24,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @SpringBootTest
 @AutoConfigureMockMvc
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.ANY)
+@TestPropertySource(properties = "spring.kafka.listener.auto-startup=false")
 class TenantWebhookIntegrationTest {
 
     private static final String API_KEY = "dev-api-key";


### PR DESCRIPTION
## 개요
대시보드 트리아지 화면의 데이터원. alerts 를 영속화하고 tenant 격리된 조회·트리아지 API를 제공한다. Closes #36

## 설계 결정
- 저장소 **MySQL** (ClickHouse 아님): 트리아지 status 가 mutable 이라 append 형 ClickHouse 대신 MySQL 채택. 이슈도 이에 맞게 수정.
- 소비·적재·조회·트리아지 전부 **api-service** 소유 (MySQL 단일 소유자 → 서비스 간 DB 공유 회피).

## 구현 (TDD)
- alerts 토픽 소비 → MySQL `alerts` 테이블 적재. 결정적 id(`hash(tenantId|host|ruleId|ts)`)로 재소비 멱등 + 트리아지 status 보존.
- `GET /api/alerts?host&severity&status&from&to&limit` — Bearer, tenant 격리, 최신순, limit clamp
- `GET /api/alerts/{id}` — 상세 + matched 근거
- `PATCH /api/alerts/{id}` `{status: confirmed|false_positive}` — 위협확정/오탐. 잘못된 값 400, 남의 것 404
- tenant 격리는 #29(EventQueryController) 패턴 재사용.

## 검증
- code-reviewer: APPROVE, Critical/High 0. matched N+1(@BatchSize) 반영.
- `./gradlew build` 전 모듈 그린. api-service 70 테스트(순수·@DataJpaTest·MockMvc 통합).

## 후속(미반영)
- detector 발행 tenantId 가 api-service tenant PK 문자열이어야 조회됨(계약 주석 명시) — 실 연동 시 검증 필요