### PR TITLE
feat: 엔드포인트(호스트) 목록·상태 요약 조회 API (#39)

### DIFF
--- a/api-service/src/main/java/com/edrdog/apiservice/alert/AlertRepository.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/alert/AlertRepository.java
@@ -27,4 +27,16 @@ public interface AlertRepository extends JpaRepository<AlertRecord, String> {
                              @Param("from") Long from,
                              @Param("to") Long to,
                              Pageable pageable);
+
+    /**
+     * host 별 열린 alert 집계(엔드포인트 목록 status/위협수용). tenant 격리는 필수.
+     * severity 리터럴은 detector 발행값(Alert.SEV_CRITICAL/SEV_HIGH)과 일치한다.
+     */
+    @Query("SELECT a.host AS host, COUNT(a) AS openTotal, "
+            + "SUM(CASE WHEN a.severity = 'CRITICAL' THEN 1 ELSE 0 END) AS openCritical, "
+            + "SUM(CASE WHEN a.severity = 'HIGH' THEN 1 ELSE 0 END) AS openHigh "
+            + "FROM AlertRecord a WHERE a.tenantId = :tenantId AND a.status = :status "
+            + "GROUP BY a.host")
+    List<HostAlertCount> openAlertCountsByHost(@Param("tenantId") String tenantId,
+                                               @Param("status") String status);
 }

--- a/api-service/src/main/java/com/edrdog/apiservice/alert/HostAlertCount.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/alert/HostAlertCount.java
@@ -1,0 +1,16 @@
+package com.edrdog.apiservice.alert;
+
+/**
+ * host 별 열린 alert 집계 결과(Spring Data 인터페이스 projection).
+ * openTotal 은 위협수, openCritical/openHigh 는 상태 분류에 쓴다.
+ */
+public interface HostAlertCount {
+
+    String getHost();
+
+    long getOpenTotal();
+
+    long getOpenCritical();
+
+    long getOpenHigh();
+}

--- a/api-service/src/main/java/com/edrdog/apiservice/host/HostAggregator.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/host/HostAggregator.java
@@ -1,0 +1,58 @@
+package com.edrdog.apiservice.host;
+
+import com.edrdog.apiservice.alert.HostAlertCount;
+import com.edrdog.apiservice.host.web.HostResponse;
+import com.edrdog.apiservice.host.web.HostSummary;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * events(호스트+last_seen)와 alerts(host 별 열린 alert 집계)를 병합하는 순수 로직.
+ * 두 저장소(ClickHouse/MySQL)라 SQL 조인이 안 되므로 여기서 host 기준으로 합친다.
+ * 호스트 집합은 events 기준이다(관측된 호스트). alert 만 있고 events 없는 host 는 나오지 않는다.
+ */
+public final class HostAggregator {
+
+    private HostAggregator() {
+    }
+
+    /**
+     * events 행(host, last_seen)에 host 별 alert 집계를 붙여 목록을 만든다.
+     * events 쿼리가 last_seen DESC 로 정렬돼 오므로 그 순서를 그대로 유지한다.
+     */
+    public static List<HostResponse> hosts(List<Map<String, Object>> eventRows, List<HostAlertCount> alertCounts) {
+        Map<String, HostAlertCount> byHost = alertCounts.stream()
+                .collect(Collectors.toMap(HostAlertCount::getHost, Function.identity()));
+
+        List<HostResponse> out = new ArrayList<>();
+        for (Map<String, Object> row : eventRows) {
+            String host = String.valueOf(row.get("host"));
+            long lastSeen = Long.parseLong(String.valueOf(row.get("last_seen")));
+            HostAlertCount c = byHost.get(host);
+            long critical = c == null ? 0 : c.getOpenCritical();
+            long high = c == null ? 0 : c.getOpenHigh();
+            long threats = c == null ? 0 : c.getOpenTotal();
+            out.add(new HostResponse(host, lastSeen, HostStatus.classify(critical, high), threats));
+        }
+        return out;
+    }
+
+    /** 목록의 각 host status 를 세어 도넛용 집계를 만든다. */
+    public static HostSummary summary(List<HostResponse> hosts) {
+        long healthy = 0;
+        long warning = 0;
+        long critical = 0;
+        for (HostResponse h : hosts) {
+            switch (h.status()) {
+                case HostStatus.CRITICAL -> critical++;
+                case HostStatus.WARNING -> warning++;
+                default -> healthy++;
+            }
+        }
+        return new HostSummary(healthy, warning, critical, hosts.size());
+    }
+}

