### PR TITLE
feat: 발표용 데모 계정·과거 데이터 시드

### DIFF
--- a/api-service/src/main/java/com/edrdog/apiservice/demo/DemoAccountSeeder.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/demo/DemoAccountSeeder.java
@@ -1,0 +1,108 @@
+package com.edrdog.apiservice.demo;
+
+import com.edrdog.apiservice.auth.domain.AppUser;
+import com.edrdog.apiservice.auth.domain.Tenant;
+import com.edrdog.apiservice.auth.repository.TenantRepository;
+import com.edrdog.apiservice.auth.repository.UserRepository;
+import jakarta.persistence.EntityManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.Optional;
+
+/**
+ * 발표용 데모 계정을 부팅 시 만든다. {@code edrdog.demo.seed=true} 일 때만 빈으로 올라온다.
+ *
+ * <p>가입 API(signup)로는 만들 수 없다. AuthValidation 이 이메일 형식과 8자 이상 비밀번호를 요구하기 때문이다.
+ * 실제 가입 규칙을 느슨하게 푸는 대신 여기서 저장소에 직접 넣는다. 로그인(login)은 형식 검증 없이
+ * 이메일로 조회만 하므로 {@code test} / {@code 1234} 로 그대로 로그인된다.
+ *
+ * <p>tenant PK 를 {@link #TENANT_ID} 로 고정하는 이유는 시나리오 발행 API 가 tenantId 를 직접 받기 때문이다.
+ * 값이 고정이라야 발표 중에 {@code /api/auth/me} 로 PK 를 확인하는 단계를 건너뛸 수 있다.
+ * PK 는 IDENTITY 라 JPA 로는 값을 지정할 수 없어 네이티브 INSERT 를 쓴다.
+ */
+@Component
+@ConditionalOnProperty(name = "edrdog.demo.seed", havingValue = "true")
+public class DemoAccountSeeder {
+
+    /**
+     * 발표 자료에 박아두는 고정 tenant PK. 가입으로 생기는 PK(1,2,3...)와 겹치지 않게 큰 값을 쓴다
+     * (같은 DB 에서 실제 조직과 공존시키기 위해서다).
+     */
+    public static final long TENANT_ID = 99L;
+
+    static final String EMAIL = "test";
+    static final String PASSWORD = "1234";
+    static final String TENANT_NAME = "데모 조직";
+    static final String ROLE = "admin";
+
+    private static final Logger log = LoggerFactory.getLogger(DemoAccountSeeder.class);
+
+    private final EntityManager em;
+    private final TenantRepository tenants;
+    private final UserRepository users;
+    private final BCryptPasswordEncoder encoder;
+
+    public DemoAccountSeeder(EntityManager em, TenantRepository tenants,
+                             UserRepository users, BCryptPasswordEncoder encoder) {
+        this.em = em;
+        this.tenants = tenants;
+        this.users = users;
+        this.encoder = encoder;
+    }
+
+    /**
+     * 데모 tenant 와 계정을 보장한다.
+     *
+     * @return 데모 tenant 를 우리가 쓰고 있으면 true. 다른 조직이 PK 를 선점했으면 false
+     *         (이 경우 호출자는 데이터 시드도 중단해야 한다. 남의 조직에 데모 데이터를 섞으면 안 된다)
+     */
+    @Transactional
+    public boolean seed() {
+        if (!ensureTenant()) {
+            return false;
+        }
+        ensureUser();
+        return true;
+    }
+
+    /**
+     * 데모 tenant 를 보장한다. 이미 PK 가 쓰이고 있으면 덮지 않는다.
+     *
+     * @return 계정을 붙여도 되는 상태면 true. 남의 조직이 PK 를 쓰고 있으면 false.
+     */
+    private boolean ensureTenant() {
+        Optional<Tenant> existing = tenants.findById(TENANT_ID);
+        if (existing.isEmpty()) {
+            em.createNativeQuery("INSERT INTO tenants (id, name, created_at) VALUES (:id, :name, :createdAt)")
+                    .setParameter("id", TENANT_ID)
+                    .setParameter("name", TENANT_NAME)
+                    .setParameter("createdAt", Timestamp.from(Instant.now()))
+                    .executeUpdate();
+            log.info("데모 tenant 생성: id={} name={}", TENANT_ID, TENANT_NAME);
+            return true;
+        }
+        if (!TENANT_NAME.equals(existing.get().getName())) {
+            log.warn("tenant {} 가 이미 다른 조직({})이라 데모 계정 시드를 건너뜁니다. 데모 DB 인지 확인하세요.",
+                    TENANT_ID, existing.get().getName());
+            return false;
+        }
+        return true;
+    }
+
+    /** 데모 계정을 보장한다. 이미 있으면 비밀번호를 덮지 않는다. */
+    private void ensureUser() {
+        if (users.existsByEmail(EMAIL)) {
+            log.info("데모 계정이 이미 있어 건너뜁니다: {}", EMAIL);
+            return;
+        }
+        users.save(AppUser.of(EMAIL, encoder.encode(PASSWORD), TENANT_ID, ROLE, Instant.now()));
+        log.info("데모 계정 생성: id={} / pw={} (tenantId={})", EMAIL, PASSWORD, TENANT_ID);
+    }
+}

