### PR TITLE
feat: osquery 수집 API (tenant 인증) (#40)

### DIFF
--- a/api-service/src/main/java/com/edrdog/apiservice/auth/domain/Tenant.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/auth/domain/Tenant.java
@@ -29,6 +29,9 @@ public class Tenant {
     @Column
     private String slackWebhookUrl;
 
+    @Column(unique = true)
+    private String enrollSecret;   // osquery 엔드포인트가 enroll 시 제출하는 테넌트 배포 시크릿
+
     protected Tenant() {
     }
 
@@ -60,5 +63,14 @@ public class Tenant {
     /** Slack webhook URL 을 갱신한다. */
     public void updateWebhook(String url) {
         this.slackWebhookUrl = url;
+    }
+
+    public String getEnrollSecret() {
+        return enrollSecret;
+    }
+
+    /** enroll secret 을 발급/회전한다. */
+    public void updateEnrollSecret(String secret) {
+        this.enrollSecret = secret;
     }
 }

--- a/api-service/src/main/java/com/edrdog/apiservice/auth/repository/TenantRepository.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/auth/repository/TenantRepository.java
@@ -3,5 +3,10 @@ package com.edrdog.apiservice.auth.repository;
 import com.edrdog.apiservice.auth.domain.Tenant;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface TenantRepository extends JpaRepository<Tenant, Long> {
+
+    /** enroll secret 으로 테넌트를 되찾는다(osquery enroll 검증). */
+    Optional<Tenant> findByEnrollSecret(String enrollSecret);
 }

--- a/api-service/src/main/java/com/edrdog/apiservice/osquery/EventsRawProducer.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/osquery/EventsRawProducer.java
@@ -1,0 +1,28 @@
+package com.edrdog.apiservice.osquery;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Service;
+
+/**
+ * tenant 태깅된 osquery 원시 result-log 를 events-raw 로 발행한다(수집 입구).
+ * collector 가 이 토픽을 소비해 Event 로 정규화 후 events 로 재발행한다.
+ * host 를 파티션 키로 보내 같은 엔드포인트 이벤트 순서를 보존한다.
+ */
+@Service
+public class EventsRawProducer {
+
+    private final KafkaTemplate<String, String> template;
+    private final String eventsRawTopic;
+
+    public EventsRawProducer(KafkaTemplate<String, String> template,
+                             @Value("${edrdog.kafka.events-raw-topic}") String eventsRawTopic) {
+        this.template = template;
+        this.eventsRawTopic = eventsRawTopic;
+    }
+
+    /** 원시 result-log JSON 1건 발행. key 는 host(엔드포인트 식별자). */
+    public void publish(String host, String rawJson) {
+        template.send(eventsRawTopic, host, rawJson);
+    }
+}

--- a/api-service/src/main/java/com/edrdog/apiservice/osquery/OsqueryConfig.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/osquery/OsqueryConfig.java
@@ -1,0 +1,38 @@
+package com.edrdog.apiservice.osquery;
+
+/**
+ * 엔드포인트에 내려줄 osquery 수집 설정(osquery.conf 의 schedule). config 엔드포인트가 그대로 응답한다.
+ *
+ * <p>스케줄 쿼리 이름이 result-log 의 {@code name} 으로 찍히므로, collector 의 정규화 규칙과 맞춘다:
+ * {@code socket_events}(이름에 socket 포함)는 network 로, {@code process_events}는 process 로 매핑된다.
+ * 각 쿼리 컬럼(path/cmdline/parent, remote_address/remote_port)도 RawEventMapper 가 읽는 이름과 맞춘다.
+ */
+public final class OsqueryConfig {
+
+    /** 프로세스 생성·소켓 연결 evented 테이블을 수집하는 최소 스케줄. */
+    public static final String SCHEDULE_JSON = """
+            {
+              "options": {
+                "host_identifier": "hostname",
+                "schedule_splay_percent": 10,
+                "disable_events": false,
+                "events_expiry": 3600
+              },
+              "schedule": {
+                "process_events": {
+                  "query": "SELECT path, cmdline, parent, pid, time FROM process_events WHERE path != ''",
+                  "interval": 10,
+                  "description": "프로세스 생성 이벤트"
+                },
+                "socket_events": {
+                  "query": "SELECT path, remote_address, remote_port, pid, time FROM socket_events WHERE action = 'connect' AND remote_address != ''",
+                  "interval": 10,
+                  "description": "아웃바운드 소켓 연결 이벤트"
+                }
+              }
+            }
+            """;
+
+    private OsqueryConfig() {
+    }
+}

--- a/api-service/src/main/java/com/edrdog/apiservice/osquery/OsqueryService.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/osquery/OsqueryService.java
@@ -1,0 +1,88 @@
+package com.edrdog.apiservice.osquery;
+
+import com.edrdog.apiservice.auth.domain.Tenant;
+import com.edrdog.apiservice.auth.repository.TenantRepository;
+import com.edrdog.apiservice.osquery.domain.OsqueryNode;
+import com.edrdog.apiservice.osquery.repository.OsqueryNodeRepository;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+import java.util.Optional;
+
+/**
+ * osquery TLS remote 3종의 서버 로직. enroll secret/node_key 인증과 tenant 태깅을 담당하고,
+ * 태깅·정규화 규칙 같은 순수 판단은 {@link RawLogTagger} 에 위임한다.
+ */
+@Service
+public class OsqueryService {
+
+    private final TenantRepository tenants;
+    private final OsqueryNodeRepository nodes;
+    private final EventsRawProducer producer;
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    public OsqueryService(TenantRepository tenants, OsqueryNodeRepository nodes, EventsRawProducer producer) {
+        this.tenants = tenants;
+        this.nodes = nodes;
+        this.producer = producer;
+    }
+
+    /**
+     * enroll secret 을 검증해 node_key 를 발급한다. 같은 tenant·host 재-enroll 은 기존 노드를 재사용한다.
+     * 시크릿이 비었거나 매칭 tenant 가 없으면 빈 Optional(=node_invalid).
+     */
+    @Transactional
+    public Optional<String> enroll(String enrollSecret, String hostIdentifier, String platform) {
+        if (enrollSecret == null || enrollSecret.isBlank()) {
+            return Optional.empty();
+        }
+        Tenant tenant = tenants.findByEnrollSecret(enrollSecret).orElse(null);
+        if (tenant == null) {
+            return Optional.empty();
+        }
+        String host = (hostIdentifier == null || hostIdentifier.isBlank()) ? "unknown" : hostIdentifier;
+        Instant now = Instant.now();
+        OsqueryNode node = nodes.findByTenantIdAndHostIdentifier(tenant.getId(), host)
+                .orElseGet(() -> OsqueryNode.enroll(OsqueryTokens.newToken(), tenant.getId(), host, platform, now));
+        node.touch(now);
+        nodes.save(node);
+        return Optional.of(node.getNodeKey());
+    }
+
+    /** node_key 가 유효하면 수집 설정을 응답. 유효하지 않으면 빈 Optional(=node_invalid). */
+    @Transactional
+    public Optional<String> config(String nodeKey) {
+        return resolve(nodeKey).map(node -> OsqueryConfig.SCHEDULE_JSON);
+    }
+
+    /**
+     * node_key 로 tenant 를 풀어 각 result-log 를 태깅 후 events-raw 로 발행한다.
+     * 유효하지 않은 node_key 면 false(=node_invalid). status 로그 등 result 가 아닌 data 는 조용히 무시.
+     */
+    @Transactional
+    public boolean log(String nodeKey, JsonNode data) {
+        Optional<OsqueryNode> found = resolve(nodeKey);
+        if (found.isEmpty()) {
+            return false;
+        }
+        OsqueryNode node = found.get();
+        String tenantId = String.valueOf(node.getTenantId());
+        for (String raw : RawLogTagger.tag(tenantId, data, mapper)) {
+            producer.publish(node.getHostIdentifier(), raw);
+        }
+        return true;
+    }
+
+    /** node_key 로 노드를 찾고 마지막 관측 시각을 갱신. */
+    private Optional<OsqueryNode> resolve(String nodeKey) {
+        if (nodeKey == null || nodeKey.isBlank()) {
+            return Optional.empty();
+        }
+        Optional<OsqueryNode> node = nodes.findById(nodeKey);
+        node.ifPresent(n -> n.touch(Instant.now()));
+        return node;
+    }
+}

--- a/api-service/src/main/java/com/edrdog/apiservice/osquery/OsqueryTlsConnectorConfig.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/osquery/OsqueryTlsConnectorConfig.java
@@ -1,0 +1,71 @@
+package com.edrdog.apiservice.osquery;
+
+import org.apache.catalina.connector.Connector;
+import org.apache.coyote.http11.Http11NioProtocol;
+import org.apache.tomcat.util.net.SSLHostConfig;
+import org.apache.tomcat.util.net.SSLHostConfigCertificate;
+import org.apache.tomcat.util.net.SSLHostConfigCertificate.Type;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.web.embedded.tomcat.TomcatServletWebServerFactory;
+import org.springframework.boot.web.server.WebServerFactoryCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.FileSystemResource;
+import org.springframework.core.io.Resource;
+
+/**
+ * osquery 전용 HTTPS 커넥터(8443)를 기본 HTTP 커넥터(8084) 옆에 병설한다.
+ * osquery TLS logger 는 평문 HTTP 로 연결하지 않으므로 수집 경로에는 HTTPS 가 필수다.
+ * 프론트는 기존 HTTP 를 그대로 쓰게 두려고 서비스 전체를 HTTPS 로 돌리지 않고 커넥터만 하나 더 연다.
+ *
+ * <p>{@code edrdog.osquery.tls.enabled=true} 일 때만 활성. dev 는 self-signed 키스토어를 만들어
+ * (scripts/gen-dev-keystore.sh) 경로를 지정하고, osquery 는 그 서버 cert 를 {@code --tls_server_certs} 로 핀한다.
+ * mTLS(클라 인증서)는 후순위라 여기서 다루지 않는다(node_key 로 인증).
+ */
+@Configuration
+@ConditionalOnProperty(name = "edrdog.osquery.tls.enabled", havingValue = "true")
+@EnableConfigurationProperties(OsqueryTlsProperties.class)
+public class OsqueryTlsConnectorConfig {
+
+    @Bean
+    public WebServerFactoryCustomizer<TomcatServletWebServerFactory> osqueryHttpsConnector(OsqueryTlsProperties props) {
+        return factory -> factory.addAdditionalTomcatConnectors(build(props));
+    }
+
+    private Connector build(OsqueryTlsProperties props) {
+        Connector connector = new Connector("org.apache.coyote.http11.Http11NioProtocol");
+        connector.setScheme("https");
+        connector.setSecure(true);
+        connector.setPort(props.port());
+
+        Http11NioProtocol protocol = (Http11NioProtocol) connector.getProtocolHandler();
+        protocol.setSSLEnabled(true);
+
+        SSLHostConfig sslHostConfig = new SSLHostConfig();
+        SSLHostConfigCertificate cert = new SSLHostConfigCertificate(sslHostConfig, Type.UNDEFINED);
+        cert.setCertificateKeystoreFile(resolve(props.keystore()));
+        cert.setCertificateKeystorePassword(props.keystorePassword());
+        cert.setCertificateKeystoreType(props.keystoreType());
+        if (props.keyAlias() != null && !props.keyAlias().isBlank()) {
+            cert.setCertificateKeyAlias(props.keyAlias());
+        }
+        sslHostConfig.addCertificate(cert);
+        connector.addSslHostConfig(sslHostConfig);
+        return connector;
+    }
+
+    /** classpath: 접두어면 리소스로, 아니면 파일 경로로 해석한 절대경로를 돌려준다. */
+    private String resolve(String location) {
+        try {
+            Resource resource = location.startsWith("classpath:")
+                    ? new ClassPathResource(location.substring("classpath:".length()))
+                    : new FileSystemResource(location);
+            return resource.getFile().getAbsolutePath();
+        } catch (Exception e) {
+            throw new IllegalStateException("osquery TLS 키스토어를 찾을 수 없습니다: " + location
+                    + " (scripts/gen-dev-keystore.sh 로 생성하세요)", e);
+        }
+    }
+}

--- a/api-service/src/main/java/com/edrdog/apiservice/osquery/OsqueryTlsProperties.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/osquery/OsqueryTlsProperties.java
@@ -1,0 +1,32 @@
+package com.edrdog.apiservice.osquery;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * osquery 전용 HTTPS 커넥터 설정. dev 는 self-signed 키스토어 경로만 지정하면 된다.
+ *
+ * @param enabled          HTTPS 커넥터 활성 여부(기본 false, 켜면 keystore 필수)
+ * @param port             HTTPS 리슨 포트(프론트 HTTP 와 별개)
+ * @param keystore         키스토어 위치(파일 경로 또는 classpath:)
+ * @param keystorePassword 키스토어 비밀번호
+ * @param keystoreType     키스토어 타입(PKCS12)
+ * @param keyAlias         키 alias(비우면 첫 키 사용)
+ */
+@ConfigurationProperties(prefix = "edrdog.osquery.tls")
+public record OsqueryTlsProperties(
+        boolean enabled,
+        int port,
+        String keystore,
+        String keystorePassword,
+        String keystoreType,
+        String keyAlias
+) {
+    public OsqueryTlsProperties {
+        if (port == 0) {
+            port = 8443;
+        }
+        if (keystoreType == null || keystoreType.isBlank()) {
+            keystoreType = "PKCS12";
+        }
+    }
+}

--- a/api-service/src/main/java/com/edrdog/apiservice/osquery/OsqueryTokens.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/osquery/OsqueryTokens.java
@@ -1,0 +1,25 @@
+package com.edrdog.apiservice.osquery;
+
+import java.security.SecureRandom;
+import java.util.Base64;
+
+/**
+ * osquery 인증 토큰 생성(순수 랜덤). enroll secret(테넌트가 엔드포인트에 배포)과
+ * node_key(enroll 성공 시 발급) 둘 다 추측 불가한 URL-safe 랜덤 문자열이면 된다.
+ */
+public final class OsqueryTokens {
+
+    private static final SecureRandom RANDOM = new SecureRandom();
+    private static final Base64.Encoder ENCODER = Base64.getUrlEncoder().withoutPadding();
+    private static final int BYTES = 32;
+
+    private OsqueryTokens() {
+    }
+
+    /** 32바이트 랜덤을 URL-safe base64(패딩 없음)로. 충돌 확률 무시 가능. */
+    public static String newToken() {
+        byte[] buf = new byte[BYTES];
+        RANDOM.nextBytes(buf);
+        return ENCODER.encodeToString(buf);
+    }
+}

--- a/api-service/src/main/java/com/edrdog/apiservice/osquery/RawLogTagger.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/osquery/RawLogTagger.java
@@ -1,0 +1,43 @@
+package com.edrdog.apiservice.osquery;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * osquery log 요청의 data 배열 각 result-log 레코드에 tenantId 를 루트로 태깅하는 순수 로직.
+ *
+ * <p>osquery 원본 로그에는 tenant 정보가 없다(엔드포인트는 node_key 만 안다). 수집 API 가 node_key 로
+ * 푼 tenantId 를 여기서 레코드 루트에 심어 events-raw 로 흘려보내면, collector 의 RawEventMapper 가
+ * 루트 {@code tenantId} 를 읽어 events 까지 격리 태그를 전파한다.
+ *
+ * <p>레코드에 이미 tenantId 가 들어 있어도 신뢰하지 않고 서버가 푼 값으로 덮어쓴다(엔드포인트 위조 방지).
+ */
+public final class RawLogTagger {
+
+    private RawLogTagger() {
+    }
+
+    /** data 배열의 객체 원소마다 루트 tenantId 를 심어 JSON 문자열 리스트로 반환. 배열이 아니면 빈 리스트. */
+    public static List<String> tag(String tenantId, JsonNode data, ObjectMapper mapper) {
+        List<String> out = new ArrayList<>();
+        if (data == null || !data.isArray()) {
+            return out;
+        }
+        for (JsonNode record : data) {
+            if (record == null || !record.isObject()) {
+                continue;   // 객체가 아닌 원소는 result-log 가 아님
+            }
+            ObjectNode tagged = ((ObjectNode) record).put("tenantId", tenantId);
+            try {
+                out.add(mapper.writeValueAsString(tagged));
+            } catch (Exception e) {
+                throw new IllegalStateException("result-log 직렬화 실패", e);
+            }
+        }
+        return out;
+    }
+}

--- a/api-service/src/main/java/com/edrdog/apiservice/osquery/domain/OsqueryNode.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/osquery/domain/OsqueryNode.java
@@ -1,0 +1,81 @@
+package com.edrdog.apiservice.osquery.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+import java.time.Instant;
+
+/**
+ * enroll 성공한 osquery 엔드포인트. node_key 로 tenant/host 를 되찾는 매핑이다.
+ * node_key 는 발급 토큰 그대로를 PK 로 쓴다(추측 불가 랜덤).
+ */
+@Entity
+@Table(name = "osquery_nodes")
+public class OsqueryNode {
+
+    @Id
+    @Column(length = 64)
+    private String nodeKey;
+
+    @Column(nullable = false)
+    private Long tenantId;
+
+    @Column(nullable = false)
+    private String hostIdentifier;
+
+    @Column
+    private String platform;
+
+    @Column(nullable = false)
+    private Instant enrolledAt;
+
+    @Column(nullable = false)
+    private Instant lastSeenAt;
+
+    protected OsqueryNode() {
+    }
+
+    private OsqueryNode(String nodeKey, Long tenantId, String hostIdentifier, String platform, Instant now) {
+        this.nodeKey = nodeKey;
+        this.tenantId = tenantId;
+        this.hostIdentifier = hostIdentifier;
+        this.platform = platform;
+        this.enrolledAt = now;
+        this.lastSeenAt = now;
+    }
+
+    public static OsqueryNode enroll(String nodeKey, Long tenantId, String hostIdentifier, String platform, Instant now) {
+        return new OsqueryNode(nodeKey, tenantId, hostIdentifier, platform, now);
+    }
+
+    /** config/log 수신 시각을 갱신(온라인 여부 관측용). */
+    public void touch(Instant now) {
+        this.lastSeenAt = now;
+    }
+
+    public String getNodeKey() {
+        return nodeKey;
+    }
+
+    public Long getTenantId() {
+        return tenantId;
+    }
+
+    public String getHostIdentifier() {
+        return hostIdentifier;
+    }
+
+    public String getPlatform() {
+        return platform;
+    }
+
+    public Instant getEnrolledAt() {
+        return enrolledAt;
+    }
+
+    public Instant getLastSeenAt() {
+        return lastSeenAt;
+    }
+}

--- a/api-service/src/main/java/com/edrdog/apiservice/osquery/repository/OsqueryNodeRepository.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/osquery/repository/OsqueryNodeRepository.java
@@ -1,0 +1,12 @@
+package com.edrdog.apiservice.osquery.repository;
+
+import com.edrdog.apiservice.osquery.domain.OsqueryNode;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface OsqueryNodeRepository extends JpaRepository<OsqueryNode, String> {
+
+    /** 같은 tenant 의 같은 host 재-enroll 시 노드를 재사용(무한 증식 방지). */
+    Optional<OsqueryNode> findByTenantIdAndHostIdentifier(Long tenantId, String hostIdentifier);
+}

--- a/api-service/src/main/java/com/edrdog/apiservice/osquery/web/EnrollRequest.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/osquery/web/EnrollRequest.java
@@ -1,0 +1,14 @@
+package com.edrdog.apiservice.osquery.web;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * osquery enroll 요청. osquery 는 snake_case 로 보낸다(enroll_secret/host_identifier/platform_type).
+ * host_details 등 나머지 필드는 무시한다.
+ */
+public record EnrollRequest(
+        @JsonProperty("enroll_secret") String enrollSecret,
+        @JsonProperty("host_identifier") String hostIdentifier,
+        @JsonProperty("platform_type") String platformType
+) {
+}

--- a/api-service/src/main/java/com/edrdog/apiservice/osquery/web/LogRequest.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/osquery/web/LogRequest.java
@@ -1,0 +1,18 @@
+package com.edrdog.apiservice.osquery.web;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.JsonNode;
+
+/**
+ * osquery log 요청. log_type 이 result 면 data 가 result-log 레코드 배열이다.
+ * status 등 다른 로그는 data 스키마가 달라 수집 대상이 아니다.
+ */
+public record LogRequest(
+        @JsonProperty("node_key") String nodeKey,
+        @JsonProperty("log_type") String logType,
+        @JsonProperty("data") JsonNode data
+) {
+    public boolean isResult() {
+        return "result".equals(logType);
+    }
+}

--- a/api-service/src/main/java/com/edrdog/apiservice/osquery/web/NodeKeyRequest.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/osquery/web/NodeKeyRequest.java
@@ -1,0 +1,9 @@
+package com.edrdog.apiservice.osquery.web;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/** config 요청 등 node_key 만 담는 요청. */
+public record NodeKeyRequest(
+        @JsonProperty("node_key") String nodeKey
+) {
+}

--- a/api-service/src/main/java/com/edrdog/apiservice/osquery/web/OsqueryController.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/osquery/web/OsqueryController.java
@@ -1,0 +1,73 @@
+package com.edrdog.apiservice.osquery.web;
+
+import com.edrdog.apiservice.osquery.OsqueryService;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Optional;
+
+/**
+ * osquery TLS remote API 3종(enroll/config/log). 프론트 X-API-Key 가 아니라 자체 node_key/enroll_secret 으로
+ * 인증하므로 ApiKeyFilter 예외 경로다. 인증 실패는 osquery 규약대로 {@code node_invalid:true} 로 응답한다.
+ */
+@RestController
+@RequestMapping("/api/osquery")
+@Tag(name = "osquery", description = "osquery 엔드포인트 수집 API (enroll/config/log)")
+public class OsqueryController {
+
+    private final OsqueryService service;
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    public OsqueryController(OsqueryService service) {
+        this.service = service;
+    }
+
+    @Operation(summary = "enroll", description = "enroll_secret(테넌트) 검증 후 node_key 를 발급한다. 실패 시 node_invalid:true.")
+    @PostMapping("/enroll")
+    public ObjectNode enroll(@RequestBody EnrollRequest req) {
+        Optional<String> nodeKey = service.enroll(req.enrollSecret(), req.hostIdentifier(), req.platformType());
+        ObjectNode res = mapper.createObjectNode();
+        nodeKey.ifPresent(key -> res.put("node_key", key));
+        res.put("node_invalid", nodeKey.isEmpty());
+        return res;
+    }
+
+    @Operation(summary = "config", description = "node_key 인증 후 수집 쿼리(osquery.conf schedule)를 응답한다. 실패 시 node_invalid:true.")
+    @PostMapping("/config")
+    public JsonNode config(@RequestBody NodeKeyRequest req) {
+        Optional<String> config = service.config(req.nodeKey());
+        if (config.isEmpty()) {
+            return invalid();
+        }
+        try {
+            ObjectNode res = (ObjectNode) mapper.readTree(config.get());
+            res.put("node_invalid", false);
+            return res;
+        } catch (Exception e) {
+            throw new IllegalStateException("osquery 설정 직렬화 실패", e);
+        }
+    }
+
+    @Operation(summary = "log", description = "node_key 인증 후 result-log 를 tenant 태깅해 events-raw 로 발행한다. 실패 시 node_invalid:true.")
+    @PostMapping("/log")
+    public ObjectNode log(@RequestBody LogRequest req) {
+        // result 만 발행 대상. status 등은 node_key 인증만 하고 발행하지 않는다(data=null).
+        boolean valid = service.log(req.nodeKey(), req.isResult() ? req.data() : null);
+        ObjectNode res = mapper.createObjectNode();
+        res.put("node_invalid", !valid);
+        return res;
+    }
+
+    private ObjectNode invalid() {
+        ObjectNode res = mapper.createObjectNode();
+        res.put("node_invalid", true);
+        return res;
+    }
+}

--- a/api-service/src/main/java/com/edrdog/apiservice/security/ApiKeyPolicy.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/security/ApiKeyPolicy.java
@@ -14,7 +14,8 @@ public class ApiKeyPolicy {
             "/api/auth/",
             "/api/events",  // 조회는 세션 Bearer 로 인증하고 tenant 를 뽑는다(EventQueryController)
             "/api/alerts",  // 알림 조회·트리아지도 세션 Bearer 로 인증(AlertController)
-            "/api/internal/"  // 서비스 간 조회는 별도 X-Internal-Key 로 인증(TenantController), 프론트 키와 분리
+            "/api/internal/",  // 서비스 간 조회는 별도 X-Internal-Key 로 인증(TenantController), 프론트 키와 분리
+            "/api/osquery/"  // 엔드포인트 수집은 자체 enroll_secret/node_key 로 인증(OsqueryController), 프론트 키와 분리
     );
 
     private final String configuredKey;

--- a/api-service/src/main/java/com/edrdog/apiservice/tenant/EnrollSecretResponse.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/tenant/EnrollSecretResponse.java
@@ -1,0 +1,5 @@
+package com.edrdog.apiservice.tenant;
+
+/** enroll secret 발급/조회 응답. 미발급이면 enrollSecret 이 null. */
+public record EnrollSecretResponse(Long tenantId, String enrollSecret) {
+}

--- a/api-service/src/main/java/com/edrdog/apiservice/tenant/TenantController.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/tenant/TenantController.java
@@ -8,6 +8,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -52,6 +53,24 @@ public class TenantController {
         Principal principal = auth.resolve(bearerToken(authorization));
         String url = tenants.getWebhook(principal.tenantId()).orElse(null);
         return new WebhookResponse(principal.tenantId(), url);
+    }
+
+    @Operation(summary = "enroll secret 발급/회전", description = "로그인 유저(Bearer)의 tenant 에 osquery enroll secret 을 새로 발급한다. 엔드포인트 osquery.conf 의 enroll_secret 에 넣는다.")
+    @PostMapping("/api/tenant/enroll-secret")
+    public EnrollSecretResponse rotateEnrollSecret(
+            @RequestHeader(name = "Authorization", required = false) String authorization) {
+        Principal principal = auth.resolve(bearerToken(authorization));
+        String secret = tenants.rotateEnrollSecret(principal.tenantId());
+        return new EnrollSecretResponse(principal.tenantId(), secret);
+    }
+
+    @Operation(summary = "내 enroll secret 조회", description = "로그인 유저(Bearer)의 tenant 에 발급된 enroll secret 을 조회한다. 미발급이면 null.")
+    @GetMapping("/api/tenant/enroll-secret")
+    public EnrollSecretResponse getEnrollSecret(
+            @RequestHeader(name = "Authorization", required = false) String authorization) {
+        Principal principal = auth.resolve(bearerToken(authorization));
+        String secret = tenants.getEnrollSecret(principal.tenantId()).orElse(null);
+        return new EnrollSecretResponse(principal.tenantId(), secret);
     }
 
     @Operation(summary = "내부 webhook 조회", description = "서비스 간 조회용(X-Internal-Key). 지정 tenant 의 webhook URL 을 조회한다.")

--- a/api-service/src/main/java/com/edrdog/apiservice/tenant/TenantService.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/tenant/TenantService.java
@@ -3,6 +3,7 @@ package com.edrdog.apiservice.tenant;
 import com.edrdog.apiservice.auth.domain.Tenant;
 import com.edrdog.apiservice.auth.exception.AuthException;
 import com.edrdog.apiservice.auth.repository.TenantRepository;
+import com.edrdog.apiservice.osquery.OsqueryTokens;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -39,5 +40,24 @@ public class TenantService {
         Tenant tenant = tenants.findById(tenantId)
                 .orElseThrow(() -> AuthException.notFound("tenant 를 찾을 수 없습니다"));
         return Optional.ofNullable(tenant.getSlackWebhookUrl());
+    }
+
+    /** enroll secret 발급/회전. 새 랜덤 토큰을 저장하고 반환한다. tenant 없음 404. */
+    @Transactional
+    public String rotateEnrollSecret(Long tenantId) {
+        Tenant tenant = tenants.findById(tenantId)
+                .orElseThrow(() -> AuthException.notFound("tenant 를 찾을 수 없습니다"));
+        String secret = OsqueryTokens.newToken();
+        tenant.updateEnrollSecret(secret);
+        tenants.save(tenant);
+        return secret;
+    }
+
+    /** 현재 enroll secret 조회. tenant 없음 404, 미발급이면 빈 Optional. */
+    @Transactional(readOnly = true)
+    public Optional<String> getEnrollSecret(Long tenantId) {
+        Tenant tenant = tenants.findById(tenantId)
+                .orElseThrow(() -> AuthException.notFound("tenant 를 찾을 수 없습니다"));
+        return Optional.ofNullable(tenant.getEnrollSecret());
     }
 }

--- a/api-service/src/main/resources/application.yml
+++ b/api-service/src/main/resources/application.yml
@@ -19,6 +19,9 @@ spring:
       properties:
         spring.json.value.default.type: com.edrdog.apiservice.alert.dto.Alert
         spring.json.trusted.packages: com.edrdog.apiservice.alert.dto
+    producer:                            # osquery 수집 원시 로그를 events-raw 로 발행(문자열)
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.apache.kafka.common.serialization.StringSerializer
 
 server:
   port: 8084
@@ -26,6 +29,15 @@ server:
 edrdog:
   kafka:
     alerts-topic: alerts                 # detector 가 발행한 판정 결과 (소비 → MySQL 적재)
+    events-raw-topic: events-raw         # osquery 수집 원시 result-log (발행 → collector 정규화)
+  osquery:
+    tls:                                 # osquery 전용 HTTPS 커넥터 (프론트 HTTP 8084 와 별도 포트)
+      enabled: ${OSQUERY_TLS_ENABLED:false}          # 켜면 keystore 필수 (scripts/gen-dev-keystore.sh)
+      port: ${OSQUERY_TLS_PORT:8443}
+      keystore: ${OSQUERY_TLS_KEYSTORE:}             # PKCS12 경로 또는 classpath:...
+      keystore-password: ${OSQUERY_TLS_KEYSTORE_PASSWORD:changeit}
+      keystore-type: PKCS12
+      key-alias: ${OSQUERY_TLS_KEY_ALIAS:osquery}
   api:
     key: ${EDRDOG_API_KEY:dev-api-key}   # 프론트가 X-API-Key 헤더로 보낼 값 (운영은 환경변수로 주입)
   internal:

--- a/api-service/src/test/java/com/edrdog/apiservice/osquery/OsqueryIngestIntegrationTest.java
+++ b/api-service/src/test/java/com/edrdog/apiservice/osquery/OsqueryIngestIntegrationTest.java
@@ -1,0 +1,143 @@
+package com.edrdog.apiservice.osquery;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * osquery 수집 3종(enroll/config/log) 배선 검증. H2(replace=ANY)로 부팅.
+ * events-raw 발행은 Kafka 없이 확인하려고 EventsRawProducer 를 목으로 대체하고 호출 인자를 검증한다.
+ * /api/osquery/** 는 자체 인증(enroll_secret/node_key)이라 X-API-Key 없이 접근된다(ApiKeyPolicy 예외).
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.ANY)
+@TestPropertySource(properties = "spring.kafka.listener.auto-startup=false")
+class OsqueryIngestIntegrationTest {
+
+    private static final String API_KEY = "dev-api-key";
+
+    @Autowired
+    private MockMvc mvc;
+
+    @Autowired
+    private ObjectMapper om;
+
+    @MockitoBean
+    private EventsRawProducer producer;   // Kafka 대신 목: 발행 인자만 검증
+
+    private String signupAndToken(String email) throws Exception {
+        MvcResult r = mvc.perform(post("/api/auth/signup")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"email\":\"" + email + "\",\"password\":\"password1\"}"))
+                .andExpect(status().isCreated())
+                .andReturn();
+        return om.readTree(r.getResponse().getContentAsString()).get("token").asText();
+    }
+
+    private long tenantIdOf(String token) throws Exception {
+        MvcResult me = mvc.perform(get("/api/auth/me").header("Authorization", "Bearer " + token))
+                .andExpect(status().isOk()).andReturn();
+        return om.readTree(me.getResponse().getContentAsString()).get("tenantId").asLong();
+    }
+
+    /** 로그인 → enroll secret 발급 → 그 secret 반환. */
+    private String issueEnrollSecret(String token) throws Exception {
+        MvcResult r = mvc.perform(post("/api/tenant/enroll-secret")
+                        .header("Authorization", "Bearer " + token)
+                        .header("X-API-Key", API_KEY))
+                .andExpect(status().isOk()).andReturn();
+        return om.readTree(r.getResponse().getContentAsString()).get("enrollSecret").asText();
+    }
+
+    @Test
+    void enroll_config_log_전체흐름_tenant_태깅_발행() throws Exception {
+        String token = signupAndToken("node@edrdog.com");
+        long tenantId = tenantIdOf(token);
+        String secret = issueEnrollSecret(token);
+
+        // enroll: 유효 secret → node_key 발급
+        MvcResult enroll = mvc.perform(post("/api/osquery/enroll")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"enroll_secret\":\"" + secret + "\",\"host_identifier\":\"mac-001\",\"platform_type\":\"darwin\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.node_invalid").value(false))
+                .andExpect(jsonPath("$.node_key").isNotEmpty())
+                .andReturn();
+        String nodeKey = om.readTree(enroll.getResponse().getContentAsString()).get("node_key").asText();
+
+        // config: node_key 인증 → 수집 스케줄
+        mvc.perform(post("/api/osquery/config")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"node_key\":\"" + nodeKey + "\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.node_invalid").value(false))
+                .andExpect(jsonPath("$.schedule.process_events").exists())
+                .andExpect(jsonPath("$.schedule.socket_events").exists());
+
+        // log: result 로그 → tenant 태깅 후 events-raw 발행
+        String logBody = "{\"node_key\":\"" + nodeKey + "\",\"log_type\":\"result\",\"data\":["
+                + "{\"name\":\"process_events\",\"hostIdentifier\":\"mac-001\",\"unixTime\":\"1700000000\",\"action\":\"added\",\"columns\":{\"path\":\"/bin/bash\",\"parent\":\"zsh\"}}"
+                + "]}";
+        mvc.perform(post("/api/osquery/log")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(logBody))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.node_invalid").value(false));
+
+        // events-raw 로 host 키 + tenantId 태깅된 원시 로그가 나갔는지
+        ArgumentCaptor<String> host = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<String> raw = ArgumentCaptor.forClass(String.class);
+        verify(producer, times(1)).publish(host.capture(), raw.capture());
+        org.junit.jupiter.api.Assertions.assertEquals("mac-001", host.getValue());
+        org.junit.jupiter.api.Assertions.assertEquals(
+                String.valueOf(tenantId), om.readTree(raw.getValue()).get("tenantId").asText());
+    }
+
+    @Test
+    void 잘못된_enroll_secret_은_node_invalid() throws Exception {
+        mvc.perform(post("/api/osquery/enroll")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"enroll_secret\":\"nope\",\"host_identifier\":\"mac-x\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.node_invalid").value(true))
+                .andExpect(jsonPath("$.node_key").doesNotExist());
+    }
+
+    @Test
+    void 잘못된_node_key_log_는_발행하지_않고_node_invalid() throws Exception {
+        mvc.perform(post("/api/osquery/log")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"node_key\":\"bogus\",\"log_type\":\"result\",\"data\":[{\"name\":\"process_events\",\"columns\":{}}]}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.node_invalid").value(true));
+
+        verify(producer, never()).publish(org.mockito.ArgumentMatchers.anyString(), org.mockito.ArgumentMatchers.anyString());
+    }
+
+    @Test
+    void 잘못된_node_key_config_는_node_invalid() throws Exception {
+        mvc.perform(post("/api/osquery/config")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"node_key\":\"bogus\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.node_invalid").value(true));
+    }
+}

