### PR TITLE
feat: alert 대시보드 집계 API + 위협명 매핑 (#48)

### DIFF
--- a/api-service/src/main/java/com/edrdog/apiservice/alert/AlertRepository.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/alert/AlertRepository.java
@@ -39,4 +39,28 @@ public interface AlertRepository extends JpaRepository<AlertRecord, String> {
             + "GROUP BY a.host")
     List<HostAlertCount> openAlertCountsByHost(@Param("tenantId") String tenantId,
                                                @Param("status") String status);
+
+    /**
+     * 기간 내 severity 별 카운트(대시보드 분포용). tenant 격리 필수, from/to 는 null 이면 무시한다.
+     */
+    @Query("SELECT a.severity AS severity, COUNT(a) AS cnt "
+            + "FROM AlertRecord a WHERE a.tenantId = :tenantId "
+            + "AND (:from is null or a.ts >= :from) "
+            + "AND (:to is null or a.ts <= :to) "
+            + "GROUP BY a.severity")
+    List<SeverityCount> countBySeverity(@Param("tenantId") String tenantId,
+                                        @Param("from") Long from,
+                                        @Param("to") Long to);
+
+    /**
+     * 기간 내 ruleId 별 카운트(대시보드 카테고리 접기용). tenant 격리 필수, from/to 는 null 이면 무시한다.
+     */
+    @Query("SELECT a.ruleId AS ruleId, COUNT(a) AS cnt "
+            + "FROM AlertRecord a WHERE a.tenantId = :tenantId "
+            + "AND (:from is null or a.ts >= :from) "
+            + "AND (:to is null or a.ts <= :to) "
+            + "GROUP BY a.ruleId")
+    List<RuleIdCount> countByRuleId(@Param("tenantId") String tenantId,
+                                    @Param("from") Long from,
+                                    @Param("to") Long to);
 }

--- a/api-service/src/main/java/com/edrdog/apiservice/alert/AlertService.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/alert/AlertService.java
@@ -3,6 +3,7 @@ package com.edrdog.apiservice.alert;
 import com.edrdog.apiservice.alert.dto.Alert;
 import com.edrdog.apiservice.alert.web.AlertResponse;
 import com.edrdog.apiservice.alert.web.LineageResponse;
+import com.edrdog.apiservice.alert.web.SummaryResponse;
 import com.edrdog.apiservice.auth.exception.AuthException;
 import com.edrdog.apiservice.clickhouse.ClickHouseReader;
 import com.edrdog.apiservice.query.EventQueryBuilder;
@@ -12,6 +13,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Instant;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -103,6 +106,50 @@ public class AlertService {
         List<Map<String, Object>> rows = reader.query(
                 events.lineageEvents(tenantId, alert.getHost(), from, to));
         return lineage.build(rows);
+    }
+
+    /** 상수 정렬을 명확히 하려는 severity 리터럴(detector 발행값과 일치). */
+    private static final String SEV_CRITICAL = "CRITICAL";
+    private static final String SEV_HIGH = "HIGH";
+    private static final String SEV_MEDIUM = "MEDIUM";
+
+    /** 카테고리 topThreats 상위 개수. */
+    static final int TOP_THREATS = 5;
+
+    /**
+     * 대시보드 집계. tenant 격리 + 기간(from/to null 이면 무시) 하에 severity 분포와
+     * 카테고리별 상위 위협을 조립한다. total 은 모든 severity 버킷 합이라 매핑 안 되는
+     * severity(null/미래값)도 포함돼 topThreats(모든 row 집계) 합과 정합이 맞는다(추가 쿼리 없음).
+     */
+    @Transactional(readOnly = true)
+    public SummaryResponse summary(String tenantId, Long from, Long to) {
+        long critical = 0;
+        long high = 0;
+        long medium = 0;
+        long total = 0;
+        for (SeverityCount c : alerts.countBySeverity(tenantId, from, to)) {
+            total += c.getCnt();
+            if (SEV_CRITICAL.equals(c.getSeverity())) {
+                critical = c.getCnt();
+            } else if (SEV_HIGH.equals(c.getSeverity())) {
+                high = c.getCnt();
+            } else if (SEV_MEDIUM.equals(c.getSeverity())) {
+                medium = c.getCnt();
+            }
+        }
+
+        Map<String, Long> byCategory = new LinkedHashMap<>();
+        for (RuleIdCount c : alerts.countByRuleId(tenantId, from, to)) {
+            byCategory.merge(ThreatCatalog.category(c.getRuleId()), c.getCnt(), Long::sum);
+        }
+        List<SummaryResponse.ThreatCount> topThreats = byCategory.entrySet().stream()
+                .map(e -> new SummaryResponse.ThreatCount(e.getKey(), e.getValue()))
+                .sorted(Comparator.comparingLong(SummaryResponse.ThreatCount::count).reversed()
+                        .thenComparing(SummaryResponse.ThreatCount::category))
+                .limit(TOP_THREATS)
+                .toList();
+
+        return new SummaryResponse(total, new SummaryResponse.Severity(critical, high, medium), topThreats);
     }
 
     /** id 로 찾되 tenant 소유가 아니면 404 로 숨긴다(없는 것과 구분 불가). */