--- a/api-service/src/main/java/com/edrdog/apiservice/demo/DemoData.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/demo/DemoData.java
@@ -1,0 +1,202 @@
+package com.edrdog.apiservice.demo;
+
+import com.edrdog.apiservice.alert.dto.Alert;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * 발표용 과거 데이터 생성 (순수 함수). 기준 시각 nowTs 를 받아 최근 {@link #DAYS} 일치를 결정적으로 만든다.
+ *
+ * <p>이 데이터는 Kafka 를 거치지 않고 저장소에 바로 적재된다(과거 시각으로는 detector 의 상관 윈도우가
+ * 성립하지 않기 때문). 실시간 시연은 detector 의 시나리오 발행 API 로 하고, 여기서는 "이미 운영 중이던
+ * 흔적"만 채운다.
+ *
+ * <p>화면이 골고루 차도록 다음을 보장한다.
+ * <ul>
+ *   <li>호스트 도넛: 위험/주의/정상이 모두 나오게 alert 없는 호스트({@link #QUIET_HOSTS})를 남긴다</li>
+ *   <li>severity 분포·카테고리 집계: 룰 4종과 심각도 3종을 모두 포함한다</li>
+ *   <li>lineage: alert 마다 같은 host 의 근거 이벤트를 같은 시각대에 함께 넣는다</li>
+ * </ul>
+ */
+public final class DemoData {
+
+    /** 과거 데이터를 채우는 기간(일). */
+    public static final int DAYS = 7;
+
+    /** alert 가 하나도 없는 정상 호스트. 도넛이 위험 색으로만 차는 걸 막는다. */
+    public static final List<String> QUIET_HOSTS = List.of("SRV-DB-01", "SRV-WEB-01");
+
+    /**
+     * 데모 데이터가 이미 적재됐는지 판별하는 대표 호스트. 이 호스트의 events 유무로 재적재를 결정한다.
+     * "events 가 하나라도 있으면 skip" 으로 하면 개발 중 남은 다른 이벤트에 가려 데모 데이터가 안 채워진다.
+     */
+    public static final String MARKER_HOST = "DESKTOP-KIM";
+
+    /** alert 가 있는 호스트. */
+    static final List<String> NOISY_HOSTS = List.of(MARKER_HOST, "DESKTOP-CHOI", "DESKTOP-LEE", "LAPTOP-PARK");
+
+    private static final long HOUR = 60 * 60 * 1000L;
+    private static final long MINUTE = 60 * 1000L;
+
+    /** 배경 소음용 정상 프로세스. 이것만 있는 호스트는 alert 가 안 생긴다. */
+    private static final List<String> BASELINE = List.of(
+            "chrome.exe", "explorer.exe", "svchost.exe", "Teams.exe", "Code.exe", "outlook.exe");
+
+    /** 배경 소음용 정상 목적지. */
+    private static final List<String> BASELINE_IPS = List.of("142.250.76.14", "20.42.65.92", "13.107.42.14");
+
+    /**
+     * 과거에 있었던 것으로 꾸밀 탐지 건. hoursAgo 는 nowTs 기준 몇 시간 전인지다.
+     * 최근일수록 촘촘하게 두어 "요즘 활발한 침해"처럼 보이게 한다.
+     */
+    private record Incident(String host, String ruleId, int hoursAgo) {
+    }
+
+    private static final List<Incident> INCIDENTS = List.of(
+            new Incident("DESKTOP-KIM", "DOWNLOAD_AND_EXECUTE", 2),
+            new Incident("DESKTOP-LEE", "SUSPICIOUS_PROCESS_CHAIN", 5),
+            new Incident("DESKTOP-KIM", "SUSPICIOUS_PROCESS_CHAIN", 9),
+            new Incident("LAPTOP-PARK", "SUSPICIOUS_PROCESS_CHAIN", 20),
+            new Incident("DESKTOP-CHOI", "DOWNLOAD_AND_EXECUTE", 26),
+            new Incident("DESKTOP-CHOI", "FILE_IN_AUTORUN_PATH", 27),
+            new Incident("LAPTOP-PARK", "SCRIPT_FROM_TEMP_PATH", 45),
+            new Incident("DESKTOP-LEE", "SCRIPT_FROM_TEMP_PATH", 52),
+            new Incident("LAPTOP-PARK", "FILE_IN_AUTORUN_PATH", 120),
+            new Incident("DESKTOP-KIM", "SCRIPT_FROM_TEMP_PATH", 150));
+
+    private DemoData() {
+    }
+
+    /** 관측 호스트 전체(alert 있는 호스트 + 정상 호스트). */
+    public static List<String> hosts() {
+        List<String> all = new ArrayList<>(NOISY_HOSTS);
+        all.addAll(QUIET_HOSTS);
+        return List.copyOf(all);
+    }
+
+    /** 과거 구간의 events. 배경 소음 + 각 탐지 건의 근거 이벤트를 함께 담는다. */
+    public static List<DemoEvent> events(String tenantId, long nowTs) {
+        List<DemoEvent> out = new ArrayList<>(baseline(tenantId, nowTs));
+        for (Incident incident : INCIDENTS) {
+            out.addAll(evidence(incident, tenantId, nowTs));
+        }
+        return List.copyOf(out);
+    }
+
+    /** 과거 구간의 alerts. 각 건의 마지막 근거 이벤트 시각을 판정 시각으로 쓴다(detector 와 동일). */
+    public static List<Alert> alerts(String tenantId, long nowTs) {
+        List<Alert> out = new ArrayList<>();
+        for (Incident incident : INCIDENTS) {
+            out.add(alertOf(incident, tenantId, nowTs));
+        }
+        return List.copyOf(out);
+    }
+
+    /** 모든 호스트에 6시간 간격으로 깔리는 평상시 활동. 호스트마다 분 단위로 어긋내 한 시각에 몰리지 않게 한다. */
+    private static List<DemoEvent> baseline(String tenantId, long nowTs) {
+        List<DemoEvent> out = new ArrayList<>();
+        List<String> hosts = hosts();
+        for (int h = 0; h < hosts.size(); h++) {
+            String host = hosts.get(h);
+            for (int hoursAgo = 6; hoursAgo < DAYS * 24; hoursAgo += 6) {
+                long ts = nowTs - hoursAgo * HOUR + h * MINUTE;
+                int seed = h + hoursAgo;
+                out.add(DemoEvent.of(host, tenantId, DemoEvent.TYPE_PROCESS, ts,
+                        pick(BASELINE, seed), "explorer.exe", "C:\\Program Files\\" + pick(BASELINE, seed)));
+                if (seed % 3 == 0) {
+                    out.add(DemoEvent.network(host, tenantId, ts + 30_000,
+                            pick(BASELINE, seed), pick(BASELINE_IPS, seed), 443));
+                }
+            }
+        }
+        return out;
+    }
+
+    /**
+     * 탐지 건의 근거 이벤트. detector 룰이 보는 패턴 그대로 만들어야 lineage 그래프가 자연스럽게 이어진다.
+     * 시퀀스 룰은 1초 간격 2건, point 룰은 1건이다.
+     */
+    private static List<DemoEvent> evidence(Incident incident, String tenantId, long nowTs) {
+        String host = incident.host();
+        long ts = nowTs - incident.hoursAgo() * HOUR;
+        return switch (incident.ruleId()) {
+            case "SUSPICIOUS_PROCESS_CHAIN" -> List.of(
+                    DemoEvent.of(host, tenantId, DemoEvent.TYPE_PROCESS, ts,
+                            "winword.exe", "explorer.exe", "\"C:\\docs\\invoice.docm\""),
+                    DemoEvent.of(host, tenantId, DemoEvent.TYPE_PROCESS, ts + 1000,
+                            "powershell.exe", "winword.exe", "powershell -enc SQBFAFgA..."));
+            case "DOWNLOAD_AND_EXECUTE" -> List.of(
+                    // network 이벤트에도 소유 프로세스를 담아야 lineage 가 process -> net 으로 이어진다
+                    DemoEvent.network(host, tenantId, ts, "chrome.exe", "185.220.101.5", 443),
+                    DemoEvent.of(host, tenantId, DemoEvent.TYPE_PROCESS, ts + 1000,
+                            "update32.exe", "explorer.exe", "C:\\Users\\Public\\update32.exe"));
+            case "SCRIPT_FROM_TEMP_PATH" -> List.of(
+                    DemoEvent.of(host, tenantId, DemoEvent.TYPE_SCRIPT, ts,
+                            "powershell.exe", "explorer.exe",
+                            "powershell -File C:\\Users\\victim\\Downloads\\setup.ps1"));
+            case "FILE_IN_AUTORUN_PATH" -> List.of(
+                    DemoEvent.of(host, tenantId, DemoEvent.TYPE_FILE, ts, "evil.lnk", "",
+                            "C:\\Users\\victim\\AppData\\Roaming\\Microsoft\\Windows"
+                                    + "\\Start Menu\\Programs\\Startup\\evil.lnk"));
+            default -> throw new IllegalStateException("근거 이벤트가 정의되지 않은 룰: " + incident.ruleId());
+        };
+    }
+
+    /** 근거 이벤트에서 alert 를 만든다. matched 문자열 형식은 detector 의 Rules.summary 와 맞춘다. */
+    private static Alert alertOf(Incident incident, String tenantId, long nowTs) {
+        List<DemoEvent> evidence = evidence(incident, tenantId, nowTs);
+        DemoEvent last = evidence.get(evidence.size() - 1);
+        String severity = severityOf(incident.ruleId());
+        return new Alert(
+                incident.host(),
+                incident.ruleId(),
+                mitreOf(incident.ruleId()),
+                severity,
+                actionFor(severity),
+                last.ts(),
+                evidence.stream().map(DemoData::summary).toList(),
+                tenantId);
+    }
+
+    /** detector Rules 의 심각도와 동일하게 맞춘다. */
+    private static String severityOf(String ruleId) {
+        return switch (ruleId) {
+            case "DOWNLOAD_AND_EXECUTE" -> "CRITICAL";
+            case "SUSPICIOUS_PROCESS_CHAIN" -> "HIGH";
+            default -> "MEDIUM";
+        };
+    }
+
+    /** detector dto Alert.actionFor 와 동일 규칙. */
+    private static String actionFor(String severity) {
+        return switch (severity) {
+            case "CRITICAL" -> "isolate";
+            case "HIGH" -> "kill";
+            default -> "notify";
+        };
+    }
+
+    private static String mitreOf(String ruleId) {
+        return switch (ruleId) {
+            case "DOWNLOAD_AND_EXECUTE" -> "T1105+T1204";
+            case "FILE_IN_AUTORUN_PATH" -> "T1547";
+            default -> "T1059";
+        };
+    }
+
+    /** detector Rules.summary 와 같은 형식의 판정 근거 한 줄. */
+    private static String summary(DemoEvent e) {
+        return switch (e.type()) {
+            case DemoEvent.TYPE_NETWORK -> "network " + e.destIp() + ":" + e.destPort();
+            case DemoEvent.TYPE_SCRIPT -> "script " + e.process() + " (" + e.cmdline() + ")";
+            case DemoEvent.TYPE_FILE -> "file " + e.cmdline();
+            default -> "process " + e.process() + " (parent " + e.parent() + ")";
+        };
+    }
+
+    /** 결정적 선택. 음수 seed 는 들어오지 않지만 방어적으로 절댓값을 쓴다. */
+    private static String pick(List<String> pool, int seed) {
+        return pool.get(Math.abs(seed) % pool.size());
+    }
+}

--- a/api-service/src/main/java/com/edrdog/apiservice/demo/DemoDataSeeder.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/demo/DemoDataSeeder.java
@@ -1,0 +1,96 @@
+package com.edrdog.apiservice.demo;
+
+import com.edrdog.apiservice.alert.AlertService;
+import com.edrdog.apiservice.alert.dto.Alert;
+import com.edrdog.apiservice.clickhouse.ClickHouseReader;
+import com.edrdog.apiservice.query.ClickHouseQuery;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * 발표용 과거 데이터를 부팅 시 채운다. {@code edrdog.demo.seed=true} 일 때만 빈으로 올라온다.
+ *
+ * <p>events(ClickHouse)와 alerts(MySQL)를 저장소에 직접 넣는다. Kafka 를 거치지 않는 이유는
+ * 과거 시각으로 발행하면 detector 의 event-time 윈도우가 성립하지 않아 판정이 안 나오기 때문이다.
+ * 실시간 시연은 detector 의 시나리오 발행 API 로 하고, 여기서는 배경만 만든다.
+ *
+ * <p>재적재 기준이 둘로 나뉜다. events 는 ClickHouse 가 emptyDir 라 파드 재시작으로 사라질 수 있어
+ * "비어 있으면 다시" 채우고, alerts 는 AlertService 가 결정적 id 로 멱등 적재하므로 매번 호출해도 안전하다.
+ *
+ * <p>시드 실패로 앱이 못 뜨면 발표 자체가 막히므로, 예외는 삼키고 경고만 남긴다.
+ */
+@Component
+@ConditionalOnProperty(name = "edrdog.demo.seed", havingValue = "true")
+public class DemoDataSeeder {
+
+    private static final Logger log = LoggerFactory.getLogger(DemoDataSeeder.class);
+
+    private static final String TENANT_ID = String.valueOf(DemoAccountSeeder.TENANT_ID);
+
+    private final DemoEventWriter writer;
+    private final ClickHouseReader reader;
+    private final AlertService alerts;
+    private final String table;
+
+    public DemoDataSeeder(DemoEventWriter writer, ClickHouseReader reader, AlertService alerts,
+                          @Value("${edrdog.clickhouse.table}") String table) {
+        this.writer = writer;
+        this.reader = reader;
+        this.alerts = alerts;
+        this.table = table;
+    }
+
+    /** 데모 tenant 가 확보된 뒤에만 호출해야 한다(DemoSeeder 가 순서를 지킨다). */
+    public void seed() {
+        long now = System.currentTimeMillis();
+        seedEvents(now);
+        seedAlerts(now);
+    }
+
+    /**
+     * 데모 events 가 없을 때만 채운다. ClickHouse 는 dedup 이 없어 두 번 넣으면 그대로 두 배가 된다.
+     * 판별은 대표 호스트({@link DemoData#MARKER_HOST}) 유무로 한다. 같은 tenant 에 개발 중 남은
+     * 다른 이벤트가 있어도 데모 데이터는 정상적으로 채워져야 하기 때문이다.
+     */
+    private void seedEvents(long now) {
+        try {
+            if (alreadySeeded()) {
+                log.info("데모 events 가 이미 있어 건너뜁니다 (tenantId={}, host={})",
+                        TENANT_ID, DemoData.MARKER_HOST);
+                return;
+            }
+            List<DemoEvent> events = DemoData.events(TENANT_ID, now);
+            writer.insert(events);
+            log.info("데모 events 적재: {}건 (최근 {}일, tenantId={})", events.size(), DemoData.DAYS, TENANT_ID);
+        } catch (Exception e) {
+            log.warn("데모 events 적재 실패. ClickHouse 상태를 확인하세요. 앱은 계속 뜹니다.", e);
+        }
+    }
+
+    /** 대표 호스트의 events 가 이미 있는지. */
+    private boolean alreadySeeded() {
+        ClickHouseQuery q = new ClickHouseQuery(
+                "SELECT count() AS cnt FROM " + table
+                        + " WHERE tenant_id = {tenantId:String} AND host = {host:String}",
+                Map.of("tenantId", TENANT_ID, "host", DemoData.MARKER_HOST));
+        List<Map<String, Object>> rows = reader.query(q);
+        return !rows.isEmpty() && Long.parseLong(String.valueOf(rows.get(0).get("cnt"))) > 0;
+    }
+
+    /** alerts 는 멱등 적재라 매번 호출해도 한 행만 남는다(트리아지한 status 도 보존된다). */
+    private void seedAlerts(long now) {
+        try {
+            List<Alert> demoAlerts = DemoData.alerts(TENANT_ID, now);
+            demoAlerts.forEach(alerts::ingest);
+            log.info("데모 alerts 적재: {}건 (tenantId={})", demoAlerts.size(), TENANT_ID);
+        } catch (Exception e) {
+            log.warn("데모 alerts 적재 실패. 앱은 계속 뜹니다.", e);
+        }
+    }
+}

--- a/api-service/src/main/java/com/edrdog/apiservice/demo/DemoEvent.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/demo/DemoEvent.java
@@ -1,0 +1,51 @@
+package com.edrdog.apiservice.demo;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * 데모 시드용 events 행. ClickHouse(edrdog.events) 컬럼과 1:1 로 맞춘 JSONEachRow 스키마다.
+ * archiver 의 EventRow 와 같은 모양이지만, 시드는 Kafka 를 거치지 않고 직접 적재하므로 여기 따로 둔다.
+ *
+ * @param host     엔드포인트 식별자
+ * @param tenantId 조직(tenant) 식별자 문자열 (조회 격리 키)
+ * @param type     process | network | file | script
+ * @param ts       발생 시각 (epoch millis)
+ * @param process  프로세스명/파일명
+ * @param parent   부모 프로세스명
+ * @param cmdline  명령행 (file/script 는 전체 경로)
+ * @param destIp   목적지 IP (network)
+ * @param destPort 목적지 포트 (network)
+ */
+public record DemoEvent(
+        @JsonProperty("host") String host,
+        @JsonProperty("tenant_id") String tenantId,
+        @JsonProperty("type") String type,
+        @JsonProperty("ts") long ts,
+        @JsonProperty("process") String process,
+        @JsonProperty("parent") String parent,
+        @JsonProperty("cmdline") String cmdline,
+        @JsonProperty("dest_ip") String destIp,
+        @JsonProperty("dest_port") int destPort
+) {
+
+    public static final String TYPE_PROCESS = "process";
+    public static final String TYPE_NETWORK = "network";
+    public static final String TYPE_FILE = "file";
+    public static final String TYPE_SCRIPT = "script";
+
+    /** process/script/file 계열 이벤트. ClickHouse 는 Nullable 이 아니므로 빈 문자열로 채운다. */
+    public static DemoEvent of(String host, String tenantId, String type, long ts,
+                               String process, String parent, String cmdline) {
+        return new DemoEvent(host, tenantId, type, ts, nz(process), nz(parent), nz(cmdline), "", 0);
+    }
+
+    /** network 이벤트. 소유 프로세스를 같이 담아야 lineage 가 process -> net 으로 이어진다. */
+    public static DemoEvent network(String host, String tenantId, long ts,
+                                    String process, String destIp, int destPort) {
+        return new DemoEvent(host, tenantId, TYPE_NETWORK, ts, nz(process), "", "", nz(destIp), destPort);
+    }
+
+    private static String nz(String v) {
+        return v == null ? "" : v;
+    }
+}

--- a/api-service/src/main/java/com/edrdog/apiservice/demo/DemoEventWriter.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/demo/DemoEventWriter.java
@@ -1,0 +1,74 @@
+package com.edrdog.apiservice.demo;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * 데모 시드 events 를 ClickHouse 에 직접 적재한다(쓰기). 평소 적재는 archiver 담당이고
+ * 여기는 발표용 과거 데이터 전용이라, 시드 플래그가 켜진 경우에만 빈으로 올라온다.
+ */
+@Component
+@ConditionalOnProperty(name = "edrdog.demo.seed", havingValue = "true")
+public class DemoEventWriter {
+
+    /** 한 번에 보내는 행 수. 수백 건 규모라 요청을 잘게 쪼개 본문이 커지는 걸 막는다. */
+    private static final int BATCH = 200;
+
+    private final RestClient client;
+    private final ObjectMapper mapper;
+    private final String table;
+
+    public DemoEventWriter(
+            @Value("${edrdog.clickhouse.url}") String url,
+            @Value("${edrdog.clickhouse.database}") String database,
+            @Value("${edrdog.clickhouse.user}") String user,
+            @Value("${edrdog.clickhouse.password}") String password,
+            @Value("${edrdog.clickhouse.table}") String table,
+            ObjectMapper mapper) {
+        this.table = table;
+        this.mapper = mapper;
+        this.client = RestClient.builder()
+                .baseUrl(url)
+                .defaultHeader("X-ClickHouse-User", user)
+                .defaultHeader("X-ClickHouse-Key", password)
+                .defaultHeader("X-ClickHouse-Database", database)
+                .build();
+    }
+
+    /** events 를 JSONEachRow 로 나눠 적재한다. */
+    public void insert(List<DemoEvent> events) {
+        for (int i = 0; i < events.size(); i += BATCH) {
+            List<DemoEvent> batch = events.subList(i, Math.min(i + BATCH, events.size()));
+            execute("INSERT INTO " + table + " FORMAT JSONEachRow\n" + toJsonLines(batch));
+        }
+    }
+
+    private String toJsonLines(List<DemoEvent> events) {
+        return events.stream().map(this::toJson).collect(Collectors.joining("\n"));
+    }
+
+    private String toJson(DemoEvent event) {
+        try {
+            return mapper.writeValueAsString(event);
+        } catch (JsonProcessingException e) {
+            throw new IllegalStateException("데모 이벤트 직렬화 실패: " + event, e);
+        }
+    }
+
+    private void execute(String sql) {
+        client.post()
+                .uri("/")
+                .contentType(MediaType.TEXT_PLAIN)
+                .body(sql)
+                .retrieve()
+                .toBodilessEntity();
+    }
+}

--- a/api-service/src/main/java/com/edrdog/apiservice/demo/DemoSeeder.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/demo/DemoSeeder.java
@@ -1,0 +1,39 @@
+package com.edrdog.apiservice.demo;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+/**
+ * 발표용 시드의 유일한 진입점. {@code edrdog.demo.seed=true} 일 때만 빈으로 올라온다.
+ *
+ * <p>계정과 데이터를 굳이 한 진입점으로 묶는 이유가 있다. 둘을 각각 ApplicationRunner 로 두면
+ * 계정 시드가 "이 tenant PK 는 남의 조직이라 건너뛴다" 고 판단해도 데이터 시드는 그걸 모른 채
+ * 그 조직에 데모 alert 를 밀어넣는다. tenant 확보에 실패하면 데이터도 넣지 않아야 한다.
+ */
+@Component
+@ConditionalOnProperty(name = "edrdog.demo.seed", havingValue = "true")
+public class DemoSeeder implements ApplicationRunner {
+
+    private static final Logger log = LoggerFactory.getLogger(DemoSeeder.class);
+
+    private final DemoAccountSeeder account;
+    private final DemoDataSeeder data;
+
+    public DemoSeeder(DemoAccountSeeder account, DemoDataSeeder data) {
+        this.account = account;
+        this.data = data;
+    }
+
+    @Override
+    public void run(ApplicationArguments args) {
+        if (!account.seed()) {
+            log.warn("데모 tenant 를 확보하지 못해 데이터 시드도 건너뜁니다. 남의 조직에 데모 데이터를 섞지 않습니다.");
+            return;
+        }
+        data.seed();
+    }
+}

--- a/api-service/src/main/resources/application.yml
+++ b/api-service/src/main/resources/application.yml
@@ -40,6 +40,10 @@ edrdog:
       key-alias: ${OSQUERY_TLS_KEY_ALIAS:osquery}
   api:
     key: ${EDRDOG_API_KEY:dev-api-key}   # 프론트가 X-API-Key 헤더로 보낼 값 (운영은 환경변수로 주입)
+  demo:
+    # 발표용 시드. 켜면 부팅 시 데모 계정(test/1234, tenantId=1)과 최근 7일치 과거 데이터를 만든다.
+    # 운영에 test/1234 가 새면 안 되므로 기본은 off. 발표 환경에서만 DEMO_SEED=true 로 켠다.
+    seed: ${DEMO_SEED:false}
   cors:
     # 브라우저에서 API 를 호출할 프론트 출처 (쉼표 구분). 기본값은 Vite dev 서버.
     # 배포 시엔 실제 프론트 도메인을 환경변수로 주입한다.

--- a/api-service/src/test/java/com/edrdog/apiservice/demo/DemoAccountSeederTest.java
+++ b/api-service/src/test/java/com/edrdog/apiservice/demo/DemoAccountSeederTest.java
@@ -1,0 +1,66 @@
+package com.edrdog.apiservice.demo;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * 시드 플래그를 켜고 전체 컨텍스트를 띄워, 부팅 직후 데모 계정으로 실제 로그인이 되는지 검증한다.
+ * tenant 는 네이티브 INSERT 로 넣기 때문에 컬럼명이 어긋나면 여기서 바로 드러난다(발표 당일 대신).
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.ANY)
+@TestPropertySource(properties = {
+        "spring.kafka.listener.auto-startup=false",
+        "edrdog.demo.seed=true"
+})
+class DemoAccountSeederTest {
+
+    private static final String LOGIN_BODY = "{\"email\":\"test\",\"password\":\"1234\"}";
+
+    @Autowired
+    private MockMvc mvc;
+
+    @Autowired
+    private DemoAccountSeeder seeder;
+
+    @Test
+    void 부팅_직후_test_1234_로_로그인되고_tenantId_는_고정값이다() throws Exception {
+        mvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(LOGIN_BODY))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.token").isNotEmpty())
+                .andExpect(jsonPath("$.email").value("test"))
+                .andExpect(jsonPath("$.tenantId").value((int) DemoAccountSeeder.TENANT_ID));
+    }
+
+    @Test
+    void 시더를_다시_돌려도_중복_없이_로그인이_유지된다() throws Exception {
+        seeder.seed();
+
+        mvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(LOGIN_BODY))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.tenantId").value((int) DemoAccountSeeder.TENANT_ID));
+    }
+
+    @Test
+    void 잘못된_비밀번호는_그대로_거부된다() throws Exception {
+        mvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"email\":\"test\",\"password\":\"wrong\"}"))
+                .andExpect(status().isUnauthorized());
+    }
+}