--- a/api-service/src/main/java/com/edrdog/apiservice/host/HostService.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/host/HostService.java
@@ -1,0 +1,43 @@
+package com.edrdog.apiservice.host;
+
+import com.edrdog.apiservice.alert.AlertRepository;
+import com.edrdog.apiservice.alert.AlertStatus;
+import com.edrdog.apiservice.alert.HostAlertCount;
+import com.edrdog.apiservice.clickhouse.ClickHouseReader;
+import com.edrdog.apiservice.host.web.HostResponse;
+import com.edrdog.apiservice.host.web.HostSummary;
+import com.edrdog.apiservice.query.EventQueryBuilder;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * 엔드포인트(호스트) 목록·요약 조회. events(ClickHouse)로 관측 호스트+last_seen 을,
+ * alerts(MySQL)로 host 별 열린 alert 집계를 각각 뽑아 병합한다. 조회는 항상 tenant 로 격리한다.
+ */
+@Service
+public class HostService {
+
+    private final ClickHouseReader reader;
+    private final EventQueryBuilder builder;
+    private final AlertRepository alerts;
+
+    public HostService(ClickHouseReader reader, EventQueryBuilder builder, AlertRepository alerts) {
+        this.reader = reader;
+        this.builder = builder;
+        this.alerts = alerts;
+    }
+
+    /** tenant 의 관측 호스트 목록(host, last_seen, status, 위협수). last_seen 최신순. */
+    public List<HostResponse> hosts(String tenantId) {
+        List<Map<String, Object>> rows = reader.query(builder.hostsLastSeen(tenantId));
+        List<HostAlertCount> counts = alerts.openAlertCountsByHost(tenantId, AlertStatus.OPEN);
+        return HostAggregator.hosts(rows, counts);
+    }
+
+    /** tenant 의 도넛용 상태 집계(정상/주의/위험 수 + 총 관측 호스트 수). */
+    public HostSummary summary(String tenantId) {
+        return HostAggregator.summary(hosts(tenantId));
+    }
+}

--- a/api-service/src/main/java/com/edrdog/apiservice/host/HostStatus.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/host/HostStatus.java
@@ -1,0 +1,26 @@
+package com.edrdog.apiservice.host;
+
+/**
+ * 호스트 상태 분류(순수). 열린 alert 의 severity 로만 판정한다.
+ * 열린 CRITICAL 이 하나라도 있으면 critical(위험), 없고 HIGH 가 있으면 warning(주의), 둘 다 없으면 healthy(정상).
+ */
+public final class HostStatus {
+
+    public static final String HEALTHY = "healthy";
+    public static final String WARNING = "warning";
+    public static final String CRITICAL = "critical";
+
+    private HostStatus() {
+    }
+
+    /** 열린 CRITICAL/HIGH 수로 상태를 정한다. CRITICAL 우선. */
+    public static String classify(long openCritical, long openHigh) {
+        if (openCritical > 0) {
+            return CRITICAL;
+        }
+        if (openHigh > 0) {
+            return WARNING;
+        }
+        return HEALTHY;
+    }
+}