--- a/api-service/src/test/java/com/edrdog/apiservice/osquery/RawLogTaggerTest.java
+++ b/api-service/src/test/java/com/edrdog/apiservice/osquery/RawLogTaggerTest.java
@@ -1,0 +1,72 @@
+package com.edrdog.apiservice.osquery;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * osquery log 요청의 data 배열 각 result-log 레코드에 tenantId 를 루트 태깅하는 순수 로직 검증.
+ * osquery 원본 로그에는 tenant 정보가 없으므로, node_key 로 푼 tenantId 를 여기서 껍데기 필드로 심는다.
+ * collector RawEventMapper 가 이 루트 tenantId 를 읽어 events 까지 전파한다.
+ */
+class RawLogTaggerTest {
+
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    private JsonNode data(String json) throws Exception {
+        return mapper.readTree(json);
+    }
+
+    @Test
+    void 각_레코드_루트에_tenantId_를_심고_JSON_문자열로_돌려준다() throws Exception {
+        JsonNode data = data("""
+                [
+                  {"name":"process_events","hostIdentifier":"mac-001","columns":{"path":"/bin/bash"}},
+                  {"name":"socket_events","hostIdentifier":"mac-001","columns":{"remote_address":"1.2.3.4"}}
+                ]
+                """);
+
+        List<String> tagged = RawLogTagger.tag("7", data, mapper);
+
+        assertEquals(2, tagged.size());
+        for (String rec : tagged) {
+            JsonNode node = mapper.readTree(rec);
+            assertEquals("7", node.get("tenantId").asText());
+        }
+        // 원본 필드는 보존
+        assertEquals("mac-001", mapper.readTree(tagged.get(0)).get("hostIdentifier").asText());
+    }
+
+    @Test
+    void data_가_배열이_아니면_빈_리스트() throws Exception {
+        assertTrue(RawLogTagger.tag("7", data("{\"node_key\":\"x\"}"), mapper).isEmpty());
+        assertTrue(RawLogTagger.tag("7", null, mapper).isEmpty());
+    }
+
+    @Test
+    void 객체가_아닌_원소는_건너뛴다() throws Exception {
+        JsonNode data = data("""
+                [ {"name":"process_events","columns":{}}, "쓰레기", 123 ]
+                """);
+
+        List<String> tagged = RawLogTagger.tag("7", data, mapper);
+
+        assertEquals(1, tagged.size());
+    }
+
+    @Test
+    void 이미_들어있는_tenantId_는_신뢰하지_않고_덮어쓴다() throws Exception {
+        JsonNode data = data("""
+                [ {"name":"process_events","tenantId":"999","columns":{}} ]
+                """);
+
+        List<String> tagged = RawLogTagger.tag("7", data, mapper);
+
+        assertEquals("7", mapper.readTree(tagged.get(0)).get("tenantId").asText());
+    }
+}