--- a/api-service/src/test/java/com/edrdog/apiservice/demo/DemoDataTest.java
+++ b/api-service/src/test/java/com/edrdog/apiservice/demo/DemoDataTest.java
@@ -1,0 +1,106 @@
+package com.edrdog.apiservice.demo;
+
+import com.edrdog.apiservice.alert.dto.Alert;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * 발표용 과거 데이터 생성(순수). nowTs 를 받아 결정적으로 만들고,
+ * 대시보드(호스트 도넛·severity 분포·카테고리)와 lineage 가 모두 채워지는 형태를 보장한다.
+ */
+class DemoDataTest {
+
+    private static final String TENANT = "1";
+    private static final long NOW = 1_770_000_000_000L;   // 고정 기준 시각 (결정성 확인용)
+
+    @Test
+    void 같은_입력이면_항상_같은_결과다() {
+        assertEquals(DemoData.events(TENANT, NOW), DemoData.events(TENANT, NOW));
+        assertEquals(DemoData.alerts(TENANT, NOW), DemoData.alerts(TENANT, NOW));
+    }
+
+    @Test
+    void 모든_이벤트와_알림이_지정_tenant_로_태깅된다() {
+        assertTrue(DemoData.events(TENANT, NOW).stream().allMatch(e -> TENANT.equals(e.tenantId())));
+        assertTrue(DemoData.alerts(TENANT, NOW).stream().allMatch(a -> TENANT.equals(a.tenantId())));
+    }
+
+    @Test
+    void 모든_시각이_과거_구간_안에_들어온다() {
+        long oldest = NOW - DemoData.DAYS * 24L * 60 * 60 * 1000;
+        assertTrue(DemoData.events(TENANT, NOW).stream().allMatch(e -> e.ts() > oldest && e.ts() <= NOW));
+        assertTrue(DemoData.alerts(TENANT, NOW).stream().allMatch(a -> a.ts() > oldest && a.ts() <= NOW));
+    }
+
+    @Test
+    void 네_종류_룰이_모두_나와_카테고리_집계가_채워진다() {
+        Set<String> ruleIds = DemoData.alerts(TENANT, NOW).stream()
+                .map(Alert::ruleId)
+                .collect(Collectors.toSet());
+        assertEquals(Set.of("SUSPICIOUS_PROCESS_CHAIN", "DOWNLOAD_AND_EXECUTE",
+                "SCRIPT_FROM_TEMP_PATH", "FILE_IN_AUTORUN_PATH"), ruleIds);
+    }
+
+    @Test
+    void severity_가_셋_다_나와_분포_차트가_채워진다() {
+        Set<String> severities = DemoData.alerts(TENANT, NOW).stream()
+                .map(Alert::severity)
+                .collect(Collectors.toSet());
+        assertEquals(Set.of("CRITICAL", "HIGH", "MEDIUM"), severities);
+    }
+
+    @Test
+    void action_은_severity_규칙과_일치한다() {
+        for (Alert a : DemoData.alerts(TENANT, NOW)) {
+            String expected = switch (a.severity()) {
+                case "CRITICAL" -> "isolate";
+                case "HIGH" -> "kill";
+                default -> "notify";
+            };
+            assertEquals(expected, a.action(), a.ruleId() + " 의 action");
+        }
+    }
+
+    @Test
+    void 조용한_호스트는_이벤트만_있고_알림은_없다() {
+        Set<String> alertedHosts = DemoData.alerts(TENANT, NOW).stream()
+                .map(Alert::host)
+                .collect(Collectors.toSet());
+        Set<String> eventHosts = DemoData.events(TENANT, NOW).stream()
+                .map(DemoEvent::host)
+                .collect(Collectors.toSet());
+
+        assertFalse(DemoData.QUIET_HOSTS.isEmpty(), "정상(초록) 호스트가 있어야 도넛이 한 색으로 안 쏠린다");
+        for (String quiet : DemoData.QUIET_HOSTS) {
+            assertTrue(eventHosts.contains(quiet), quiet + " 는 events 에 있어야 호스트 목록에 뜬다");
+            assertFalse(alertedHosts.contains(quiet), quiet + " 에는 alert 가 없어야 한다");
+        }
+    }
+
+    @Test
+    void 알림마다_같은_호스트_이벤트가_lineage_윈도우_안에_있다() {
+        List<DemoEvent> events = DemoData.events(TENANT, NOW);
+        long window = 5 * 60 * 1000L;   // AlertService.LINEAGE_WINDOW_MS 와 동일
+
+        for (Alert a : DemoData.alerts(TENANT, NOW)) {
+            boolean hasEvidence = events.stream().anyMatch(e ->
+                    e.host().equals(a.host())
+                            && e.ts() >= a.ts() - window
+                            && e.ts() <= a.ts() + window);
+            assertTrue(hasEvidence, a.host() + "/" + a.ruleId() + " 의 근거 이벤트가 윈도우 안에 없다");
+        }
+    }
+
+    @Test
+    void 알림에는_판정_근거가_붙어_상세화면이_비지_않는다() {
+        assertTrue(DemoData.alerts(TENANT, NOW).stream()
+                .allMatch(a -> a.matched() != null && !a.matched().isEmpty()));
+    }
+}