--- a/api-service/src/main/java/com/edrdog/apiservice/host/web/HostController.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/host/web/HostController.java
@@ -1,0 +1,63 @@
+package com.edrdog.apiservice.host.web;
+
+import com.edrdog.apiservice.auth.service.AuthService;
+import com.edrdog.apiservice.auth.service.Principal;
+import com.edrdog.apiservice.host.HostService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+/**
+ * 엔드포인트(호스트) 목록·상태 요약 REST. 세션 Bearer 토큰으로 인증하고 그 tenant 로만 격리한다
+ * (EventQueryController/AlertController 와 동일 패턴). 호스트 대장 없이 events+alerts 집계로 관측 호스트를 준다.
+ */
+@RestController
+@RequestMapping("/api/hosts")
+@Tag(name = "hosts", description = "관측 호스트 목록 및 상태 요약 (events+alerts 집계, tenant 격리)")
+public class HostController {
+
+    private static final String BEARER_PREFIX = "Bearer ";
+
+    private final HostService hosts;
+    private final AuthService auth;
+
+    public HostController(HostService hosts, AuthService auth) {
+        this.hosts = hosts;
+        this.auth = auth;
+    }
+
+    @Operation(summary = "호스트 목록",
+            description = "로그인 유저의 tenant 관측 호스트를 last_seen 최신순으로. 각 host 의 status(정상|주의|위험)와 위협수(열린 alert 수) 포함.")
+    @GetMapping
+    public List<HostResponse> list(
+            @RequestHeader(name = "Authorization", required = false) String authorization) {
+        return hosts.hosts(currentTenantId(authorization));
+    }
+
+    @Operation(summary = "호스트 상태 요약",
+            description = "대시보드 도넛용. 로그인 유저의 tenant 호스트를 정상/주의/위험 수와 총 관측 호스트 수로 집계.")
+    @GetMapping("/summary")
+    public HostSummary summary(
+            @RequestHeader(name = "Authorization", required = false) String authorization) {
+        return hosts.summary(currentTenantId(authorization));
+    }
+
+    /** Bearer 토큰을 검증해 현재 유저의 tenant 를 문자열로 반환. 토큰이 없거나 만료면 AuthService 가 401. */
+    private String currentTenantId(String authorization) {
+        Principal principal = auth.resolve(bearerToken(authorization));
+        return String.valueOf(principal.tenantId());
+    }
+
+    /** "Bearer " 접두어를 떼서 토큰만 반환. 없으면 null. */
+    private static String bearerToken(String authorization) {
+        if (authorization == null || !authorization.startsWith(BEARER_PREFIX)) {
+            return null;
+        }
+        return authorization.substring(BEARER_PREFIX.length()).trim();
+    }
+}

--- a/api-service/src/main/java/com/edrdog/apiservice/host/web/HostResponse.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/host/web/HostResponse.java
@@ -1,0 +1,13 @@
+package com.edrdog.apiservice.host.web;
+
+/**
+ * 엔드포인트(호스트) 목록 한 행. status 는 영문 enum(healthy|warning|critical),
+ * threats 는 열린 alert 총수, lastSeen 은 events 최신 ts(epoch millis).
+ */
+public record HostResponse(
+        String host,
+        long lastSeen,
+        String status,
+        long threats
+) {
+}

--- a/api-service/src/main/java/com/edrdog/apiservice/host/web/HostSummary.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/host/web/HostSummary.java
@@ -1,0 +1,12 @@
+package com.edrdog.apiservice.host.web;
+
+/**
+ * 대시보드 도넛용 상태 집계. 목록의 각 호스트 status 를 세어 정상/주의/위험 수와 총 관측 호스트 수를 준다.
+ */
+public record HostSummary(
+        long healthy,
+        long warning,
+        long critical,
+        long total
+) {
+}

--- a/api-service/src/main/java/com/edrdog/apiservice/query/EventQueryBuilder.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/query/EventQueryBuilder.java
@@ -39,6 +39,19 @@ public class EventQueryBuilder {
         return new ClickHouseQuery(sql, params);
     }
 