--- a/api-service/src/test/java/com/edrdog/apiservice/security/ApiKeyPolicyTest.java
+++ b/api-service/src/test/java/com/edrdog/apiservice/security/ApiKeyPolicyTest.java
@@ -34,6 +34,13 @@ class ApiKeyPolicyTest {
     }
 
     @Test
+    void osquery_수집은_자체_인증이므로_API키_예외() {
+        assertTrue(policy.isExempt("/api/osquery/enroll"));
+        assertTrue(policy.isExempt("/api/osquery/config"));
+        assertTrue(policy.isExempt("/api/osquery/log"));
+    }
+
+    @Test
     void auth_접두어만_같은_경로는_예외가_아님() {
         assertFalse(policy.isExempt("/api/authz"));
         assertFalse(policy.isExempt("/api/auth-logs"));

--- a/collector-service/src/main/java/com/edrdog/collectorservice/RawEventMapper.java
+++ b/collector-service/src/main/java/com/edrdog/collectorservice/RawEventMapper.java
@@ -53,19 +53,22 @@ public final class RawEventMapper {
         long ts = toMillis(firstNonBlank(text(root, "unixTime"), text(columns, "time")));
         String type = isNetwork(text(root, "name")) ? Event.TYPE_NETWORK : Event.TYPE_PROCESS;
         String process = basename(text(columns, "path"));
+        String tenantId = text(root, "tenantId");   // 수집 API 가 node_key→tenant 로 풀어 루트에 태깅
 
         if (Event.TYPE_NETWORK.equals(type)) {
             return Optional.of(new Event(
                     host, type, ts, process, null,
                     text(columns, "cmdline"),
                     text(columns, "remote_address"),
-                    toInt(text(columns, "remote_port"))));
+                    toInt(text(columns, "remote_port")),
+                    tenantId));
         }
         return Optional.of(new Event(
                 host, type, ts, process,
                 text(columns, "parent"),
                 text(columns, "cmdline"),
-                null, 0));
+                null, 0,
+                tenantId));
     }
 
     private static boolean isNetwork(String name) {

--- a/collector-service/src/main/java/com/edrdog/collectorservice/dto/Event.java
+++ b/collector-service/src/main/java/com/edrdog/collectorservice/dto/Event.java
@@ -11,6 +11,7 @@ package com.edrdog.collectorservice.dto;
  * @param cmdline   명령행
  * @param destIp    목적지 IP — network 이벤트
  * @param destPort  목적지 포트 — network 이벤트
+ * @param tenantId  조직(tenant) 식별자 — 멀티테넌시 격리 태그. 수집 API 가 node_key 로 풀어 루트에 태깅한 값을 그대로 흘린다.
  */
 public record Event(
         String host,
@@ -20,7 +21,8 @@ public record Event(
         String parent,
         String cmdline,
         String destIp,
-        int destPort
+        int destPort,
+        String tenantId
 ) {
     public static final String TYPE_PROCESS = "process";
     public static final String TYPE_NETWORK = "network";

--- a/collector-service/src/test/java/com/edrdog/collectorservice/RawEventMapperTest.java
+++ b/collector-service/src/test/java/com/edrdog/collectorservice/RawEventMapperTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Test;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -98,6 +99,39 @@ class RawEventMapperTest {
         assertEquals("curl", e.process());
         assertEquals("203.0.113.9", e.destIp());
         assertEquals(443, e.destPort());
+    }
+
+    @Test
+    void 루트_tenantId_를_Event_로_전파한다() {
+        String raw = """
+                {
+                  "name": "process_events",
+                  "hostIdentifier": "mac-001",
+                  "unixTime": "1700000000",
+                  "action": "added",
+                  "tenantId": "7",
+                  "columns": { "path": "/bin/bash", "parent": "zsh" }
+                }
+                """;
+
+        Event e = map(raw).orElseThrow();
+
+        assertEquals("7", e.tenantId());   // 수집 API 가 node_key 로 풀어 루트에 태깅한 값
+    }
+
+    @Test
+    void tenantId_가_없으면_null_로_흐른다() {
+        String raw = """
+                {
+                  "name": "socket_events",
+                  "hostIdentifier": "mac-001",
+                  "unixTime": "1700000005",
+                  "action": "added",
+                  "columns": { "path": "/usr/bin/curl", "remote_address": "203.0.113.9", "remote_port": "443" }
+                }
+                """;
+
+        assertNull(map(raw).orElseThrow().tenantId());
     }
 
     @Test

--- a/scripts/gen-dev-keystore.sh
+++ b/scripts/gen-dev-keystore.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# osquery 수집 HTTPS(dev)용 self-signed 키스토어와, osquery 가 핀할 서버 cert(PEM)를 생성한다.
+# osquery TLS logger 는 평문 HTTP 로 붙지 않으므로 로컬 e2e 테스트에도 HTTPS 가 필요하다.
+#
+# 사용:
+#   ./scripts/gen-dev-keystore.sh [출력디렉토리] [호스트명]
+#   OSQUERY_TLS_KEYSTORE_PASSWORD=... ./scripts/gen-dev-keystore.sh ./dev-tls localhost
+#
+# 산출물:
+#   <out>/osquery-keystore.p12  → api-service OSQUERY_TLS_KEYSTORE 로 지정
+#   <out>/osquery-server.pem    → osquery --tls_server_certs 로 핀
+set -euo pipefail
+
+OUT="${1:-./dev-tls}"
+HOST="${2:-localhost}"
+PASS="${OSQUERY_TLS_KEYSTORE_PASSWORD:-changeit}"
+ALIAS="${OSQUERY_TLS_KEY_ALIAS:-osquery}"
+
+mkdir -p "$OUT"
+
+keytool -genkeypair -alias "$ALIAS" -keyalg RSA -keysize 2048 -validity 825 \
+  -dname "CN=$HOST" -ext "SAN=dns:$HOST,ip:127.0.0.1" \
+  -keystore "$OUT/osquery-keystore.p12" -storetype PKCS12 \
+  -storepass "$PASS" -keypass "$PASS"
+
+keytool -exportcert -alias "$ALIAS" -rfc \
+  -keystore "$OUT/osquery-keystore.p12" -storepass "$PASS" \
+  -file "$OUT/osquery-server.pem"
+
+echo
+echo "생성 완료:"
+echo "  keystore : $OUT/osquery-keystore.p12  (비번: $PASS, alias: $ALIAS)"
+echo "  server cert(PEM) : $OUT/osquery-server.pem"
+echo
+echo "api-service 기동 예:"
+echo "  OSQUERY_TLS_ENABLED=true \\"
+echo "  OSQUERY_TLS_KEYSTORE=$OUT/osquery-keystore.p12 \\"
+echo "  OSQUERY_TLS_KEYSTORE_PASSWORD=$PASS \\"
+echo "  ./gradlew :api-service:bootRun"
+echo
+echo "osquery 는 scripts/osquery.flags.example 참고 (--tls_server_certs=$OUT/osquery-server.pem)"

--- a/scripts/osquery.flags.example
+++ b/scripts/osquery.flags.example
@@ -1,0 +1,25 @@
+# osquery 엔드포인트가 EDRdog 수집 서버(api-service)로 붙는 TLS remote 설정 예시.
+# 실행: osqueryd --flagfile=osquery.flags.example
+# (Windows 는 osqueryd.exe --flagfile=C:\path\osquery.flags)
+
+# --- TLS remote 플러그인 활성 ---
+--enroll_secret_path=/etc/osquery/enroll.secret     # 로그인 후 발급받은 enroll secret 을 이 파일에 저장
+--tls_hostname=localhost:8443                        # api-service osquery HTTPS 커넥터 (dev)
+--tls_server_certs=/etc/osquery/osquery-server.pem   # gen-dev-keystore.sh 가 만든 서버 cert 를 핀
+
+--config_plugin=tls
+--config_tls_endpoint=/api/osquery/config
+--config_refresh=60
+
+--enroll_tls_endpoint=/api/osquery/enroll
+
+--logger_plugin=tls
+--logger_tls_endpoint=/api/osquery/log
+--logger_tls_period=10
+--disable_carver=true
+
+# --- evented 테이블(수집 스케줄이 process_events/socket_events 를 쓴다) ---
+--disable_events=false
+--enable_socket_events=true
+# Linux: --audit_allow_config=true --audit_allow_sockets=true
+# macOS(EndpointSecurity): 최신 osquery 는 process_events 지원


### PR DESCRIPTION
## 목적
osquery(mac/win) 엔드포인트가 보낸 이벤트를 tenant 인증해 `events-raw` 로 넣는 수집 경로. osquery TLS logger → HTTP(S) 수신 방식으로 통일. Closes #40

## 변경
**osquery 수집 3종 (api-service `osquery` 패키지)**
- `POST /api/osquery/enroll` — enroll_secret(테넌트) 검증 → node_key 발급 + `OsqueryNode`(node_key↔tenant↔host) 저장 (같은 tenant·host 재-enroll 은 재사용)
- `POST /api/osquery/config` — node_key 인증 → 수집 스케줄(process_events/socket_events) 응답
- `POST /api/osquery/log` — node_key 인증 → result-log tenant 태깅 → `events-raw` 발행
- osquery 규약대로 `node_invalid` 응답, 레코드 내 tenantId 는 서버 값으로 덮어씀(위조 방지)

**tenant enroll secret (로그인 후 설정, Bearer)**
- `POST/GET /api/tenant/enroll-secret` — 발급·회전·조회, `Tenant.enrollSecret` 추가

**collector tenant 전파**
- `Event`/`RawEventMapper` 가 루트 `tenantId` 를 읽어 events 까지 격리 태그 전파 (기존엔 유실됐음)

**인증/HTTPS**
- `ApiKeyPolicy` 에 `/api/osquery/**` 예외 (자체 node_key 인증)
- osquery 전용 HTTPS 커넥터(8443) 병설, 프론트 HTTP(8084) 유지. 토글식(`edrdog.osquery.tls.enabled`, 기본 off)
- `scripts/gen-dev-keystore.sh` + `scripts/osquery.flags.example`
- mTLS 는 후순위(node_key 로 인증), 배포단 TLS 종단은 짝 배포 이슈

## 검증
- 단위(TDD): `RawLogTaggerTest`(tenant 태깅), `RawEventMapperTest`(+전파), `ApiKeyPolicyTest`(+예외)
- 통합: `OsqueryIngestIntegrationTest` — H2 부팅으로 enroll→config→log + events-raw 발행 인자(host 키 + tenantId) 검증
- 전체 모듈 테스트 통과
- **로컬 kind 실증**: MySQL+Kafka+HTTPS(8443, self-signed) 붙여 enroll→config→log 전 구간 curl, events-raw 에 `"tenantId":"1"` 태깅 로그 도착 확인

## 범위 밖
- Fleet UI/원격 라이브쿼리, 배포 인그레스 TLS(짝 이슈), 발표용 합성 주입(그대로 유지)