--- a/api-service/src/test/java/com/edrdog/apiservice/demo/DemoSeederTest.java
+++ b/api-service/src/test/java/com/edrdog/apiservice/demo/DemoSeederTest.java
@@ -1,0 +1,38 @@
+package com.edrdog.apiservice.demo;
+
+import org.junit.jupiter.api.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * 시드 순서 계약. 계정 시드가 tenant 를 확보하지 못하면 데이터 시드도 멈춰야 한다.
+ * 예전에 둘을 각각 ApplicationRunner 로 두어, 남의 조직이 tenant PK 를 쓰고 있는데도
+ * 데모 alert 가 그 조직에 적재된 적이 있다.
+ */
+class DemoSeederTest {
+
+    @Test
+    void tenant_확보에_실패하면_데이터를_넣지_않는다() {
+        DemoAccountSeeder account = mock(DemoAccountSeeder.class);
+        DemoDataSeeder data = mock(DemoDataSeeder.class);
+        when(account.seed()).thenReturn(false);
+
+        new DemoSeeder(account, data).run(null);
+
+        verify(data, never()).seed();
+    }
+
+    @Test
+    void tenant_를_확보하면_데이터도_넣는다() {
+        DemoAccountSeeder account = mock(DemoAccountSeeder.class);
+        DemoDataSeeder data = mock(DemoDataSeeder.class);
+        when(account.seed()).thenReturn(true);
+
+        new DemoSeeder(account, data).run(null);
+
+        verify(data).seed();
+    }
+}


