### PR TITLE
feat: alert 공격 경로 lineage 조회 API (#37)

### DIFF
--- a/api-service/src/main/java/com/edrdog/apiservice/alert/AlertService.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/alert/AlertService.java
@@ -2,7 +2,10 @@ package com.edrdog.apiservice.alert;
 
 import com.edrdog.apiservice.alert.dto.Alert;
 import com.edrdog.apiservice.alert.web.AlertResponse;
+import com.edrdog.apiservice.alert.web.LineageResponse;
 import com.edrdog.apiservice.auth.exception.AuthException;
+import com.edrdog.apiservice.clickhouse.ClickHouseReader;
+import com.edrdog.apiservice.query.EventQueryBuilder;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -10,6 +13,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Instant;
 import java.util.List;
+import java.util.Map;
 
 /**
  * alert 적재/조회/트리아지 로직. 리스너·컨트롤러는 얇게 두고 여기서 tenant 격리와 멱등 적재를 담당한다.
@@ -20,10 +24,20 @@ public class AlertService {
     static final int DEFAULT_LIMIT = 100;
     static final int MAX_LIMIT = 1000;
 
-    private final AlertRepository alerts;
+    /** lineage 재구성 윈도우: alert.ts 기준 앞뒤 5분. */
+    static final long LINEAGE_WINDOW_MS = 5 * 60 * 1000L;
 
-    public AlertService(AlertRepository alerts) {
+    private final AlertRepository alerts;
+    private final ClickHouseReader reader;
+    private final EventQueryBuilder events;
+    private final LineageGraphBuilder lineage;
+
+    public AlertService(AlertRepository alerts, ClickHouseReader reader,
+                        EventQueryBuilder events, LineageGraphBuilder lineage) {
         this.alerts = alerts;
+        this.reader = reader;
+        this.events = events;
+        this.lineage = lineage;
     }
 
     /**
@@ -75,6 +89,20 @@ public class AlertService {
         AlertRecord record = owned(tenantId, id);
         record.triage(status, Instant.now());
         return AlertResponse.from(record);
+    }
+
+    /**
+     * alert 의 공격 경로 그래프. 소유 확인 후, 같은 tenant+host 의 alert.ts ±5분 윈도우 events 를
+     * 시간순으로 긁어와 이름 기반 process/network 체인으로 재구성한다. 없거나 남의 tenant 것이면 404.
+     */
+    @Transactional(readOnly = true)
+    public LineageResponse lineage(String tenantId, String id) {
+        AlertRecord alert = owned(tenantId, id);
+        long from = Math.max(0, alert.getTs() - LINEAGE_WINDOW_MS);
+        long to = alert.getTs() + LINEAGE_WINDOW_MS;
+        List<Map<String, Object>> rows = reader.query(
+                events.lineageEvents(tenantId, alert.getHost(), from, to));
+        return lineage.build(rows);
     }
 
     /** id 로 찾되 tenant 소유가 아니면 404 로 숨긴다(없는 것과 구분 불가). */

--- a/api-service/src/main/java/com/edrdog/apiservice/alert/LineageGraphBuilder.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/alert/LineageGraphBuilder.java
@@ -1,0 +1,86 @@
+package com.edrdog.apiservice.alert;
+
+import com.edrdog.apiservice.alert.web.LineageResponse;
+import com.edrdog.apiservice.alert.web.LineageResponse.Edge;
+import com.edrdog.apiservice.alert.web.LineageResponse.Node;
+import org.springframework.stereotype.Component;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * events 행 목록을 lineage 그래프(nodes/edges)로 바꾸는 순수 로직.
+ *
+ * <p>규칙(이름 기반):
+ * <ul>
+ *   <li>process 이벤트: {@code process} 노드. {@code parent} 가 있으면 parent 노드 + parent->process(spawned)</li>
+ *   <li>network 이벤트: {@code dest_ip:port} 노드. 소유 {@code process} 가 있으면 process->net(connected)</li>
+ * </ul>
+ * 같은 노드 id / 같은 (from,to,rel) 엣지는 첫 등장만 남기고 dedup 하며, 입력 순서를 보존한다.
+ * pid/ppid 가 없어 동명 프로세스는 한 노드로 합쳐진다(경로가 거칢).
+ */
+@Component
+public class LineageGraphBuilder {
+
+    public LineageResponse build(List<Map<String, Object>> rows) {
+        Map<String, Node> nodes = new LinkedHashMap<>();
+        Map<String, Edge> edges = new LinkedHashMap<>();
+
+        for (Map<String, Object> row : rows) {
+            if ("network".equals(str(row.get("type")))) {
+                addNetwork(row, nodes, edges);
+            } else {
+                addProcess(row, nodes, edges);
+            }
+        }
+        return new LineageResponse(List.copyOf(nodes.values()), List.copyOf(edges.values()));
+    }
+
+    private static void addProcess(Map<String, Object> row, Map<String, Node> nodes, Map<String, Edge> edges) {
+        String proc = str(row.get("process"));
+        if (proc.isEmpty()) {
+            return;
+        }
+        String procId = putProcess(nodes, proc);
+        String parent = str(row.get("parent"));
+        if (!parent.isEmpty()) {
+            String parentId = putProcess(nodes, parent);
+            putEdge(edges, parentId, procId, "spawned");
+        }
+    }
+
+    private static void addNetwork(Map<String, Object> row, Map<String, Node> nodes, Map<String, Edge> edges) {
+        String ip = str(row.get("dest_ip"));
+        if (ip.isEmpty()) {
+            return;
+        }
+        String target = ip + ":" + str(row.get("dest_port"));
+        String netId = "net:" + target;
+        putNode(nodes, netId, "network", target);
+        String proc = str(row.get("process"));
+        if (!proc.isEmpty()) {
+            String procId = putProcess(nodes, proc);
+            putEdge(edges, procId, netId, "connected");
+        }
+    }
+
+    private static String putProcess(Map<String, Node> nodes, String name) {
+        String id = "proc:" + name;
+        putNode(nodes, id, "process", name);
+        return id;
+    }
+
+    private static void putNode(Map<String, Node> nodes, String id, String kind, String label) {
+        nodes.putIfAbsent(id, new Node(id, kind, label));
+    }
+
+    private static void putEdge(Map<String, Edge> edges, String from, String to, String rel) {
+        edges.putIfAbsent(from + "->" + to + ":" + rel, new Edge(from, to, rel));
+    }
+
+    /** null/빈값을 빈 문자열로 정규화하고 앞뒤 공백을 없앤다. 숫자(dest_port)는 문자열로 변환. */
+    private static String str(Object v) {
+        return v == null ? "" : String.valueOf(v).trim();
+    }
+}

--- a/api-service/src/main/java/com/edrdog/apiservice/alert/web/AlertController.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/alert/web/AlertController.java
@@ -58,6 +58,17 @@ public class AlertController {
         return alerts.get(tenantId, id);
     }
 
+    @Operation(summary = "알림 공격 경로(lineage)",
+            description = "알림 하나의 process lineage 그래프(nodes/edges). 같은 host+tenant 의 알림 시각 ±5분 events 를 "
+                    + "이름 기반 process/network 체인으로 재구성한다. 남의 tenant 것이면 404.")
+    @GetMapping("/{id}/lineage")
+    public LineageResponse lineage(
+            @RequestHeader(name = "Authorization", required = false) String authorization,
+            @PathVariable String id) {
+        String tenantId = currentTenantId(authorization);
+        return alerts.lineage(tenantId, id);
+    }
+
     @Operation(summary = "알림 트리아지", description = "status 를 confirmed/false_positive 로 갱신. 잘못된 값 400, 남의 tenant 것 404.")
     @PatchMapping("/{id}")
     public AlertResponse triage(

--- a/api-service/src/main/java/com/edrdog/apiservice/alert/web/LineageResponse.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/alert/web/LineageResponse.java
@@ -1,0 +1,33 @@
+package com.edrdog.apiservice.alert.web;
+
+import java.util.List;
+
+/**
+ * alert 하나의 공격 경로(process lineage) 그래프 응답. 프론트는 nodes/edges 를 트리로 그린다.
+ *
+ * <p>현재 events 테이블은 process/parent(이름)와 network(dest_ip:port)만 담고 pid/ppid·file 이 없어
+ * 경로는 이름 체인 기준이라 거칠다(동명 프로세스는 한 노드로 합쳐진다). file/wrote 는 데이터가 없어
+ * 미발생이며, kind/rel enum 에는 자리를 남겨 둔다.
+ */
+public record LineageResponse(List<Node> nodes, List<Edge> edges) {
+
+    /**
+     * 그래프 노드.
+     *
+     * @param id    dedup 키 겸 식별자 ({@code proc:<name>} 또는 {@code net:<ip>:<port>})
+     * @param kind  process | file | network (file 은 현재 미발생)
+     * @param label 화면 표시용 이름/주소
+     */
+    public record Node(String id, String kind, String label) {
+    }
+
+    /**
+     * 그래프 엣지.
+     *
+     * @param from 출발 노드 id
+     * @param to   도착 노드 id
+     * @param rel  spawned | wrote | connected (wrote 는 현재 미발생)
+     */
+    public record Edge(String from, String to, String rel) {
+    }
+}

--- a/api-service/src/main/java/com/edrdog/apiservice/query/EventQueryBuilder.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/query/EventQueryBuilder.java
@@ -39,6 +39,20 @@ public class EventQueryBuilder {
         return new ClickHouseQuery(sql, params);
     }
 
+    /**
+     * lineage 재구성용: tenant+host 격리 하에 시간 윈도우[from,to] events 를 시간순으로 조회.
+     * 그래프 빌드에 필요한 컬럼만 뽑고, ts 오름차순(부모->자식 체인 순)으로 정렬한다.
+     * 상한(MAX_LIMIT)으로 클램프해 폭주를 막는다. tenantId 는 필수.
+     */
+    public ClickHouseQuery lineageEvents(String tenantId, String host, Long from, Long to) {
+        Map<String, String> params = new LinkedHashMap<>();
+        String where = where(tenantId, host, null, from, to, params);
+        String sql = "SELECT type, ts, process, parent, dest_ip, dest_port FROM " + table
+                + where
+                + " ORDER BY ts ASC LIMIT " + MAX_LIMIT;
+        return new ClickHouseQuery(sql, params);
+    }
+
     /** tenant 격리 하에 type 별 건수 집계. 시간범위 필터(옵션) 지원. tenantId 는 필수. */
     public ClickHouseQuery summaryByType(String tenantId, Long from, Long to) {
         Map<String, String> params = new LinkedHashMap<>();

--- a/api-service/src/test/java/com/edrdog/apiservice/alert/AlertIngestTest.java
+++ b/api-service/src/test/java/com/edrdog/apiservice/alert/AlertIngestTest.java
@@ -1,6 +1,7 @@
 package com.edrdog.apiservice.alert;
 
 import com.edrdog.apiservice.alert.dto.Alert;
+import com.edrdog.apiservice.query.EventQueryBuilder;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
@@ -20,8 +21,9 @@ class AlertIngestTest {
     @Autowired
     private AlertRepository alerts;
 
+    // 적재/트리아지만 검증하므로 lineage 의존성(reader)은 쓰지 않는다.
     private AlertService service() {
-        return new AlertService(alerts);
+        return new AlertService(alerts, null, new EventQueryBuilder("edrdog.events"), new LineageGraphBuilder());
     }
 
     private static Alert alert(String tenantId, long ts) {

--- a/api-service/src/test/java/com/edrdog/apiservice/alert/LineageGraphBuilderTest.java
+++ b/api-service/src/test/java/com/edrdog/apiservice/alert/LineageGraphBuilderTest.java
@@ -1,0 +1,120 @@
+package com.edrdog.apiservice.alert;
+
+import com.edrdog.apiservice.alert.web.LineageResponse;
+import org.junit.jupiter.api.Test;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * events 행 목록 -> lineage 그래프(nodes/edges) 변환의 순수 로직 검증.
+ * 이름 기반 체인이므로 같은 이름/주소는 한 노드로 합치고(dedup), 같은 엣지도 중복 제거한다.
+ */
+class LineageGraphBuilderTest {
+
+    private final LineageGraphBuilder builder = new LineageGraphBuilder();
+
+    private static Map<String, Object> process(String proc, String parent) {
+        Map<String, Object> row = new LinkedHashMap<>();
+        row.put("type", "process");
+        row.put("process", proc);
+        row.put("parent", parent);
+        return row;
+    }
+
+    private static Map<String, Object> network(String proc, String ip, int port) {
+        Map<String, Object> row = new LinkedHashMap<>();
+        row.put("type", "network");
+        row.put("process", proc);
+        row.put("dest_ip", ip);
+        row.put("dest_port", port);
+        return row;
+    }
+
+    private static boolean hasNode(LineageResponse g, String id, String kind, String label) {
+        return g.nodes().stream().anyMatch(n ->
+                n.id().equals(id) && n.kind().equals(kind) && n.label().equals(label));
+    }
+
+    private static boolean hasEdge(LineageResponse g, String from, String to, String rel) {
+        return g.edges().stream().anyMatch(e ->
+                e.from().equals(from) && e.to().equals(to) && e.rel().equals(rel));
+    }
+
+    @Test
+    void process_이벤트는_process_노드와_spawned_엣지를_만든다() {
+        LineageResponse g = builder.build(List.of(process("powershell.exe", "winword.exe")));
+
+        assertTrue(hasNode(g, "proc:winword.exe", "process", "winword.exe"), g.nodes().toString());
+        assertTrue(hasNode(g, "proc:powershell.exe", "process", "powershell.exe"));
+        assertTrue(hasEdge(g, "proc:winword.exe", "proc:powershell.exe", "spawned"));
+    }
+
+    @Test
+    void parent_가_비어있으면_노드만_만들고_엣지는_없다() {
+        LineageResponse g = builder.build(List.of(process("explorer.exe", "")));
+
+        assertTrue(hasNode(g, "proc:explorer.exe", "process", "explorer.exe"));
+        assertEquals(0, g.edges().size());
+    }
+
+    @Test
+    void network_이벤트는_network_노드와_connected_엣지를_만든다() {
+        LineageResponse g = builder.build(List.of(network("powershell.exe", "10.0.0.9", 4444)));
+
+        assertTrue(hasNode(g, "net:10.0.0.9:4444", "network", "10.0.0.9:4444"));
+        assertTrue(hasNode(g, "proc:powershell.exe", "process", "powershell.exe"));
+        assertTrue(hasEdge(g, "proc:powershell.exe", "net:10.0.0.9:4444", "connected"));
+    }
+
+    @Test
+    void network_소유_process_가_없으면_network_노드만_남고_엣지는_없다() {
+        LineageResponse g = builder.build(List.of(network("", "10.0.0.9", 4444)));
+
+        assertTrue(hasNode(g, "net:10.0.0.9:4444", "network", "10.0.0.9:4444"));
+        assertEquals(0, g.edges().size());
+    }
+
+    @Test
+    void dest_ip_가_비어있는_network_는_스킵한다() {
+        LineageResponse g = builder.build(List.of(network("powershell.exe", "", 0)));
+
+        assertTrue(g.nodes().stream().noneMatch(n -> n.kind().equals("network")));
+    }
+
+    @Test
+    void 같은_이름_프로세스는_한_노드로_합친다() {
+        LineageResponse g = builder.build(List.of(
+                process("powershell.exe", "winword.exe"),
+                process("powershell.exe", "winword.exe")));
+
+        assertEquals(1, g.nodes().stream().filter(n -> n.id().equals("proc:powershell.exe")).count());
+        assertEquals(1, g.edges().size());
+    }
+
+    @Test
+    void 빈_입력이면_빈_그래프() {
+        LineageResponse g = builder.build(List.of());
+
+        assertEquals(0, g.nodes().size());
+        assertEquals(0, g.edges().size());
+    }
+
+    @Test
+    void 체인을_이어붙인다() {
+        LineageResponse g = builder.build(List.of(
+                process("winword.exe", "explorer.exe"),
+                process("powershell.exe", "winword.exe"),
+                network("powershell.exe", "10.0.0.9", 4444)));
+
+        assertTrue(hasEdge(g, "proc:explorer.exe", "proc:winword.exe", "spawned"));
+        assertTrue(hasEdge(g, "proc:winword.exe", "proc:powershell.exe", "spawned"));
+        assertTrue(hasEdge(g, "proc:powershell.exe", "net:10.0.0.9:4444", "connected"));
+        assertEquals(4, g.nodes().size());
+        assertEquals(3, g.edges().size());
+    }
+}

--- a/api-service/src/test/java/com/edrdog/apiservice/alert/web/AlertApiIntegrationTest.java
+++ b/api-service/src/test/java/com/edrdog/apiservice/alert/web/AlertApiIntegrationTest.java
@@ -4,6 +4,8 @@ import com.edrdog.apiservice.alert.AlertId;
 import com.edrdog.apiservice.alert.AlertRecord;
 import com.edrdog.apiservice.alert.AlertRepository;
 import com.edrdog.apiservice.alert.AlertStatus;
+import com.edrdog.apiservice.clickhouse.ClickHouseReader;
+import com.edrdog.apiservice.query.ClickHouseQuery;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -12,12 +14,16 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 
 import java.time.Instant;
 import java.util.List;
+import java.util.Map;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -42,6 +48,10 @@ class AlertApiIntegrationTest {
 
     @Autowired
     private AlertRepository alerts;
+
+    // lineage 는 ClickHouse 를 읽는다. 실 브로커에 붙지 않도록 reader 를 대체해 지정한 events 행을 돌려준다.
+    @MockitoBean
+    private ClickHouseReader reader;
 
     private static String signupBody(String email) {
         return "{\"email\":\"" + email + "\",\"password\":\"password1\"}";
@@ -120,5 +130,60 @@ class AlertApiIntegrationTest {
     @Test
     void 토큰_없으면_401() throws Exception {
         mvc.perform(get("/api/alerts")).andExpect(status().isUnauthorized());
+    }
+
+    // --- lineage ---
+
+    private static Map<String, Object> procRow(String process, String parent) {
+        return Map.of("type", "process", "ts", 100L, "process", process, "parent", parent,
+                "dest_ip", "", "dest_port", 0);
+    }
+
+    private static Map<String, Object> netRow(String process, String ip, int port) {
+        return Map.of("type", "network", "ts", 100L, "process", process, "parent", "",
+                "dest_ip", ip, "dest_port", port);
+    }
+
+    @Test
+    void 자기_alert_lineage_는_이름체인_그래프를_돌려준다() throws Exception {
+        String[] a = signup("a-lineage@edrdog.com");
+        String id = seedAlert(a[1], "hostA", 100L);
+        when(reader.query(any(ClickHouseQuery.class))).thenReturn(List.of(
+                procRow("child.exe", "root.exe"),
+                netRow("child.exe", "10.0.0.9", 4444)));
+
+        mvc.perform(get("/api/alerts/" + id + "/lineage").header("Authorization", "Bearer " + a[0]))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.nodes.length()").value(3))
+                .andExpect(jsonPath("$.edges.length()").value(2))
+                .andExpect(jsonPath("$.edges[?(@.rel=='spawned')].from").value("proc:root.exe"))
+                .andExpect(jsonPath("$.edges[?(@.rel=='connected')].to").value("net:10.0.0.9:4444"));
+    }
+
+    @Test
+    void 이벤트가_없으면_lineage_는_빈_그래프_200() throws Exception {
+        String[] a = signup("a-emptylineage@edrdog.com");
+        String id = seedAlert(a[1], "hostA", 100L);
+        when(reader.query(any(ClickHouseQuery.class))).thenReturn(List.of());
+
+        mvc.perform(get("/api/alerts/" + id + "/lineage").header("Authorization", "Bearer " + a[0]))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.nodes.length()").value(0))
+                .andExpect(jsonPath("$.edges.length()").value(0));
+    }
+
+    @Test
+    void 남의_alert_lineage_는_404() throws Exception {
+        String[] a = signup("a-plineage@edrdog.com");
+        String[] b = signup("b-plineage@edrdog.com");
+        String bId = seedAlert(b[1], "hostB", 200L);
+
+        mvc.perform(get("/api/alerts/" + bId + "/lineage").header("Authorization", "Bearer " + a[0]))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void lineage_도_토큰_없으면_401() throws Exception {
+        mvc.perform(get("/api/alerts/anything/lineage")).andExpect(status().isUnauthorized());
     }
 }

--- a/api-service/src/test/java/com/edrdog/apiservice/query/EventQueryBuilderTest.java
+++ b/api-service/src/test/java/com/edrdog/apiservice/query/EventQueryBuilderTest.java
@@ -126,6 +126,43 @@ class EventQueryBuilderTest {
         assertTrue(builder.events(TENANT, null, null, null, null, 100).sql().contains("ORDER BY ts DESC"));
     }
 
+    // --- lineage ---
+
+    @Test
+    void lineage는_tenant_host_시간윈도우를_모두_바인딩한다() {
+        ClickHouseQuery q = builder.lineageEvents(TENANT, "host-01", 1000L, 2000L);
+        assertTrue(q.sql().contains("tenant_id = {tenant:String}"), q.sql());
+        assertTrue(q.sql().contains("host = {host:String}"), q.sql());
+        assertTrue(q.sql().contains("ts >= {from:UInt64}"), q.sql());
+        assertTrue(q.sql().contains("ts <= {to:UInt64}"), q.sql());
+        assertEquals(TENANT, q.params().get("tenant"));
+        assertEquals("host-01", q.params().get("host"));
+        assertEquals("1000", q.params().get("from"));
+        assertEquals("2000", q.params().get("to"));
+    }
+
+    @Test
+    void lineage는_그래프_빌드에_필요한_컬럼만_시간순으로_뽑는다() {
+        ClickHouseQuery q = builder.lineageEvents(TENANT, "host-01", 1000L, 2000L);
+        assertTrue(q.sql().contains("process"), q.sql());
+        assertTrue(q.sql().contains("parent"), q.sql());
+        assertTrue(q.sql().contains("dest_ip"), q.sql());
+        assertTrue(q.sql().contains("dest_port"), q.sql());
+        assertTrue(q.sql().contains("ORDER BY ts ASC"), q.sql());
+    }
+
+    @Test
+    void lineage도_상한으로_클램프해_폭주를_막는다() {
+        ClickHouseQuery q = builder.lineageEvents(TENANT, "host-01", 1000L, 2000L);
+        assertTrue(q.sql().contains("LIMIT 1000"), q.sql());
+    }
+
+    @Test
+    void lineage도_tenant_가_null_이면_예외() {
+        assertThrows(IllegalArgumentException.class,
+                () -> builder.lineageEvents(null, "host-01", 1000L, 2000L));
+    }
+
     // --- 요약 ---
 
     @Test


### PR DESCRIPTION
## 목적
alert 하나에서 "어디서 시작해 어떻게 퍼졌나"를 process lineage 그래프(nodes/edges)로 제공. 프론트는 트리로 그린다. Closes #37

## 변경
- `GET /api/alerts/{id}/lineage` 추가 (Bearer, tenant 격리, 남의 것 404)
- 같은 host+tenant 의 `alert.ts ±5분` events 를 이름 기반 process/network 체인으로 재구성
- 응답: `{ nodes:[{id,kind,label}], edges:[{from,to,rel}] }`
  - kind: `process | network` (process spawned, network connected)

## 구현
- `LineageGraphBuilder`: events 행 → nodes/edges 순수 변환 (dedup, 입력순 보존)
- `EventQueryBuilder.lineageEvents`: tenant+host 윈도우 조회 (ts ASC, 상한 클램프)
- `AlertService.lineage`: 소유 확인(404) → ClickHouse 조회 → 그래프 빌드
- tenant 격리/404/401 은 기존 alert API 패턴 재사용

## 데이터 한계 (이슈 명시)
- events 에 pid/ppid 없음 → 경로는 이름 체인 기준이라 거칢(동명 프로세스는 한 노드로 합쳐짐)
- events type 은 `process`/`network` 뿐 → `file`/`wrote` 는 데이터 없어 이번 범위 제외 (kind/rel enum 자리만 유지)
- pid/ppid 스키마 확장은 수집·detector 영향이라 별도 이슈로 판단

## 테스트
- `LineageGraphBuilderTest` 8케이스 (체인/dedup/network/고아 노드/빈 입력)
- `EventQueryBuilderTest` lineage 4케이스 (윈도우 바인딩/컬럼/정렬/상한/tenant 필수)
- `AlertApiIntegrationTest` lineage 4케이스 (그래프 형태/빈 그래프 200/남의 tenant 404/토큰없음 401)
- 전체 86개 통과 (실패 0, 에러 0)