### PR TITLE
fix: 이벤트/alert tenantId 를 실제 tenant PK 로 정합 (#43)

### DIFF
--- a/detector-service/src/main/java/com/edrdog/detectorservice/api/IngestController.java
+++ b/detector-service/src/main/java/com/edrdog/detectorservice/api/IngestController.java
@@ -42,16 +42,22 @@ public class IngestController {
     }
 
     @Operation(summary = "공격 시나리오 발행",
-            description = "룰을 확실히 트리거하는 2-이벤트 시퀀스를 발행한다. name: process-chain(T1059/HIGH) 또는 download-exec(T1105/CRITICAL).")
+            description = "룰을 확실히 트리거하는 2-이벤트 시퀀스를 발행한다. name: process-chain(T1059/HIGH) 또는 download-exec(T1105/CRITICAL). "
+                    + "tenantId 는 로그인 tenant 의 PK(GET /api/auth/me 의 tenantId, 예: 1)여야 해당 tenant 로 alert 조회/Slack 이 도달한다.")
     @PostMapping("/events/scenario/{name}")
     public ResponseEntity<Map<String, Object>> publishScenario(
             @PathVariable String name,
             @RequestParam(defaultValue = "demo-host-01") String host,
-            @RequestParam(defaultValue = "tenant-a") String tenantId) {
+            @RequestParam String tenantId) {
         if (!Scenarios.isSupported(name)) {
             return ResponseEntity.badRequest().body(Map.of(
                     "error", "미지원 시나리오: " + name,
                     "supported", List.of(Scenarios.PROCESS_CHAIN, Scenarios.DOWNLOAD_EXEC)));
+        }
+        if (!TenantIds.isValidPk(tenantId)) {
+            return ResponseEntity.badRequest().body(Map.of(
+                    "error", "tenantId 는 tenant PK(양의 정수)여야 합니다: " + tenantId,
+                    "hint", "회원가입/로그인 후 GET /api/auth/me 의 tenantId 를 사용하세요"));
         }
         // 발행 시각 기준으로 윈도우 안 시퀀스 생성 (판정은 이벤트 ts 필드로 상관)
         long baseTs = System.currentTimeMillis();

--- a/detector-service/src/main/java/com/edrdog/detectorservice/api/TenantIds.java
+++ b/detector-service/src/main/java/com/edrdog/detectorservice/api/TenantIds.java
@@ -1,0 +1,20 @@
+package com.edrdog.detectorservice.api;
+
+import java.util.regex.Pattern;
+
+/**
+ * 인제스트 tenantId 검증(순수). api-service 의 tenant PK 는 IDENTITY 로 발급된 양의 정수이므로,
+ * alert 조회/webhook 격리(String.valueOf(tenantId) 매칭)와 맞으려면 tenantId 도 양의 정수 문자열이어야 한다.
+ */
+public final class TenantIds {
+
+    private static final Pattern POSITIVE_INT = Pattern.compile("[1-9][0-9]*");
+
+    private TenantIds() {
+    }
+
+    /** 양의 정수 문자열(선행 0 없음)만 유효한 tenant PK 로 본다. */
+    public static boolean isValidPk(String tenantId) {
+        return tenantId != null && POSITIVE_INT.matcher(tenantId).matches();
+    }
+}

--- a/detector-service/src/test/java/com/edrdog/detectorservice/api/IngestControllerTest.java
+++ b/detector-service/src/test/java/com/edrdog/detectorservice/api/IngestControllerTest.java
@@ -1,0 +1,52 @@
+package com.edrdog.detectorservice.api;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/** 시나리오 발행의 tenantId 검증 배선: PK 아니면 400, 유효 PK 면 발행. */
+@WebMvcTest(IngestController.class)
+class IngestControllerTest {
+
+    @Autowired
+    private MockMvc mvc;
+
+    @MockitoBean
+    private EventProducer producer;
+
+    @MockitoBean
+    private RecentAlerts recentAlerts;
+
+    @Test
+    @DisplayName("tenantId 가 PK(정수) 아니면 400, 발행 안 함")
+    void invalidTenantId_400() throws Exception {
+        mvc.perform(post("/api/events/scenario/process-chain").param("tenantId", "tenant-a"))
+                .andExpect(status().isBadRequest());
+        verifyNoInteractions(producer);
+    }
+
+    @Test
+    @DisplayName("tenantId 누락은 400")
+    void missingTenantId_400() throws Exception {
+        mvc.perform(post("/api/events/scenario/process-chain"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("유효한 tenant PK 면 202 로 발행")
+    void validPk_publishes() throws Exception {
+        mvc.perform(post("/api/events/scenario/process-chain").param("tenantId", "1"))
+                .andExpect(status().isAccepted());
+        verify(producer, atLeastOnce()).publish(any());
+    }
+}

--- a/detector-service/src/test/java/com/edrdog/detectorservice/api/TenantIdsTest.java
+++ b/detector-service/src/test/java/com/edrdog/detectorservice/api/TenantIdsTest.java
@@ -1,0 +1,37 @@
+package com.edrdog.detectorservice.api;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * 인제스트 tenantId 가 api-service 의 tenant PK(양의 정수 문자열) 형식인지 검증하는 순수 로직.
+ * 조회/webhook 격리가 tenant PK 문자열로 매칭되므로, 임의 문자열("tenant-a") 유입을 막는다.
+ */
+class TenantIdsTest {
+
+    @Test
+    @DisplayName("양의 정수 문자열은 유효한 tenant PK")
+    void validPk_positiveInteger() {
+        assertThat(TenantIds.isValidPk("1")).isTrue();
+        assertThat(TenantIds.isValidPk("42")).isTrue();
+    }
+
+    @Test
+    @DisplayName("임의 문자열·빈값·null 은 무효")
+    void invalid_nonNumeric() {
+        assertThat(TenantIds.isValidPk("tenant-a")).isFalse();
+        assertThat(TenantIds.isValidPk("")).isFalse();
+        assertThat(TenantIds.isValidPk("  ")).isFalse();
+        assertThat(TenantIds.isValidPk(null)).isFalse();
+    }
+
+    @Test
+    @DisplayName("0·음수·선행 0 은 무효 (PK 는 1 이상)")
+    void invalid_zeroNegativeLeadingZero() {
+        assertThat(TenantIds.isValidPk("0")).isFalse();
+        assertThat(TenantIds.isValidPk("-1")).isFalse();
+        assertThat(TenantIds.isValidPk("01")).isFalse();
+    }
+}


### PR DESCRIPTION
## 개요
detector 인제스트가 alert 에 붙이는 tenantId 를 로그인 tenant 의 PK 와 맞춘다. Closes #43

지금까지 시나리오 발행 기본값이 `"tenant-a"` 임의 문자열이라, 로그인 유저(tenant PK "1")와 안 맞아 #36 조회 0건·#33 Slack skip 이었다.

## 변경
- `POST /api/events/scenario/{name}` 의 `tenantId` 기본값 제거 → **필수** + **양의 정수(tenant PK) 검증**
- PK 형식 아니면 400 + 안내(`GET /api/auth/me` 의 tenantId 사용)
- 순수 검증 `TenantIds.isValidPk` + WebMvcTest

## 범위 밖
- 실제 수집 에이전트별 tenant 프로비저닝, detector 완전 인증 도입

## 사용법 (데모)
회원가입/로그인 → `GET /api/auth/me` 로 tenantId 확인 → `POST /api/events/scenario/process-chain?tenantId=<그 값>` → 그 tenant 로 로그인하면 #36 조회/#33 Slack 도달.

## 검증
`./gradlew build` 전 모듈 그린. TDD(순수 검증 RED→GREEN + 컨트롤러 400/202).