+    /**
+     * tenant 격리 하에 관측된 host 목록과 각 host 의 last_seen(최신 ts)을 뽑는다. tenantId 는 필수.
+     * 호스트 대장(registry) 없이 events 집계로만 관측 호스트를 얻는다(엔드포인트 목록의 데이터원).
+     */
+    public ClickHouseQuery hostsLastSeen(String tenantId) {
+        Map<String, String> params = new LinkedHashMap<>();
+        String where = where(tenantId, null, null, null, null, params);
+        String sql = "SELECT host, max(ts) AS last_seen FROM " + table
+                + where
+                + " GROUP BY host ORDER BY last_seen DESC";
+        return new ClickHouseQuery(sql, params);
+    }
+
     /** tenant 격리 하에 type 별 건수 집계. 시간범위 필터(옵션) 지원. tenantId 는 필수. */
     public ClickHouseQuery summaryByType(String tenantId, Long from, Long to) {
         Map<String, String> params = new LinkedHashMap<>();

--- a/api-service/src/main/java/com/edrdog/apiservice/security/ApiKeyPolicy.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/security/ApiKeyPolicy.java
@@ -14,6 +14,7 @@ public class ApiKeyPolicy {
             "/api/auth/",
             "/api/events",  // 조회는 세션 Bearer 로 인증하고 tenant 를 뽑는다(EventQueryController)
             "/api/alerts",  // 알림 조회·트리아지도 세션 Bearer 로 인증(AlertController)
+            "/api/hosts",   // 호스트 목록·요약도 세션 Bearer 로 인증(HostController)
             "/api/internal/"  // 서비스 간 조회는 별도 X-Internal-Key 로 인증(TenantController), 프론트 키와 분리
     );
 

--- a/api-service/src/test/java/com/edrdog/apiservice/alert/AlertRepositoryTest.java
+++ b/api-service/src/test/java/com/edrdog/apiservice/alert/AlertRepositoryTest.java
@@ -81,4 +81,51 @@ class AlertRepositoryTest {
         assertEquals(2, limited.size());
         assertEquals(300L, limited.get(0).getTs());
     }
+
+    // --- host 별 열린 alert 집계 ---
+
+    private static HostAlertCount find(List<HostAlertCount> counts, String host) {
+        return counts.stream().filter(c -> c.getHost().equals(host)).findFirst().orElseThrow();
+    }
+
+    @Test
+    void 열린_alert만_host별로_집계하고_severity를_센다() {
+        seed("A", "h1", "CRITICAL", AlertStatus.OPEN, 100L);
+        seed("A", "h1", "HIGH", AlertStatus.OPEN, 110L);
+        seed("A", "h2", "HIGH", AlertStatus.OPEN, 200L);
+
+        List<HostAlertCount> counts = alerts.openAlertCountsByHost("A", AlertStatus.OPEN);
+        assertEquals(2, counts.size());
+
+        HostAlertCount h1 = find(counts, "h1");
+        assertEquals(2L, h1.getOpenTotal());
+        assertEquals(1L, h1.getOpenCritical());
+        assertEquals(1L, h1.getOpenHigh());
+
+        HostAlertCount h2 = find(counts, "h2");
+        assertEquals(1L, h2.getOpenTotal());
+        assertEquals(0L, h2.getOpenCritical());
+        assertEquals(1L, h2.getOpenHigh());
+    }
+
+    @Test
+    void 트리아지된_alert는_집계에서_빠진다() {
+        seed("A", "h1", "CRITICAL", AlertStatus.CONFIRMED, 100L);
+        seed("A", "h1", "HIGH", AlertStatus.OPEN, 110L);
+
+        HostAlertCount h1 = find(alerts.openAlertCountsByHost("A", AlertStatus.OPEN), "h1");
+        assertEquals(1L, h1.getOpenTotal());
+        assertEquals(0L, h1.getOpenCritical());
+        assertEquals(1L, h1.getOpenHigh());
+    }
+
+    @Test
+    void 집계도_tenant_격리() {
+        seed("A", "h1", "HIGH", AlertStatus.OPEN, 100L);
+        seed("B", "h1", "CRITICAL", AlertStatus.OPEN, 200L);
+
+        List<HostAlertCount> a = alerts.openAlertCountsByHost("A", AlertStatus.OPEN);
+        assertEquals(1, a.size());
+        assertEquals(0L, find(a, "h1").getOpenCritical());
+    }
 }