### PR DESCRIPTION
## 무엇을

발표 시연용 데모 계정과 과거 데이터를 부팅 시 자동으로 채우는 시더를 추가했습니다.
로그인하면 대시보드가 이미 채워진 상태로 보이게 하고, 실시간 시연은 기존 detector 시나리오 API를 그대로 씁니다.

## 왜

- 신규 계정은 새 tenant라 데이터가 0이라 대시보드가 텅 빈 채로 발표가 시작됨
- signup API는 이메일 형식·비번 8자 이상을 요구해 `test`/`1234`로는 가입 불가 → 저장소에 직접 시드

## 변경

- **데모 계정**: `test` / `1234`, 고정 tenant PK `99` (가입 PK 1,2,3…과 충돌 안 나게 큰 값)
- **과거 데이터**: 최근 7일치 events(ClickHouse) + alerts(MySQL). 호스트 6대(위험/주의/정상 골고루), 룰 4종·심각도 3종, lineage 근거까지 채움
- **안전장치**:
  - `edrdog.demo.seed` 플래그, 기본 `false` (운영에 `test`/`1234` 유출 방지). 발표 환경만 `DEMO_SEED=true`
  - 계정·데이터를 `DemoSeeder` 한 진입점으로 묶어, tenant 확보 실패 시 데이터도 넣지 않음(남의 조직 오염 방지)
  - events는 없을 때만, alerts는 멱등 적재라 재부팅해도 안전
- 실시간 시연은 기존 `POST /api/events/scenario/{name}` 재사용 (신규 API 없음)

## 발표 사용법

1. api-service를 `DEMO_SEED=true`로 기동
2. `test` / `1234` 로그인 → 대시보드에 호스트·alert가 이미 보임
3. 실시간: detector Swagger에서 `POST /api/events/scenario/download-exec?tenantId=99` 발행 → 잠시 후 새 alert

## 검증

- 테스트 14개 통과 (DemoData 9, DemoAccountSeeder 3, DemoSeeder 2)
- 로컬 E2E: 로그인 → me → 호스트 도넛(정상2/주의2/위험2) → alert 집계·목록·lineage → 트리아지 → 미인증 401