### PR TITLE
feat: api-service CORS 설정

### DIFF
--- a/api-service/src/main/java/com/edrdog/apiservice/security/CorsConfig.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/security/CorsConfig.java
@@ -1,0 +1,63 @@
+package com.edrdog.apiservice.security;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+import org.springframework.web.filter.CorsFilter;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * 브라우저에서 다른 출처의 프론트가 API 를 호출할 수 있게 CORS 를 연다.
+ *
+ * <p>필터로 두고 {@link Ordered#HIGHEST_PRECEDENCE} 를 주는 이유: preflight(OPTIONS)에는
+ * Authorization/X-API-Key 헤더가 붙지 않아 {@link ApiKeyFilter} 보다 뒤에 오면 401 로 막힌다.
+ * CorsFilter 가 먼저 돌면 preflight 를 여기서 끝내고 인증 필터까지 가지 않는다.
+ *
+ * <p>허용 출처는 설정값({@code edrdog.cors.allowed-origins}, 쉼표 구분)으로만 받는다.
+ * 인증은 Bearer 토큰(헤더)이라 쿠키가 필요 없어 allowCredentials 는 켜지 않는다.
+ */
+@Configuration
+public class CorsConfig {
+
+    private static final List<String> ALLOWED_METHODS = List.of("GET", "POST", "PATCH", "OPTIONS");
+
+    private static final List<String> ALLOWED_HEADERS =
+            List.of("Authorization", "Content-Type", "X-API-Key");
+
+    /** preflight 결과 캐시(초). 브라우저가 매 요청마다 OPTIONS 를 보내지 않도록 한다. */
+    private static final long MAX_AGE_SECONDS = 3600;
+
+    private final List<String> allowedOrigins;
+
+    public CorsConfig(@Value("${edrdog.cors.allowed-origins}") String allowedOrigins) {
+        this.allowedOrigins = parseOrigins(allowedOrigins);
+    }
+
+    @Bean
+    @Order(Ordered.HIGHEST_PRECEDENCE)
+    public CorsFilter corsFilter() {
+        CorsConfiguration config = new CorsConfiguration();
+        config.setAllowedOrigins(allowedOrigins);
+        config.setAllowedMethods(ALLOWED_METHODS);
+        config.setAllowedHeaders(ALLOWED_HEADERS);
+        config.setMaxAge(MAX_AGE_SECONDS);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/api/**", config);
+        return new CorsFilter(source);
+    }
+
+    /** 쉼표로 구분된 설정값을 출처 목록으로. 빈 항목은 버린다. */
+    private static List<String> parseOrigins(String raw) {
+        return Arrays.stream(raw.split(","))
+                .map(String::trim)
+                .filter(s -> !s.isEmpty())
+                .toList();
+    }
+}

--- a/api-service/src/main/resources/application.yml
+++ b/api-service/src/main/resources/application.yml
@@ -40,6 +40,10 @@ edrdog:
       key-alias: ${OSQUERY_TLS_KEY_ALIAS:osquery}
   api:
     key: ${EDRDOG_API_KEY:dev-api-key}   # 프론트가 X-API-Key 헤더로 보낼 값 (운영은 환경변수로 주입)
+  cors:
+    # 브라우저에서 API 를 호출할 프론트 출처 (쉼표 구분). 기본값은 Vite dev 서버.
+    # 배포 시엔 실제 프론트 도메인을 환경변수로 주입한다.
+    allowed-origins: ${CORS_ALLOWED_ORIGINS:http://localhost:5173}
   internal:
     key: ${INTERNAL_API_KEY:dev-internal-key}   # 서비스 간 내부 조회 전용 키 (프론트 X-API-Key 와 분리, X-Internal-Key 헤더)
   clickhouse:

--- a/api-service/src/test/java/com/edrdog/apiservice/security/CorsIntegrationTest.java
+++ b/api-service/src/test/java/com/edrdog/apiservice/security/CorsIntegrationTest.java
@@ -1,0 +1,75 @@
+package com.edrdog.apiservice.security;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.options;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * 브라우저에서 다른 출처의 프론트가 API 를 호출할 수 있는지 검증한다.
+ * 핵심은 preflight(OPTIONS)가 ApiKeyFilter 의 401 에 막히지 않고 CORS 헤더와 함께 통과하는 것이다.
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.ANY)
+@TestPropertySource(properties = {
+        "spring.kafka.listener.auto-startup=false",
+        "edrdog.cors.allowed-origins=http://localhost:5173,https://edrdog.example"
+})
+class CorsIntegrationTest {
+
+    @Autowired
+    private MockMvc mvc;
+
+    @Test
+    void 허용된_출처의_preflight_는_인증_없이_통과한다() throws Exception {
+        mvc.perform(options("/api/alerts")
+                        .header("Origin", "http://localhost:5173")
+                        .header("Access-Control-Request-Method", "GET")
+                        .header("Access-Control-Request-Headers", "Authorization"))
+                .andExpect(status().isOk())
+                .andExpect(header().string("Access-Control-Allow-Origin", "http://localhost:5173"));
+    }
+
+    @Test
+    void 설정에_적힌_다른_출처도_허용된다() throws Exception {
+        mvc.perform(options("/api/alerts")
+                        .header("Origin", "https://edrdog.example")
+                        .header("Access-Control-Request-Method", "GET"))
+                .andExpect(status().isOk())
+                .andExpect(header().string("Access-Control-Allow-Origin", "https://edrdog.example"));
+    }
+
+    @Test
+    void 트리아지에_쓰는_PATCH_도_preflight_에서_허용된다() throws Exception {
+        mvc.perform(options("/api/alerts/some-id")
+                        .header("Origin", "http://localhost:5173")
+                        .header("Access-Control-Request-Method", "PATCH")
+                        .header("Access-Control-Request-Headers", "Authorization,Content-Type"))
+                .andExpect(status().isOk())
+                .andExpect(header().string("Access-Control-Allow-Methods", org.hamcrest.Matchers.containsString("PATCH")));
+    }
+
+    @Test
+    void 허용되지_않은_출처의_preflight_는_거부된다() throws Exception {
+        mvc.perform(options("/api/alerts")
+                        .header("Origin", "https://evil.example")
+                        .header("Access-Control-Request-Method", "GET"))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void 실제_요청_응답에도_허용_출처_헤더가_붙는다() throws Exception {
+        // 토큰이 없어 401 이지만, 브라우저가 응답을 읽으려면 CORS 헤더는 붙어 있어야 한다.
+        mvc.perform(get("/api/alerts").header("Origin", "http://localhost:5173"))
+                .andExpect(header().string("Access-Control-Allow-Origin", "http://localhost:5173"));
+    }
+}


### PR DESCRIPTION
## 개요
브라우저에서 다른 출처의 프론트가 API 를 호출할 수 있게 CORS 를 열었습니다. Closes #54

## 작업 내용
- `CorsConfig` — `CorsFilter` 를 `HIGHEST_PRECEDENCE` 로 등록
- `application.yml` — `edrdog.cors.allowed-origins` (기본값 `http://localhost:5173`, 배포는 `CORS_ALLOWED_ORIGINS` 로 주입)

### 왜 필터이고, 왜 최우선 순위인가
preflight(`OPTIONS`)에는 `Authorization` / `X-API-Key` 헤더가 붙지 않습니다. 그래서 `ApiKeyFilter` 뒤에 두면 preflight 가 401 로 막혀 실제 요청까지 가지 못합니다. `CorsFilter` 를 먼저 돌려 preflight 를 여기서 끝냅니다.

### 설정
| 항목 | 값 |
|---|---|
| 허용 출처 | `edrdog.cors.allowed-origins` (쉼표 구분, 하드코딩 없음) |
| 허용 메서드 | `GET`, `POST`, `PATCH`, `OPTIONS` |
| 허용 헤더 | `Authorization`, `Content-Type`, `X-API-Key` |
| `allowCredentials` | 끔 — 인증이 Bearer 토큰(헤더)이라 쿠키가 필요 없음 |
| preflight 캐시 | 3600초 |

## 검증
TDD 로 진행했습니다 (테스트 먼저 → 4개 실패 확인 → 구현 → 통과).

`CorsIntegrationTest` 5개:
- 허용 출처 preflight 가 인증 없이 통과
- 설정에 적힌 다른 출처도 허용
- 트리아지용 `PATCH` 도 preflight 에서 허용
- 미허용 출처 preflight 는 403
- 실제 요청 응답에도 허용 출처 헤더가 붙음 (401 응답이어도 브라우저가 읽을 수 있어야 함)

`:api-service:test` 전체 통과.

실제 기동(kind + MySQL/Kafka/ClickHouse) 후 확인:
```
$ curl -i -X OPTIONS localhost:8084/api/alerts -H 'Origin: http://localhost:5173' \
    -H 'Access-Control-Request-Method: GET' -H 'Access-Control-Request-Headers: Authorization'
HTTP/1.1 200
Access-Control-Allow-Origin: http://localhost:5173
Access-Control-Allow-Methods: GET,POST,PATCH,OPTIONS
Access-Control-Allow-Headers: Authorization
Access-Control-Max-Age: 3600

$ curl -o /dev/null -w '%{http_code}' -X OPTIONS localhost:8084/api/alerts -H 'Origin: https://evil.example' ...
403
```

프론트(Frontend PR #13)를 실제 api-service 에 붙여 5개 화면 전부 동작 확인했습니다.