--- a/api-service/src/test/java/com/edrdog/apiservice/host/HostAggregatorTest.java
+++ b/api-service/src/test/java/com/edrdog/apiservice/host/HostAggregatorTest.java
@@ -1,0 +1,122 @@
+package com.edrdog.apiservice.host;
+
+import com.edrdog.apiservice.alert.HostAlertCount;
+import com.edrdog.apiservice.host.web.HostResponse;
+import com.edrdog.apiservice.host.web.HostSummary;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * events 행과 alert 집계를 host 기준으로 병합하는 순수 로직 검증.
+ * 호스트 집합은 events 기준, status/위협수는 alert 집계에서 붙는다.
+ */
+class HostAggregatorTest {
+
+    /** ClickHouse 응답 한 행(host, last_seen). last_seen 은 UInt64 라 문자열로 온다. */
+    private static Map<String, Object> row(String host, String lastSeen) {
+        return Map.of("host", host, "last_seen", lastSeen);
+    }
+
+    /** HostAlertCount projection 테스트용 구현. */
+    private static HostAlertCount count(String host, long total, long critical, long high) {
+        return new HostAlertCount() {
+            public String getHost() {
+                return host;
+            }
+
+            public long getOpenTotal() {
+                return total;
+            }
+
+            public long getOpenCritical() {
+                return critical;
+            }
+
+            public long getOpenHigh() {
+                return high;
+            }
+        };
+    }
+
+    @Test
+    void alert_없는_host_는_정상_위협0() {
+        List<HostResponse> hosts = HostAggregator.hosts(
+                List.of(row("h1", "1000")), List.of());
+
+        assertEquals(1, hosts.size());
+        HostResponse h = hosts.get(0);
+        assertEquals("h1", h.host());
+        assertEquals(1000L, h.lastSeen());
+        assertEquals(HostStatus.HEALTHY, h.status());
+        assertEquals(0L, h.threats());
+    }
+
+    @Test
+    void 열린_CRITICAL_있는_host_는_위험_위협수는_열린총수() {
+        List<HostResponse> hosts = HostAggregator.hosts(
+                List.of(row("h1", "1000")),
+                List.of(count("h1", 3, 1, 2)));
+
+        HostResponse h = hosts.get(0);
+        assertEquals(HostStatus.CRITICAL, h.status());
+        assertEquals(3L, h.threats());
+    }
+
+    @Test
+    void HIGH만_있는_host_는_주의() {
+        List<HostResponse> hosts = HostAggregator.hosts(
+                List.of(row("h1", "1000")),
+                List.of(count("h1", 2, 0, 2)));
+
+        assertEquals(HostStatus.WARNING, hosts.get(0).status());
+        assertEquals(2L, hosts.get(0).threats());
+    }
+
+    @Test
+    void events_순서를_그대로_유지한다() {
+        List<HostResponse> hosts = HostAggregator.hosts(
+                List.of(row("h2", "3000"), row("h1", "1000")),
+                List.of(count("h1", 1, 1, 0)));
+
+        assertEquals("h2", hosts.get(0).host());
+        assertEquals("h1", hosts.get(1).host());
+    }
+
+    @Test
+    void alert만_있고_events_없는_host_는_목록에_없다() {
+        List<HostResponse> hosts = HostAggregator.hosts(
+                List.of(row("h1", "1000")),
+                List.of(count("ghost", 5, 5, 0)));
+
+        assertEquals(1, hosts.size());
+        assertEquals("h1", hosts.get(0).host());
+    }
+
+    @Test
+    void 요약은_status별_수와_총수를_센다() {
+        List<HostResponse> hosts = List.of(
+                new HostResponse("h1", 1, HostStatus.CRITICAL, 2),
+                new HostResponse("h2", 1, HostStatus.WARNING, 1),
+                new HostResponse("h3", 1, HostStatus.HEALTHY, 0),
+                new HostResponse("h4", 1, HostStatus.HEALTHY, 0));
+
+        HostSummary s = HostAggregator.summary(hosts);
+        assertEquals(2L, s.healthy());
+        assertEquals(1L, s.warning());
+        assertEquals(1L, s.critical());
+        assertEquals(4L, s.total());
+    }
+
+    @Test
+    void 빈_목록_요약은_전부_0() {
+        HostSummary s = HostAggregator.summary(List.of());
+        assertEquals(0L, s.healthy());
+        assertEquals(0L, s.warning());
+        assertEquals(0L, s.critical());
+        assertEquals(0L, s.total());
+    }
+}

--- a/api-service/src/test/java/com/edrdog/apiservice/host/HostStatusTest.java
+++ b/api-service/src/test/java/com/edrdog/apiservice/host/HostStatusTest.java
@@ -1,0 +1,33 @@
+package com.edrdog.apiservice.host;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * 호스트 상태 분류 순수 로직. 열린 CRITICAL 우선, 없으면 HIGH, 둘 다 없으면 정상.
+ */
+class HostStatusTest {
+
+    @Test
+    void 열린_CRITICAL_이_있으면_위험() {
+        assertEquals(HostStatus.CRITICAL, HostStatus.classify(1, 0));
+        assertEquals(HostStatus.CRITICAL, HostStatus.classify(2, 3));
+    }
+
+    @Test
+    void CRITICAL_없고_HIGH_있으면_주의() {
+        assertEquals(HostStatus.WARNING, HostStatus.classify(0, 1));
+        assertEquals(HostStatus.WARNING, HostStatus.classify(0, 5));
+    }
+
+    @Test
+    void 열린것이_없으면_정상() {
+        assertEquals(HostStatus.HEALTHY, HostStatus.classify(0, 0));
+    }
+
+    @Test
+    void CRITICAL_이_HIGH_보다_우선() {
+        assertEquals(HostStatus.CRITICAL, HostStatus.classify(1, 10));
+    }
+}