--- a/api-service/src/main/java/com/edrdog/apiservice/alert/RuleIdCount.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/alert/RuleIdCount.java
@@ -1,0 +1,11 @@
+package com.edrdog.apiservice.alert;
+
+/**
+ * ruleId 별 alert 집계 결과(Spring Data 인터페이스 projection). summary 의 카테고리 접기에 쓴다.
+ */
+public interface RuleIdCount {
+
+    String getRuleId();
+
+    long getCnt();
+}

--- a/api-service/src/main/java/com/edrdog/apiservice/alert/SeverityCount.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/alert/SeverityCount.java
@@ -1,0 +1,11 @@
+package com.edrdog.apiservice.alert;
+
+/**
+ * severity 별 alert 집계 결과(Spring Data 인터페이스 projection). summary 의 분포 계산에 쓴다.
+ */
+public interface SeverityCount {
+
+    String getSeverity();
+
+    long getCnt();
+}

--- a/api-service/src/main/java/com/edrdog/apiservice/alert/ThreatCatalog.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/alert/ThreatCatalog.java
@@ -1,0 +1,40 @@
+package com.edrdog.apiservice.alert;
+
+import java.util.Map;
+
+/**
+ * ruleId → 한글 위협명/카테고리 매핑(순수). detector 가 발행하는 ruleId 를 화면 표시용으로 옮긴다.
+ * 미등록 ruleId 는 이름은 원문, 카테고리는 "기타" 로 안전하게 fallback 한다(null 포함).
+ */
+public final class ThreatCatalog {
+
+    static final String UNKNOWN_CATEGORY = "기타";
+
+    /** ruleId → {한글 이름, 카테고리}. 중복 키 방지를 위해 단일 불변 Map 으로 관리한다. */
+    private static final Map<String, Threat> THREATS = Map.of(
+            "SUSPICIOUS_PROCESS_CHAIN", new Threat("의심스러운 프로세스 실행 체인", "권한상승"),
+            "DOWNLOAD_AND_EXECUTE", new Threat("다운로드 후 실행", "악성코드"));
+
+    private ThreatCatalog() {
+    }
+
+    /** 한글 위협명. 매핑 없으면 ruleId 원문(null 이면 null)을 그대로 반환한다. */
+    public static String threatName(String ruleId) {
+        Threat threat = lookup(ruleId);
+        return threat == null ? ruleId : threat.name();
+    }
+
+    /** 위협 카테고리. 매핑 없으면 "기타". */
+    public static String category(String ruleId) {
+        Threat threat = lookup(ruleId);
+        return threat == null ? UNKNOWN_CATEGORY : threat.category();
+    }
+
+    /** null ruleId 는 Map.of 조회에서 NPE 가 나므로 미리 걸러 fallback 시킨다. */
+    private static Threat lookup(String ruleId) {
+        return ruleId == null ? null : THREATS.get(ruleId);
+    }
+
+    private record Threat(String name, String category) {
+    }
+}

--- a/api-service/src/main/java/com/edrdog/apiservice/alert/web/AlertController.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/alert/web/AlertController.java
@@ -49,6 +49,17 @@ public class AlertController {
         return alerts.query(tenantId, host, severity, status, from, to, limit);
     }
 
+    @Operation(summary = "알림 대시보드 집계",
+            description = "로그인 유저의 tenant 것만 기간(from/to 옵션)으로 total·severity 분포·카테고리별 상위 위협을 집계한다.")
+    @GetMapping("/summary")
+    public SummaryResponse summary(
+            @RequestHeader(name = "Authorization", required = false) String authorization,
+            @RequestParam(required = false) Long from,
+            @RequestParam(required = false) Long to) {
+        String tenantId = currentTenantId(authorization);
+        return alerts.summary(tenantId, from, to);
+    }
+
     @Operation(summary = "알림 상세", description = "단건 상세(matched 포함). 남의 tenant 것이면 404.")
     @GetMapping("/{id}")
     public AlertResponse detail(

--- a/api-service/src/main/java/com/edrdog/apiservice/alert/web/AlertResponse.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/alert/web/AlertResponse.java
@@ -1,16 +1,19 @@
 package com.edrdog.apiservice.alert.web;
 
 import com.edrdog.apiservice.alert.AlertRecord;
+import com.edrdog.apiservice.alert.ThreatCatalog;
 
 import java.util.List;
 
 /**
  * alert 조회/상세/트리아지 응답. 목록과 상세가 같은 형태를 쓴다(matched 포함).
+ * threatName 은 ruleId 를 화면 표시용 한글로 옮긴 값이다(원문 ruleId/mitre 는 유지).
  */
 public record AlertResponse(
         String id,
         String host,
         String ruleId,
+        String threatName,
         String mitre,
         String severity,
         String action,
@@ -19,7 +22,7 @@ public record AlertResponse(
         List<String> matched
 ) {
     public static AlertResponse from(AlertRecord r) {
-        return new AlertResponse(r.getId(), r.getHost(), r.getRuleId(), r.getMitre(),
-                r.getSeverity(), r.getAction(), r.getTs(), r.getStatus(), List.copyOf(r.getMatched()));
+        return new AlertResponse(r.getId(), r.getHost(), r.getRuleId(), ThreatCatalog.threatName(r.getRuleId()),
+                r.getMitre(), r.getSeverity(), r.getAction(), r.getTs(), r.getStatus(), List.copyOf(r.getMatched()));
     }
 }

--- a/api-service/src/main/java/com/edrdog/apiservice/alert/web/SummaryResponse.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/alert/web/SummaryResponse.java
@@ -1,0 +1,20 @@
+package com.edrdog.apiservice.alert.web;
+
+import java.util.List;
+
+/**
+ * alert 대시보드 집계 응답. total 은 기간 내 총 alert 수, severity 는 3단계 분포,
+ * topThreats 는 카테고리별 상위 위협이다(count 내림차순).
+ */
+public record SummaryResponse(long total, Severity severity, List<ThreatCount> topThreats) {
+
+    /**
+     * severity 3단계 분포. 현재 데이터에는 MEDIUM 이 없어 medium 은 사실상 항상 0 이다.
+     */
+    public record Severity(long critical, long high, long medium) {
+    }
+
+    /** 카테고리별 위협 건수. */
+    public record ThreatCount(String category, long count) {
+    }
+}

--- a/api-service/src/test/java/com/edrdog/apiservice/alert/ThreatCatalogTest.java
+++ b/api-service/src/test/java/com/edrdog/apiservice/alert/ThreatCatalogTest.java
@@ -1,0 +1,32 @@
+package com.edrdog.apiservice.alert;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * ruleId → 한글 위협명/카테고리 매핑 순수 로직. 미등록 ruleId 는 원문/"기타" 로 fallback.
+ */
+class ThreatCatalogTest {
+
+    @Test
+    void 등록된_ruleId_는_한글_이름과_카테고리를_돌려준다() {
+        assertEquals("의심스러운 프로세스 실행 체인", ThreatCatalog.threatName("SUSPICIOUS_PROCESS_CHAIN"));
+        assertEquals("권한상승", ThreatCatalog.category("SUSPICIOUS_PROCESS_CHAIN"));
+
+        assertEquals("다운로드 후 실행", ThreatCatalog.threatName("DOWNLOAD_AND_EXECUTE"));
+        assertEquals("악성코드", ThreatCatalog.category("DOWNLOAD_AND_EXECUTE"));
+    }
+
+    @Test
+    void 미등록_ruleId_는_이름은_원문_카테고리는_기타() {
+        assertEquals("UNKNOWN_RULE", ThreatCatalog.threatName("UNKNOWN_RULE"));
+        assertEquals("기타", ThreatCatalog.category("UNKNOWN_RULE"));
+    }
+
+    @Test
+    void null_ruleId_도_안전하게_fallback() {
+        assertEquals(null, ThreatCatalog.threatName(null));
+        assertEquals("기타", ThreatCatalog.category(null));
+    }
+}

--- a/api-service/src/test/java/com/edrdog/apiservice/alert/web/AlertApiIntegrationTest.java
+++ b/api-service/src/test/java/com/edrdog/apiservice/alert/web/AlertApiIntegrationTest.java
@@ -75,17 +75,25 @@ class AlertApiIntegrationTest {
         return id;
     }
 
+    private void seedAlert(String tenantId, String host, String ruleId, String severity, long ts) {
+        String id = AlertId.of(tenantId, host, ruleId, ts);
+        alerts.save(AlertRecord.open(id, tenantId, host, ruleId, "T1059",
+                severity, "notify", ts, List.of("m1"), Instant.now()));
+    }
+
     @Test
     void 목록은_자기_tenant_것만_보인다() throws Exception {
         String[] a = signup("a-list@edrdog.com");
         String[] b = signup("b-list@edrdog.com");
-        seedAlert(a[1], "hostA", 100L);
+        seedAlert(a[1], "hostA", "DOWNLOAD_AND_EXECUTE", "HIGH", 100L);
         seedAlert(b[1], "hostB", 200L);
 
         mvc.perform(get("/api/alerts").header("Authorization", "Bearer " + a[0]))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.length()").value(1))
-                .andExpect(jsonPath("$[0].host").value("hostA"));
+                .andExpect(jsonPath("$[0].host").value("hostA"))
+                .andExpect(jsonPath("$[0].ruleId").value("DOWNLOAD_AND_EXECUTE"))
+                .andExpect(jsonPath("$[0].threatName").value("다운로드 후 실행"));
     }
 
     @Test
@@ -185,5 +193,71 @@ class AlertApiIntegrationTest {
     @Test
     void lineage_도_토큰_없으면_401() throws Exception {
         mvc.perform(get("/api/alerts/anything/lineage")).andExpect(status().isUnauthorized());
+    }
+
+    // --- summary ---
+
+    @Test
+    void summary_는_자기_tenant_것만_집계하고_severity_분포와_topThreats_를_돌려준다() throws Exception {
+        String[] a = signup("a-alertsummary@edrdog.com");
+        String[] b = signup("b-alertsummary@edrdog.com");
+        // A: 악성코드 2건(DOWNLOAD_AND_EXECUTE CRITICAL/HIGH), 권한상승 1건(SUSPICIOUS_PROCESS_CHAIN HIGH)
+        seedAlert(a[1], "hostA", "DOWNLOAD_AND_EXECUTE", "CRITICAL", 100L);
+        seedAlert(a[1], "hostA", "DOWNLOAD_AND_EXECUTE", "HIGH", 110L);
+        seedAlert(a[1], "hostA", "SUSPICIOUS_PROCESS_CHAIN", "HIGH", 120L);
+        // B: 섞이면 안 되는 다른 tenant 데이터
+        seedAlert(b[1], "hostB", "DOWNLOAD_AND_EXECUTE", "CRITICAL", 130L);
+
+        mvc.perform(get("/api/alerts/summary").header("Authorization", "Bearer " + a[0]))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.total").value(3))
+                .andExpect(jsonPath("$.severity.critical").value(1))
+                .andExpect(jsonPath("$.severity.high").value(2))
+                .andExpect(jsonPath("$.severity.medium").value(0))
+                .andExpect(jsonPath("$.topThreats.length()").value(2))
+                .andExpect(jsonPath("$.topThreats[0].category").value("악성코드"))
+                .andExpect(jsonPath("$.topThreats[0].count").value(2))
+                .andExpect(jsonPath("$.topThreats[1].category").value("권한상승"))
+                .andExpect(jsonPath("$.topThreats[1].count").value(1));
+    }
+
+    @Test
+    void summary_는_기간_필터를_적용한다() throws Exception {
+        String[] a = signup("a-summaryperiod@edrdog.com");
+        seedAlert(a[1], "hostA", "DOWNLOAD_AND_EXECUTE", "CRITICAL", 100L);
+        seedAlert(a[1], "hostA", "DOWNLOAD_AND_EXECUTE", "HIGH", 300L);
+
+        mvc.perform(get("/api/alerts/summary")
+                        .param("from", "200")
+                        .header("Authorization", "Bearer " + a[0]))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.total").value(1))
+                .andExpect(jsonPath("$.severity.critical").value(0))
+                .andExpect(jsonPath("$.severity.high").value(1));
+    }
+
+    @Test
+    void summary_total_은_미매핑_severity_도_포함하고_동점_카테고리는_이름순() throws Exception {
+        String[] a = signup("a-alertsummarytotal@edrdog.com");
+        // 악성코드 1건(CRITICAL) + 기타 1건(미등록 ruleId, severity=null) → 동점(각 1)
+        seedAlert(a[1], "hostA", "DOWNLOAD_AND_EXECUTE", "CRITICAL", 100L);
+        seedAlert(a[1], "hostA", "UNKNOWN_RULE", null, 110L);
+
+        mvc.perform(get("/api/alerts/summary").header("Authorization", "Bearer " + a[0]))
+                .andExpect(status().isOk())
+                // null severity 는 어느 버킷에도 안 들어가지만 total 에는 포함(2)
+                .andExpect(jsonPath("$.total").value(2))
+                .andExpect(jsonPath("$.severity.critical").value(1))
+                .andExpect(jsonPath("$.severity.high").value(0))
+                .andExpect(jsonPath("$.severity.medium").value(0))
+                // 동점(각 1)은 category 오름차순으로 결정적: "기타"(ㄱ) < "악성코드"(ㅇ)
+                .andExpect(jsonPath("$.topThreats.length()").value(2))
+                .andExpect(jsonPath("$.topThreats[0].category").value("기타"))
+                .andExpect(jsonPath("$.topThreats[1].category").value("악성코드"));
+    }
+
+    @Test
+    void summary_토큰_없으면_401() throws Exception {
+        mvc.perform(get("/api/alerts/summary")).andExpect(status().isUnauthorized());
     }
 }


### PR DESCRIPTION
## 목적
대시보드·요약보기 화면이 요구하는 알림 집계와, 프론트에 보여줄 한글 위협명을 제공한다. (#48)

## 변경
### 1. 위협명 매핑 계층 (`ThreatCatalog`)
- `ruleId` → 한글 위협명 / 위협 카테고리 매핑 (순수 클래스)
  - `SUSPICIOUS_PROCESS_CHAIN` → "의심스러운 프로세스 실행 체인" / 권한상승
  - `DOWNLOAD_AND_EXECUTE` → "다운로드 후 실행" / 악성코드
- 미등록/null ruleId는 원문·"기타"로 안전 fallback
- 새 룰 추가 시 이 매핑 테이블에 한 줄씩 추가 (소프트 커플링)

### 2. 집계 API `GET /api/alerts/summary?from=&to=`
Bearer 인증 + tenant 격리 (기존 핸들러와 동일 패턴)
- `total`: 기간 내 탐지 총건수
- `severity`: 심각도 분포 critical/high/medium 3단계 고정 (현재 medium은 항상 0, detector가 MEDIUM 생성 시 자동 반영)
- `topThreats`: 위협 카테고리 TOP5 (count 내림차순 → category 오름차순, 결정적 정렬)

### 3. `AlertResponse`
- `threatName`(한글) 필드 추가, `ruleId`/`mitre` 원문 유지

## 구현 메모
- 집계는 tenant+기간 격리 JPA projection 쿼리 2개(severity별/ruleId별)로 처리, 추가 라운드트립 없음
- `total`은 전체 severity 버킷 합으로 계산해 예상 밖 severity(null 등)도 누락 없이 포함, topThreats 합과 정합

## 테스트
- `ThreatCatalogTest`: 매핑/fallback/null (TDD)
- `AlertApiIntegrationTest`: tenant 격리, 기간 필터, severity 분포, topThreats 정렬, 미매핑 severity total 포함, 동점 정렬, 401
- `./gradlew :api-service:test` → BUILD SUCCESSFUL, 실패 0