--- a/api-service/src/test/java/com/edrdog/apiservice/host/web/HostApiIntegrationTest.java
+++ b/api-service/src/test/java/com/edrdog/apiservice/host/web/HostApiIntegrationTest.java
@@ -1,0 +1,115 @@
+package com.edrdog.apiservice.host.web;
+
+import com.edrdog.apiservice.alert.AlertId;
+import com.edrdog.apiservice.alert.AlertRecord;
+import com.edrdog.apiservice.alert.AlertRepository;
+import com.edrdog.apiservice.clickhouse.ClickHouseReader;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * 전체 컨텍스트로 hosts API 배선(라우팅, Bearer tenant 격리, events+alerts 병합)을 검증한다.
+ * ClickHouse(events)는 실제 붙지 않도록 ClickHouseReader 를 목으로 대체하고, alert 는 H2 로 실적재한다.
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.ANY)
+@TestPropertySource(properties = "spring.kafka.listener.auto-startup=false")
+class HostApiIntegrationTest {
+
+    @Autowired
+    private MockMvc mvc;
+
+    @Autowired
+    private ObjectMapper om;
+
+    @Autowired
+    private AlertRepository alerts;
+
+    @MockitoBean
+    private ClickHouseReader reader;
+
+    /** 회원가입으로 토큰과 tenantId 를 받는다. */
+    private String[] signup(String email) throws Exception {
+        MvcResult res = mvc.perform(post("/api/auth/signup")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"email\":\"" + email + "\",\"password\":\"password1\"}"))
+                .andExpect(status().isCreated())
+                .andReturn();
+        var node = om.readTree(res.getResponse().getContentAsString());
+        return new String[]{node.get("token").asText(), node.get("tenantId").asText()};
+    }
+
+    private void seedOpenAlert(String tenantId, String host, String severity, long ts) {
+        String id = AlertId.of(tenantId, host, "RULE_" + ts, ts);
+        alerts.save(AlertRecord.open(id, tenantId, host, "RULE_" + ts, "T1059",
+                severity, "notify", ts, List.of("m1"), Instant.now()));
+    }
+
+    /** events 관측 호스트는 목으로 고정: h1, h2. */
+    private void stubHosts() {
+        when(reader.query(any())).thenReturn(List.of(
+                Map.of("host", "h1", "last_seen", "2000"),
+                Map.of("host", "h2", "last_seen", "1000")));
+    }
+
+    @Test
+    void 목록은_events호스트에_자기_tenant_alert만_붙인다() throws Exception {
+        stubHosts();
+        String[] a = signup("a-hosts@edrdog.com");
+        String[] b = signup("b-hosts@edrdog.com");
+        seedOpenAlert(a[1], "h1", "CRITICAL", 100L);   // A 의 h1 은 위험
+        seedOpenAlert(b[1], "h2", "CRITICAL", 200L);   // B 의 h2 (A 에는 안 보여야 함)
+
+        mvc.perform(get("/api/hosts").header("Authorization", "Bearer " + a[0]))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(2))
+                .andExpect(jsonPath("$[0].host").value("h1"))
+                .andExpect(jsonPath("$[0].status").value("critical"))
+                .andExpect(jsonPath("$[0].threats").value(1))
+                .andExpect(jsonPath("$[0].lastSeen").value(2000))
+                .andExpect(jsonPath("$[1].host").value("h2"))
+                .andExpect(jsonPath("$[1].status").value("healthy"))  // B 의 alert 는 격리
+                .andExpect(jsonPath("$[1].threats").value(0));
+    }
+
+    @Test
+    void 요약은_status별_수와_총수를_준다() throws Exception {
+        stubHosts();
+        String[] a = signup("a-summary@edrdog.com");
+        seedOpenAlert(a[1], "h1", "HIGH", 100L);   // h1 주의, h2 정상
+
+        mvc.perform(get("/api/hosts/summary").header("Authorization", "Bearer " + a[0]))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.healthy").value(1))
+                .andExpect(jsonPath("$.warning").value(1))
+                .andExpect(jsonPath("$.critical").value(0))
+                .andExpect(jsonPath("$.total").value(2));
+    }
+
+    @Test
+    void 토큰_없으면_401() throws Exception {
+        mvc.perform(get("/api/hosts")).andExpect(status().isUnauthorized());
+        mvc.perform(get("/api/hosts/summary")).andExpect(status().isUnauthorized());
+    }
+}

--- a/api-service/src/test/java/com/edrdog/apiservice/query/EventQueryBuilderTest.java
+++ b/api-service/src/test/java/com/edrdog/apiservice/query/EventQueryBuilderTest.java
@@ -144,4 +144,26 @@ class EventQueryBuilderTest {
         assertEquals("1000", q.params().get("from"));
         assertEquals("2000", q.params().get("to"));
     }
+
+    // --- 호스트 목록 ---
+
+    @Test
+    void 호스트목록은_tenant로_필터하며_host별_last_seen을_집계한다() {
+        ClickHouseQuery q = builder.hostsLastSeen(TENANT);
+        assertTrue(q.sql().contains("tenant_id = {tenant:String}"), q.sql());
+        assertEquals(TENANT, q.params().get("tenant"));
+        assertTrue(q.sql().contains("max(ts) AS last_seen"), q.sql());
+        assertTrue(q.sql().contains("GROUP BY host"), q.sql());
+    }
+
+    @Test
+    void 호스트목록은_last_seen_최신순() {
+        assertTrue(builder.hostsLastSeen(TENANT).sql().contains("ORDER BY last_seen DESC"));
+    }
+
+    @Test
+    void 호스트목록도_tenant_필수() {
+        assertThrows(IllegalArgumentException.class, () -> builder.hostsLastSeen(null));
+        assertThrows(IllegalArgumentException.class, () -> builder.hostsLastSeen("  "));
+    }
 }

--- a/api-service/src/test/java/com/edrdog/apiservice/security/ApiKeyPolicyTest.java
+++ b/api-service/src/test/java/com/edrdog/apiservice/security/ApiKeyPolicyTest.java
@@ -34,6 +34,13 @@ class ApiKeyPolicyTest {
     }
 
     @Test
+    void alerts_hosts_조회도_세션_Bearer_예외() {
+        assertTrue(policy.isExempt("/api/alerts"));
+        assertTrue(policy.isExempt("/api/hosts"));
+        assertTrue(policy.isExempt("/api/hosts/summary"));
+    }
+
+    @Test
     void auth_접두어만_같은_경로는_예외가_아님() {
         assertFalse(policy.isExempt("/api/authz"));
         assertFalse(policy.isExempt("/api/auth-logs"));


### PR DESCRIPTION
## 개요
호스트 대장(registry) 없이 **events+alerts 집계**로 관측된 호스트를 뽑는 조회 API. 엔드포인트 탭 + 대시보드 상태 도넛의 데이터원. Closes #39

## 엔드포인트
- `GET /api/hosts` — host, lastSeen(events 최신 ts), status, threats(열린 alert 수). last_seen 최신순
- `GET /api/hosts/summary` — 도넛용 정상/주의/위험 count + 총 관측 호스트 수
- status 분류: 열린 CRITICAL 있으면 `critical` / HIGH 있으면 `warning` / 없으면 `healthy`
- Bearer + tenant 격리 (EventQueryController/AlertController 패턴 재사용)

## 설계
- events(ClickHouse)에서 host+max(ts), alerts(MySQL)에서 host별 열린 alert 집계 → 두 저장소라 SQL 조인 불가, Java에서 병합
- 분류·병합은 순수 로직(`HostStatus`, `HostAggregator`)으로 분리해 단위테스트
- 호스트 집합은 events 기준. alert만 있고 events 없는 host는 제외(alert는 events에서 파생되므로 실무상 항상 존재)

## 범위 밖 (이슈대로)
- OS 정보 / heartbeat(온라인·오프라인) / 전체 대장 대수 → events에 데이터 없어 제외

## 테스트
- 순수 로직: HostStatusTest(4), HostAggregatorTest(7)
- 리포지토리 집계·tenant 격리: AlertRepositoryTest +3
- 쿼리 빌더: EventQueryBuilderTest +3 / ApiKeyPolicyTest +1
- 배선·Bearer 격리(ClickHouse mock): HostApiIntegrationTest(3)
- `:api-service:test` 전체 통과

## 관련
- #36 알림 데이터 재사용