### PR TITLE
feat: host 소유자 기반 per-user Slack 알림 라우팅 (#60)

### DIFF
--- a/alert-service/src/main/java/com/edrdog/alertservice/AlertListener.java
+++ b/alert-service/src/main/java/com/edrdog/alertservice/AlertListener.java
@@ -2,26 +2,33 @@ package com.edrdog.alertservice;
 
 import com.edrdog.alertservice.dto.Alert;
 import com.edrdog.alertservice.slack.SlackNotifier;
+import com.edrdog.alertservice.webhook.AlertRouter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
 
+import java.util.Optional;
+
 /**
- * alerts 토픽을 소비해 tenant 별 Slack 으로 알림을 보내는 리스너.
- * 같은 tenant+host+ruleId 는 쿨다운 창 안에서 중복 발송을 억제한다 (Slack 스팸 방지).
- * tenantId 없는 alert 는 webhook 조회가 불가능하므로 skip 한다.
+ * alerts 토픽을 소비해 host 소유 유저(없으면 tenant 관리자 채널)의 Slack 으로 알림을 보내는 리스너.
+ * 라우팅은 {@link AlertRouter} 가 결정하고, 같은 대상(user 또는 tenant)+host+ruleId 는
+ * 쿨다운 창 안에서 중복 발송을 억제한다 (Slack 스팸 방지).
+ * tenantId 없는 alert 는 목적지 조회가 불가능하므로 skip 한다.
  */
 @Component
 public class AlertListener {
 
     private static final Logger log = LoggerFactory.getLogger(AlertListener.class);
 
+    private final AlertRouter router;
     private final SlackNotifier slack;
     private final Cooldown cooldown;
 
-    public AlertListener(@Value("${edrdog.alert.cooldown-ms}") long cooldownMs, SlackNotifier slack) {
+    public AlertListener(@Value("${edrdog.alert.cooldown-ms}") long cooldownMs,
+                         AlertRouter router, SlackNotifier slack) {
+        this.router = router;
         this.slack = slack;
         this.cooldown = new Cooldown(cooldownMs);
     }
@@ -32,12 +39,18 @@ public class AlertListener {
             return;
         }
         if (alert.tenantId() == null) {
-            log.warn("tenantId 없는 alert → webhook 조회 불가로 skip (host={}, rule={})", alert.host(), alert.ruleId());
+            log.warn("tenantId 없는 alert → 목적지 조회 불가로 skip (host={}, rule={})", alert.host(), alert.ruleId());
             return;
         }
-        String key = alert.tenantId() + "|" + alert.host() + "|" + alert.ruleId();
+        Optional<AlertRouter.Route> route = router.route(alert);
+        if (route.isEmpty()) {
+            log.warn("목적지 미등록 → 발송 skip (tenant={}, host={}, rule={})",
+                    alert.tenantId(), alert.host(), alert.ruleId());
+            return;
+        }
+        String key = route.get().cooldownId() + "|" + alert.host() + "|" + alert.ruleId();
         if (cooldown.allow(key, alert.ts())) {
-            slack.send(alert);
+            slack.send(alert, route.get().webhookUrl());
         }
     }
 }

--- a/alert-service/src/main/java/com/edrdog/alertservice/slack/SlackNotifier.java
+++ b/alert-service/src/main/java/com/edrdog/alertservice/slack/SlackNotifier.java
@@ -1,7 +1,6 @@
 package com.edrdog.alertservice.slack;
 
 import com.edrdog.alertservice.dto.Alert;
-import com.edrdog.alertservice.webhook.TenantWebhookClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.MediaType;
@@ -9,12 +8,11 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
 
 import java.util.Map;
-import java.util.Optional;
 
 /**
- * alert 를 tenant 별 Slack Incoming Webhook 으로 전송한다.
- * tenantId 로 {@link TenantWebhookClient} 를 통해 webhook 을 조회하고,
- * 미등록(empty) 이면 발송을 건너뛴다. 메시지 포맷(format)은 순수 로직으로 분리해 단위 테스트한다.
+ * alert 를 지정된 Slack Incoming Webhook 으로 전송한다.
+ * 목적지(webhook) 결정은 {@link com.edrdog.alertservice.webhook.AlertRouter} 가 담당하고,
+ * 여기서는 받은 URL 로 POST 만 한다. 메시지 포맷(format)은 순수 로직으로 분리해 단위 테스트한다.
  */
 @Component
 public class SlackNotifier {
@@ -22,24 +20,16 @@ public class SlackNotifier {
     private static final Logger log = LoggerFactory.getLogger(SlackNotifier.class);
 
     private final RestClient client;
-    private final TenantWebhookClient webhooks;
 
-    public SlackNotifier(RestClient.Builder builder, TenantWebhookClient webhooks) {
+    public SlackNotifier(RestClient.Builder builder) {
         this.client = builder.build();
-        this.webhooks = webhooks;
     }
 
-    /** alert 를 tenant webhook 으로 전송. 미등록 시 경고 로그 후 skip. */
-    public void send(Alert alert) {
-        Optional<String> webhookUrl = webhooks.resolve(alert.tenantId());
-        if (webhookUrl.isEmpty()) {
-            log.warn("tenant webhook 미등록 → 발송 skip (tenant={}, host={}, rule={})",
-                    alert.tenantId(), alert.host(), alert.ruleId());
-            return;
-        }
+    /** alert 를 주어진 webhook URL 로 전송. 실패는 경고 로그만 남기고 삼킨다. */
+    public void send(Alert alert, String webhookUrl) {
         try {
             client.post()
-                    .uri(webhookUrl.get())
+                    .uri(webhookUrl)
                     .contentType(MediaType.APPLICATION_JSON)
                     .body(Map.of("text", format(alert)))
                     .retrieve()

--- a/alert-service/src/main/java/com/edrdog/alertservice/webhook/AlertRouter.java
+++ b/alert-service/src/main/java/com/edrdog/alertservice/webhook/AlertRouter.java
@@ -1,0 +1,39 @@
+package com.edrdog.alertservice.webhook;
+
+import com.edrdog.alertservice.dto.Alert;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+
+/**
+ * 탐지 alert 를 어디로 보낼지 결정한다.
+ * 1) host 소유 유저의 개인 webhook (per-user)
+ * 2) 없으면 tenant webhook (관리자 채널 fallback)
+ * 3) 둘 다 없으면 empty (발송 skip)
+ * cooldownId 는 중복 억제 단위를 구분한다: 유저 경로는 {@code user:{userId}}, fallback 은 {@code tenant:{tenantId}}.
+ */
+@Component
+public class AlertRouter {
+
+    private final HostTargetClient hostTargets;
+    private final TenantWebhookClient tenantWebhooks;
+
+    public AlertRouter(HostTargetClient hostTargets, TenantWebhookClient tenantWebhooks) {
+        this.hostTargets = hostTargets;
+        this.tenantWebhooks = tenantWebhooks;
+    }
+
+    /** alert 의 발송 대상을 해결. 유저 목적지 우선, 없으면 tenant fallback, 그것도 없으면 empty. */
+    public Optional<Route> route(Alert alert) {
+        Optional<HostTargetClient.Target> target = hostTargets.resolve(alert.tenantId(), alert.host());
+        if (target.isPresent()) {
+            return Optional.of(new Route(target.get().webhookUrl(), "user:" + target.get().userId()));
+        }
+        return tenantWebhooks.resolve(alert.tenantId())
+                .map(url -> new Route(url, "tenant:" + alert.tenantId()));
+    }
+
+    /** 발송 목적지 URL + 쿨다운 단위 식별자. */
+    public record Route(String webhookUrl, String cooldownId) {
+    }
+}

--- a/alert-service/src/main/java/com/edrdog/alertservice/webhook/HostTargetClient.java
+++ b/alert-service/src/main/java/com/edrdog/alertservice/webhook/HostTargetClient.java
@@ -1,0 +1,100 @@
+package com.edrdog.alertservice.webhook;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestClient;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * api-service 내부 엔드포인트로 host 소유 유저의 알림 목적지를 조회한다 (API 컴포지션).
+ * {@code GET {base}/api/internal/alert-target?tenantId={}&host={}}, 헤더 {@code X-Internal-Key}.
+ * {@link TenantWebhookClient} 와 같은 캐시 규칙: 확정 결과(200/404)만 짧은 TTL 로 캐시하고
+ * 일시 오류(api-service 다운 등)는 캐시하지 않아 다음 alert 때 재시도한다.
+ */
+@Component
+public class HostTargetClient {
+
+    private static final Logger log = LoggerFactory.getLogger(HostTargetClient.class);
+
+    private final RestClient client;
+    private final String internalKey;
+    private final long ttlMs;
+    private final Map<String, Cached> cache = new ConcurrentHashMap<>();
+
+    public HostTargetClient(
+            RestClient.Builder builder,
+            @Value("${edrdog.api.base-url:http://localhost:8084}") String baseUrl,
+            @Value("${edrdog.internal.key:dev-internal-key}") String internalKey,
+            @Value("${edrdog.api.webhook-cache-ttl-ms:60000}") long ttlMs) {
+        this.client = builder.baseUrl(baseUrl).build();
+        this.internalKey = internalKey;
+        this.ttlMs = ttlMs;
+    }
+
+    /** tenantId+host 의 소유 목적지를 조회. 소유자 없음/미설정은 empty. 확정 결과만 TTL 캐시. */
+    public Optional<Target> resolve(String tenantId, String host) {
+        if (tenantId == null || tenantId.isBlank() || host == null || host.isBlank()) {
+            return Optional.empty();
+        }
+        String key = tenantId + "|" + host;
+        long now = System.currentTimeMillis();
+        Cached cached = cache.get(key);
+        if (cached != null && now - cached.at() < ttlMs) {
+            return cached.value();
+        }
+        Fetched fetched = fetch(tenantId, host);
+        if (fetched.cacheable()) {
+            cache.put(key, new Cached(fetched.value(), now));
+        }
+        return fetched.value();
+    }
+
+    private Fetched fetch(String tenantId, String host) {
+        try {
+            TargetResponse resp = client.get()
+                    .uri(uriBuilder -> uriBuilder.path("/api/internal/alert-target")
+                            .queryParam("tenantId", tenantId)
+                            .queryParam("host", host)
+                            .build())
+                    .header("X-Internal-Key", internalKey)
+                    .retrieve()
+                    .body(TargetResponse.class);
+            return new Fetched(toTarget(resp), true);         // 200 → 확정, 캐시
+        } catch (HttpClientErrorException.NotFound e) {
+            return new Fetched(Optional.empty(), true);       // 404 → 소유자 없음 확정, 캐시
+        } catch (Exception e) {
+            log.warn("alert-target 조회 실패 (일시 오류로 보고 캐시 안 함) tenantId={} host={}: {}",
+                    tenantId, host, e.getMessage());
+            return new Fetched(Optional.empty(), false);      // 일시 오류 → 캐시 안 함(다음에 재시도)
+        }
+    }
+
+    /** 응답 → Target. 응답이 없거나 webhookUrl 이 비면 미설정(empty). */
+    static Optional<Target> toTarget(TargetResponse resp) {
+        if (resp == null || resp.webhookUrl() == null || resp.webhookUrl().isBlank()) {
+            return Optional.empty();
+        }
+        return Optional.of(new Target(resp.userId(), resp.webhookUrl()));
+    }
+
+    /** host 소유 유저의 목적지. */
+    public record Target(Long userId, String webhookUrl) {
+    }
+
+    /** 내부 엔드포인트 응답 스키마. 여분 필드는 무시. */
+    public record TargetResponse(Long userId, String webhookUrl) {
+    }
+
+    private record Cached(Optional<Target> value, long at) {
+    }
+
+    /** 조회 결과 + 캐시 가능 여부(확정 결과만 true). */
+    private record Fetched(Optional<Target> value, boolean cacheable) {
+    }
+}

--- a/alert-service/src/main/resources/application.yml
+++ b/alert-service/src/main/resources/application.yml
@@ -19,7 +19,7 @@ edrdog:
   kafka:
     alerts-topic: alerts        # detector 가 발행한 판정 결과 (소비 입력)
   alert:
-    cooldown-ms: 60000          # 같은 tenant+host+ruleId 중복 발송 억제 창
+    cooldown-ms: 60000          # 같은 대상(user 또는 tenant)+host+ruleId 중복 발송 억제 창
   api:
     base-url: ${EDRDOG_API_BASE_URL:http://localhost:8084}   # api-service 내부 엔드포인트 base
     webhook-cache-ttl-ms: 60000                              # tenant webhook 조회 캐시 TTL

--- a/alert-service/src/test/java/com/edrdog/alertservice/slack/SlackNotifierTest.java
+++ b/alert-service/src/test/java/com/edrdog/alertservice/slack/SlackNotifierTest.java
@@ -1,27 +1,21 @@
 package com.edrdog.alertservice.slack;
 
 import com.edrdog.alertservice.dto.Alert;
-import com.edrdog.alertservice.webhook.TenantWebhookClient;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.test.web.client.MockRestServiceServer;
 import org.springframework.web.client.RestClient;
 
 import java.util.List;
-import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 import static org.springframework.http.HttpMethod.POST;
-import static org.springframework.test.web.client.ExpectedCount.never;
 import static org.springframework.test.web.client.ExpectedCount.once;
-import static org.springframework.test.web.client.match.MockRestRequestMatchers.anything;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
 import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
 
-/** SlackNotifier: 메시지 포맷(순수) + tenant webhook 라우팅 검증. */
+/** SlackNotifier: 메시지 포맷(순수) + 주어진 webhook 으로 POST 검증. */
 class SlackNotifierTest {
 
     private Alert alert(String severity, String action) {
@@ -50,37 +44,20 @@ class SlackNotifierTest {
         assertThat(SlackNotifier.format(alert(Alert.SEV_MEDIUM, Alert.ACTION_NOTIFY))).startsWith("🟡");
     }
 
-    // --- 라우팅 ---
+    // --- 발송 ---
 
     @Test
-    @DisplayName("tenant webhook 이 있으면 그 URL 로 POST 한다")
-    void send_postsToResolvedWebhook() {
+    @DisplayName("주어진 webhook URL 로 POST 한다")
+    void send_postsToGivenWebhook() {
         RestClient.Builder builder = RestClient.builder();
         MockRestServiceServer server = MockRestServiceServer.bindTo(builder).build();
-        TenantWebhookClient webhooks = mock(TenantWebhookClient.class);
-        when(webhooks.resolve("t1")).thenReturn(Optional.of("https://hooks/abc"));
-        SlackNotifier notifier = new SlackNotifier(builder, webhooks);
+        SlackNotifier notifier = new SlackNotifier(builder);
 
         server.expect(once(), requestTo("https://hooks/abc"))
                 .andExpect(method(POST))
                 .andRespond(withSuccess());
 
-        notifier.send(alert(Alert.SEV_HIGH, Alert.ACTION_KILL));
-        server.verify();
-    }
-
-    @Test
-    @DisplayName("tenant webhook 이 미등록이면 발송하지 않는다 (skip)")
-    void send_skipsWhenUnregistered() {
-        RestClient.Builder builder = RestClient.builder();
-        MockRestServiceServer server = MockRestServiceServer.bindTo(builder).build();
-        TenantWebhookClient webhooks = mock(TenantWebhookClient.class);
-        when(webhooks.resolve("t1")).thenReturn(Optional.empty());
-        SlackNotifier notifier = new SlackNotifier(builder, webhooks);
-
-        server.expect(never(), anything());
-
-        notifier.send(alert(Alert.SEV_HIGH, Alert.ACTION_KILL));
+        notifier.send(alert(Alert.SEV_HIGH, Alert.ACTION_KILL), "https://hooks/abc");
         server.verify();
     }
 }

--- a/alert-service/src/test/java/com/edrdog/alertservice/webhook/AlertRouterTest.java
+++ b/alert-service/src/test/java/com/edrdog/alertservice/webhook/AlertRouterTest.java
@@ -1,0 +1,74 @@
+package com.edrdog.alertservice.webhook;
+
+import com.edrdog.alertservice.dto.Alert;
+import com.edrdog.alertservice.webhook.AlertRouter.Route;
+import com.edrdog.alertservice.webhook.HostTargetClient.Target;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/** AlertRouter: 유저 목적지 우선 → tenant fallback → skip 라우팅 결정. */
+class AlertRouterTest {
+
+    private HostTargetClient hostTargets;
+    private TenantWebhookClient tenantWebhooks;
+    private AlertRouter router;
+
+    @BeforeEach
+    void setUp() {
+        hostTargets = mock(HostTargetClient.class);
+        tenantWebhooks = mock(TenantWebhookClient.class);
+        router = new AlertRouter(hostTargets, tenantWebhooks);
+    }
+
+    private Alert alert() {
+        return new Alert("7", "host-1", "RULE", "T1059", "HIGH", "kill", 1_000, List.of("e"));
+    }
+
+    @Test
+    @DisplayName("host 소유 유저 목적지가 있으면 그 webhook + user 쿨다운 식별자")
+    void route_userTarget() {
+        when(hostTargets.resolve("7", "host-1")).thenReturn(Optional.of(new Target(10L, "https://hooks/u")));
+
+        Optional<Route> route = router.route(alert());
+
+        assertThat(route).contains(new Route("https://hooks/u", "user:10"));
+    }
+
+    @Test
+    @DisplayName("유저 목적지 없으면 tenant webhook + tenant 쿨다운 식별자 (관리자 fallback)")
+    void route_tenantFallback() {
+        when(hostTargets.resolve("7", "host-1")).thenReturn(Optional.empty());
+        when(tenantWebhooks.resolve("7")).thenReturn(Optional.of("https://hooks/admin"));
+
+        Optional<Route> route = router.route(alert());
+
+        assertThat(route).contains(new Route("https://hooks/admin", "tenant:7"));
+    }
+
+    @Test
+    @DisplayName("유저·tenant 목적지 모두 없으면 empty (skip)")
+    void route_none_empty() {
+        when(hostTargets.resolve("7", "host-1")).thenReturn(Optional.empty());
+        when(tenantWebhooks.resolve("7")).thenReturn(Optional.empty());
+
+        assertThat(router.route(alert())).isEmpty();
+    }
+
+    @Test
+    @DisplayName("유저 목적지가 있으면 tenant 조회는 하지 않는다")
+    void route_userTarget_skipsTenantLookup() {
+        when(hostTargets.resolve("7", "host-1")).thenReturn(Optional.of(new Target(10L, "https://hooks/u")));
+
+        router.route(alert());
+
+        org.mockito.Mockito.verifyNoInteractions(tenantWebhooks);
+    }
+}

--- a/alert-service/src/test/java/com/edrdog/alertservice/webhook/HostTargetClientTest.java
+++ b/alert-service/src/test/java/com/edrdog/alertservice/webhook/HostTargetClientTest.java
@@ -1,0 +1,111 @@
+package com.edrdog.alertservice.webhook;
+
+import com.edrdog.alertservice.webhook.HostTargetClient.Target;
+import com.edrdog.alertservice.webhook.HostTargetClient.TargetResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestClient;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.http.HttpMethod.GET;
+import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
+import static org.springframework.http.HttpStatus.NOT_FOUND;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.client.ExpectedCount.once;
+import static org.springframework.test.web.client.ExpectedCount.times;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.header;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withStatus;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+/** host 소유 목적지 조회 클라이언트: 응답 매핑(순수) + HTTP(404/성공/캐시) 검증. */
+class HostTargetClientTest {
+
+    private static final String BASE = "http://api";
+    private static final String KEY = "test-key";
+
+    // --- 순수 응답 매핑 ---
+
+    @Test
+    @DisplayName("null 응답은 empty")
+    void toTarget_null() {
+        assertThat(HostTargetClient.toTarget(null)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("webhookUrl 이 null 이면 empty")
+    void toTarget_nullUrl() {
+        assertThat(HostTargetClient.toTarget(new TargetResponse(10L, null))).isEmpty();
+    }
+
+    @Test
+    @DisplayName("userId+webhookUrl 이 있으면 Target 반환")
+    void toTarget_present() {
+        assertThat(HostTargetClient.toTarget(new TargetResponse(10L, "https://hooks/u")))
+                .contains(new Target(10L, "https://hooks/u"));
+    }
+
+    // --- HTTP ---
+
+    @Test
+    @DisplayName("404(소유자 없음) 는 empty, tenantId+host 를 쿼리로 GET")
+    void resolve_notFound_empty() {
+        RestClient.Builder builder = RestClient.builder();
+        MockRestServiceServer server = MockRestServiceServer.bindTo(builder).build();
+        HostTargetClient client = new HostTargetClient(builder, BASE, KEY, 60_000);
+
+        server.expect(once(), requestTo(BASE + "/api/internal/alert-target?tenantId=7&host=host-1"))
+                .andExpect(method(GET))
+                .andExpect(header("X-Internal-Key", KEY))
+                .andRespond(withStatus(NOT_FOUND));
+
+        assertThat(client.resolve("7", "host-1")).isEmpty();
+        server.verify();
+    }
+
+    @Test
+    @DisplayName("200 이면 Target 반환")
+    void resolve_ok_returnsTarget() {
+        RestClient.Builder builder = RestClient.builder();
+        MockRestServiceServer server = MockRestServiceServer.bindTo(builder).build();
+        HostTargetClient client = new HostTargetClient(builder, BASE, KEY, 60_000);
+
+        server.expect(once(), requestTo(BASE + "/api/internal/alert-target?tenantId=7&host=host-1"))
+                .andRespond(withSuccess("{\"userId\":10,\"webhookUrl\":\"https://hooks/u\"}", APPLICATION_JSON));
+
+        assertThat(client.resolve("7", "host-1")).contains(new Target(10L, "https://hooks/u"));
+        server.verify();
+    }
+
+    @Test
+    @DisplayName("404 는 캐시 → 두 번 조회해도 HTTP 1회")
+    void resolve_notFound_cached() {
+        RestClient.Builder builder = RestClient.builder();
+        MockRestServiceServer server = MockRestServiceServer.bindTo(builder).build();
+        HostTargetClient client = new HostTargetClient(builder, BASE, KEY, 60_000);
+
+        server.expect(once(), requestTo(BASE + "/api/internal/alert-target?tenantId=7&host=host-1"))
+                .andRespond(withStatus(NOT_FOUND));
+
+        assertThat(client.resolve("7", "host-1")).isEmpty();
+        assertThat(client.resolve("7", "host-1")).isEmpty();
+        server.verify();
+    }
+
+    @Test
+    @DisplayName("일시 오류(5xx)는 캐시 안 함 → 재시도(HTTP 2회)")
+    void resolve_transientError_notCached() {
+        RestClient.Builder builder = RestClient.builder();
+        MockRestServiceServer server = MockRestServiceServer.bindTo(builder).build();
+        HostTargetClient client = new HostTargetClient(builder, BASE, KEY, 60_000);
+
+        server.expect(times(2), requestTo(BASE + "/api/internal/alert-target?tenantId=7&host=host-1"))
+                .andRespond(withStatus(INTERNAL_SERVER_ERROR));
+
+        assertThat(client.resolve("7", "host-1")).isEmpty();
+        assertThat(client.resolve("7", "host-1")).isEmpty();
+        server.verify();
+    }
+}

--- a/api-service/src/main/java/com/edrdog/apiservice/auth/domain/AppUser.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/auth/domain/AppUser.java
@@ -35,6 +35,9 @@ public class AppUser {
     @Column(nullable = false)
     private Instant createdAt;
 
+    @Column
+    private String slackWebhookUrl;   // 유저 개인 알림 목적지 (자기 소유 host 탐지 알림 수신)
+
     protected AppUser() {
     }
 
@@ -72,5 +75,14 @@ public class AppUser {
 
     public Instant getCreatedAt() {
         return createdAt;
+    }
+
+    public String getSlackWebhookUrl() {
+        return slackWebhookUrl;
+    }
+
+    /** 개인 Slack webhook URL 을 갱신한다. */
+    public void updateWebhook(String url) {
+        this.slackWebhookUrl = url;
     }
 }

--- a/api-service/src/main/java/com/edrdog/apiservice/notify/AlertTarget.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/notify/AlertTarget.java
@@ -1,0 +1,7 @@
+package com.edrdog.apiservice.notify;
+
+/**
+ * host 소유 유저의 알림 목적지. resolveTarget 결과이자 내부 라우팅 엔드포인트 응답의 원본.
+ */
+public record AlertTarget(Long userId, String webhookUrl) {
+}

--- a/api-service/src/main/java/com/edrdog/apiservice/notify/UserNotifyService.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/notify/UserNotifyService.java
@@ -1,0 +1,107 @@
+package com.edrdog.apiservice.notify;
+
+import com.edrdog.apiservice.auth.domain.AppUser;
+import com.edrdog.apiservice.auth.exception.AuthException;
+import com.edrdog.apiservice.auth.repository.UserRepository;
+import com.edrdog.apiservice.notify.domain.HostOwner;
+import com.edrdog.apiservice.notify.repository.HostOwnerRepository;
+import com.edrdog.apiservice.tenant.WebhookValidation;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * 유저 개인 알림 설정: 개인 Slack webhook 등록/조회, 소유 host 등록/조회/해제,
+ * 그리고 탐지 알림의 라우팅 대상(host 소유자의 목적지) 해결.
+ * 검증 실패 400 / 없음 404 / 소유 충돌 409 는 AuthException 으로 던져 전역 핸들러가 매핑한다.
+ */
+@Service
+public class UserNotifyService {
+
+    private final UserRepository users;
+    private final HostOwnerRepository hostOwners;
+
+    public UserNotifyService(UserRepository users, HostOwnerRepository hostOwners) {
+        this.users = users;
+        this.hostOwners = hostOwners;
+    }
+
+    /** 개인 webhook 등록/갱신. URL 검증 실패 400, 유저 없음 404. */
+    @Transactional
+    public void setWebhook(Long userId, String url) {
+        if (!WebhookValidation.valid(url)) {
+            throw AuthException.invalidInput("webhook URL 은 https:// 로 시작해야 합니다");
+        }
+        AppUser user = user(userId);
+        user.updateWebhook(url);
+        users.save(user);
+    }
+
+    /** 개인 webhook 조회. 유저 없음 404, 미설정이면 빈 Optional. */
+    @Transactional(readOnly = true)
+    public Optional<String> getWebhook(Long userId) {
+        return Optional.ofNullable(user(userId).getSlackWebhookUrl());
+    }
+
+    /**
+     * 소유 host 등록. 이미 내가 소유면 멱등(no-op), 같은 tenant 안에서 다른 유저가 소유 중이면 409.
+     * host blank 400.
+     */
+    @Transactional
+    public void registerHost(Long tenantId, Long userId, String host) {
+        if (host == null || host.isBlank()) {
+            throw AuthException.invalidInput("host 는 비어 있을 수 없습니다");
+        }
+        Optional<HostOwner> existing = hostOwners.findByTenantIdAndHost(tenantId, host);
+        if (existing.isPresent()) {
+            if (!existing.get().getUserId().equals(userId)) {
+                throw AuthException.duplicate("이미 다른 유저가 소유한 host 입니다");
+            }
+            return;   // 이미 내 것 → 멱등
+        }
+        try {
+            hostOwners.save(HostOwner.of(tenantId, host, userId, Instant.now()));
+        } catch (DataIntegrityViolationException e) {
+            // find 통과 후 동시 요청이 unique(tenantId, host) 를 밟은 경우 → 409
+            throw AuthException.duplicate("이미 다른 유저가 소유한 host 입니다");
+        }
+    }
+
+    /** 내가 소유한 host 목록. */
+    @Transactional(readOnly = true)
+    public List<String> listHosts(Long userId) {
+        return hostOwners.findByUserId(userId).stream()
+                .map(HostOwner::getHost)
+                .toList();
+    }
+
+    /** 소유 host 해제. 내 host 가 아니면(미등록 포함) 404. */
+    @Transactional
+    public void unregisterHost(Long tenantId, Long userId, String host) {
+        HostOwner owner = hostOwners.findByTenantIdAndHost(tenantId, host)
+                .filter(o -> o.getUserId().equals(userId))
+                .orElseThrow(() -> AuthException.notFound("등록된 내 host 가 아닙니다"));
+        hostOwners.delete(owner);
+    }
+
+    /**
+     * 탐지 알림 라우팅 대상 해결: host 소유자의 개인 webhook.
+     * 소유자 없거나 소유자가 webhook 미설정이면 empty(호출측이 관리자 채널로 fallback 하도록).
+     */
+    @Transactional(readOnly = true)
+    public Optional<AlertTarget> resolveTarget(Long tenantId, String host) {
+        return hostOwners.findByTenantIdAndHost(tenantId, host)
+                .flatMap(owner -> users.findById(owner.getUserId())
+                        .filter(u -> u.getSlackWebhookUrl() != null && !u.getSlackWebhookUrl().isBlank())
+                        .map(u -> new AlertTarget(owner.getUserId(), u.getSlackWebhookUrl())));
+    }
+
+    private AppUser user(Long userId) {
+        return users.findById(userId)
+                .orElseThrow(() -> AuthException.notFound("유저를 찾을 수 없습니다"));
+    }
+}

--- a/api-service/src/main/java/com/edrdog/apiservice/notify/domain/HostOwner.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/notify/domain/HostOwner.java
@@ -1,0 +1,70 @@
+package com.edrdog.apiservice.notify.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+
+import java.time.Instant;
+
+/**
+ * host(엔드포인트) 소유권. 탐지 알림을 그 host 소유 유저의 개인 목적지로 라우팅하기 위한 매핑이다.
+ * 같은 tenant 안에서 host 는 소유자 1명(unique(tenantId, host)). 유저가 자기 host 를 등록한다.
+ */
+@Entity
+@Table(name = "host_owners", uniqueConstraints = @UniqueConstraint(columnNames = {"tenant_id", "host"}))
+public class HostOwner {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "tenant_id", nullable = false)
+    private Long tenantId;
+
+    @Column(nullable = false)
+    private String host;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(name = "created_at", nullable = false)
+    private Instant createdAt;
+
+    protected HostOwner() {
+    }
+
+    private HostOwner(Long tenantId, String host, Long userId, Instant createdAt) {
+        this.tenantId = tenantId;
+        this.host = host;
+        this.userId = userId;
+        this.createdAt = createdAt;
+    }
+
+    public static HostOwner of(Long tenantId, String host, Long userId, Instant createdAt) {
+        return new HostOwner(tenantId, host, userId, createdAt);
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Long getTenantId() {
+        return tenantId;
+    }
+
+    public String getHost() {
+        return host;
+    }
+
+    public Long getUserId() {
+        return userId;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+}

--- a/api-service/src/main/java/com/edrdog/apiservice/notify/repository/HostOwnerRepository.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/notify/repository/HostOwnerRepository.java
@@ -1,0 +1,14 @@
+package com.edrdog.apiservice.notify.repository;
+
+import com.edrdog.apiservice.notify.domain.HostOwner;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface HostOwnerRepository extends JpaRepository<HostOwner, Long> {
+
+    Optional<HostOwner> findByTenantIdAndHost(Long tenantId, String host);
+
+    List<HostOwner> findByUserId(Long userId);
+}

--- a/api-service/src/main/java/com/edrdog/apiservice/notify/web/HostRequest.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/notify/web/HostRequest.java
@@ -1,0 +1,5 @@
+package com.edrdog.apiservice.notify.web;
+
+/** 소유 host 등록 요청 본문. */
+public record HostRequest(String host) {
+}

--- a/api-service/src/main/java/com/edrdog/apiservice/notify/web/HostsResponse.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/notify/web/HostsResponse.java
@@ -1,0 +1,7 @@
+package com.edrdog.apiservice.notify.web;
+
+import java.util.List;
+
+/** 내가 소유한 host 목록 응답. */
+public record HostsResponse(List<String> hosts) {
+}

--- a/api-service/src/main/java/com/edrdog/apiservice/notify/web/UserNotifyController.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/notify/web/UserNotifyController.java
@@ -1,0 +1,117 @@
+package com.edrdog.apiservice.notify.web;
+
+import com.edrdog.apiservice.auth.exception.AuthException;
+import com.edrdog.apiservice.auth.service.AuthService;
+import com.edrdog.apiservice.auth.service.Principal;
+import com.edrdog.apiservice.notify.AlertTarget;
+import com.edrdog.apiservice.notify.UserNotifyService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 유저 개인 알림 설정. host 소유 유저에게 개별로 탐지 알림을 보내기 위한 관리 API.
+ * /api/me/** 은 로그인 유저(Bearer)가 자기 것만 다룬다.
+ * /api/internal/alert-target 은 alert-service 가 host 소유자 목적지를 조회하는 서비스 간 경로(X-Internal-Key).
+ */
+@RestController
+@Tag(name = "me", description = "유저 개인 알림 목적지·host 소유 등록")
+public class UserNotifyController {
+
+    private static final String BEARER_PREFIX = "Bearer ";
+
+    private final UserNotifyService notify;
+    private final AuthService auth;
+    private final String internalKey;
+
+    public UserNotifyController(UserNotifyService notify, AuthService auth,
+                               @Value("${edrdog.internal.key}") String internalKey) {
+        this.notify = notify;
+        this.auth = auth;
+        this.internalKey = internalKey;
+    }
+
+    @Operation(summary = "내 webhook 등록", description = "로그인 유저의 개인 Slack webhook URL 을 저장한다.")
+    @PutMapping("/api/me/webhook")
+    public UserWebhookResponse setWebhook(
+            @RequestHeader(name = "Authorization", required = false) String authorization,
+            @RequestBody UserWebhookRequest req) {
+        Principal p = principal(authorization);
+        notify.setWebhook(p.userId(), req.webhookUrl());
+        return new UserWebhookResponse(p.userId(), req.webhookUrl());
+    }
+
+    @Operation(summary = "내 webhook 조회", description = "로그인 유저의 개인 Slack webhook URL 을 조회한다. 미설정이면 null.")
+    @GetMapping("/api/me/webhook")
+    public UserWebhookResponse getWebhook(
+            @RequestHeader(name = "Authorization", required = false) String authorization) {
+        Principal p = principal(authorization);
+        return new UserWebhookResponse(p.userId(), notify.getWebhook(p.userId()).orElse(null));
+    }
+
+    @Operation(summary = "내 host 등록", description = "로그인 유저가 소유한 host 를 등록한다. 그 host 탐지 알림이 내 webhook 으로 온다.")
+    @PostMapping("/api/me/hosts")
+    public ResponseEntity<HostsResponse> registerHost(
+            @RequestHeader(name = "Authorization", required = false) String authorization,
+            @RequestBody HostRequest req) {
+        Principal p = principal(authorization);
+        notify.registerHost(p.tenantId(), p.userId(), req.host());
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(new HostsResponse(notify.listHosts(p.userId())));
+    }
+
+    @Operation(summary = "내 host 목록", description = "로그인 유저가 소유 등록한 host 목록을 조회한다.")
+    @GetMapping("/api/me/hosts")
+    public HostsResponse listHosts(
+            @RequestHeader(name = "Authorization", required = false) String authorization) {
+        Principal p = principal(authorization);
+        return new HostsResponse(notify.listHosts(p.userId()));
+    }
+
+    @Operation(summary = "내 host 해제", description = "로그인 유저가 소유 등록한 host 를 해제한다.")
+    @DeleteMapping("/api/me/hosts/{host}")
+    public ResponseEntity<Void> unregisterHost(
+            @RequestHeader(name = "Authorization", required = false) String authorization,
+            @PathVariable String host) {
+        Principal p = principal(authorization);
+        notify.unregisterHost(p.tenantId(), p.userId(), host);
+        return ResponseEntity.noContent().build();
+    }
+
+    @Operation(summary = "내부 라우팅 대상 조회",
+            description = "서비스 간 조회용(X-Internal-Key). 지정 tenant+host 의 소유 유저 목적지를 조회한다. 소유자 없거나 미설정이면 404.")
+    @GetMapping("/api/internal/alert-target")
+    public AlertTarget getAlertTarget(
+            @RequestParam Long tenantId,
+            @RequestParam String host,
+            @RequestHeader(name = "X-Internal-Key", required = false) String internalKeyHeader) {
+        if (internalKeyHeader == null || !internalKey.equals(internalKeyHeader)) {
+            throw AuthException.unauthorized("유효한 X-Internal-Key 가 필요합니다");
+        }
+        return notify.resolveTarget(tenantId, host)
+                .orElseThrow(() -> AuthException.notFound("host 소유 목적지가 없습니다"));
+    }
+
+    private Principal principal(String authorization) {
+        return auth.resolve(bearerToken(authorization));
+    }
+
+    /** "Bearer " 접두어를 떼서 토큰만 반환. 없으면 null. */
+    private static String bearerToken(String authorization) {
+        if (authorization == null || !authorization.startsWith(BEARER_PREFIX)) {
+            return null;
+        }
+        return authorization.substring(BEARER_PREFIX.length()).trim();
+    }
+}

--- a/api-service/src/main/java/com/edrdog/apiservice/notify/web/UserWebhookRequest.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/notify/web/UserWebhookRequest.java
@@ -1,0 +1,5 @@
+package com.edrdog.apiservice.notify.web;
+
+/** 개인 webhook 등록 요청 본문. */
+public record UserWebhookRequest(String webhookUrl) {
+}

--- a/api-service/src/main/java/com/edrdog/apiservice/notify/web/UserWebhookResponse.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/notify/web/UserWebhookResponse.java
@@ -1,0 +1,5 @@
+package com.edrdog.apiservice.notify.web;
+
+/** 개인 webhook 조회/등록 응답. webhookUrl 은 미설정 시 null. */
+public record UserWebhookResponse(Long userId, String webhookUrl) {
+}

--- a/api-service/src/main/java/com/edrdog/apiservice/security/ApiKeyPolicy.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/security/ApiKeyPolicy.java
@@ -15,6 +15,7 @@ public class ApiKeyPolicy {
             "/api/events",  // 조회는 세션 Bearer 로 인증하고 tenant 를 뽑는다(EventQueryController)
             "/api/alerts",  // 알림 조회·트리아지도 세션 Bearer 로 인증(AlertController)
             "/api/hosts",   // 호스트 목록·요약도 세션 Bearer 로 인증(HostController)
+            "/api/me",      // 유저 개인 알림 설정도 세션 Bearer 로 인증(UserNotifyController)
             "/api/internal/",  // 서비스 간 조회는 별도 X-Internal-Key 로 인증(TenantController), 프론트 키와 분리
             "/api/osquery/"  // 엔드포인트 수집은 자체 enroll_secret/node_key 로 인증(OsqueryController), 프론트 키와 분리
     );

--- a/api-service/src/test/java/com/edrdog/apiservice/notify/UserNotifyServiceTest.java
+++ b/api-service/src/test/java/com/edrdog/apiservice/notify/UserNotifyServiceTest.java
@@ -1,0 +1,202 @@
+package com.edrdog.apiservice.notify;
+
+import com.edrdog.apiservice.auth.domain.AppUser;
+import com.edrdog.apiservice.auth.exception.AuthException;
+import com.edrdog.apiservice.auth.repository.UserRepository;
+import com.edrdog.apiservice.notify.domain.HostOwner;
+import com.edrdog.apiservice.notify.repository.HostOwnerRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * UserNotifyService: 리포지토리는 목킹, WebhookValidation 은 실제 사용.
+ */
+class UserNotifyServiceTest {
+
+    private UserRepository users;
+    private HostOwnerRepository hostOwners;
+    private UserNotifyService service;
+
+    @BeforeEach
+    void setUp() {
+        users = mock(UserRepository.class);
+        hostOwners = mock(HostOwnerRepository.class);
+        service = new UserNotifyService(users, hostOwners);
+    }
+
+    private static AppUser newUser(Long tenantId) {
+        return AppUser.of("u@e.com", "hash", tenantId, "admin", Instant.now());
+    }
+
+    // --- webhook ---
+
+    @Test
+    @DisplayName("setWebhook: 유효 URL 이면 유저에 저장")
+    void setWebhook_valid_saves() {
+        AppUser u = newUser(1L);
+        when(users.findById(10L)).thenReturn(Optional.of(u));
+
+        service.setWebhook(10L, "https://hooks.slack.com/services/x");
+
+        assertEquals("https://hooks.slack.com/services/x", u.getSlackWebhookUrl());
+        verify(users).save(any(AppUser.class));
+    }
+
+    @Test
+    @DisplayName("setWebhook: https 아니면 400")
+    void setWebhook_invalid_400() {
+        AuthException e = assertThrows(AuthException.class, () -> service.setWebhook(10L, "http://no"));
+        assertEquals(AuthException.Kind.INVALID_INPUT, e.getKind());
+    }
+
+    @Test
+    @DisplayName("setWebhook: 유저 없으면 404")
+    void setWebhook_noUser_404() {
+        when(users.findById(99L)).thenReturn(Optional.empty());
+        AuthException e = assertThrows(AuthException.class,
+                () -> service.setWebhook(99L, "https://hooks.slack.com/x"));
+        assertEquals(AuthException.Kind.NOT_FOUND, e.getKind());
+    }
+
+    @Test
+    @DisplayName("getWebhook: 미설정이면 empty")
+    void getWebhook_unset_empty() {
+        when(users.findById(10L)).thenReturn(Optional.of(newUser(1L)));
+        assertThat(service.getWebhook(10L)).isEmpty();
+    }
+
+    // --- host 등록 ---
+
+    @Test
+    @DisplayName("registerHost: 미소유 host 면 저장")
+    void registerHost_new_saves() {
+        when(hostOwners.findByTenantIdAndHost(1L, "host-1")).thenReturn(Optional.empty());
+
+        service.registerHost(1L, 10L, "host-1");
+
+        verify(hostOwners).save(any(HostOwner.class));
+    }
+
+    @Test
+    @DisplayName("registerHost: 이미 내가 소유면 멱등(중복 저장 안 함)")
+    void registerHost_alreadyMine_idempotent() {
+        when(hostOwners.findByTenantIdAndHost(1L, "host-1"))
+                .thenReturn(Optional.of(HostOwner.of(1L, "host-1", 10L, Instant.now())));
+
+        service.registerHost(1L, 10L, "host-1");
+
+        verify(hostOwners, never()).save(any(HostOwner.class));
+    }
+
+    @Test
+    @DisplayName("registerHost: 다른 유저가 소유 중이면 409")
+    void registerHost_ownedByOther_409() {
+        when(hostOwners.findByTenantIdAndHost(1L, "host-1"))
+                .thenReturn(Optional.of(HostOwner.of(1L, "host-1", 99L, Instant.now())));
+
+        AuthException e = assertThrows(AuthException.class,
+                () -> service.registerHost(1L, 10L, "host-1"));
+        assertEquals(AuthException.Kind.DUPLICATE, e.getKind());
+    }
+
+    @Test
+    @DisplayName("registerHost: find 통과 후 동시 insert 가 unique 제약을 밟으면 409")
+    void registerHost_raceOnUnique_409() {
+        when(hostOwners.findByTenantIdAndHost(1L, "host-1")).thenReturn(Optional.empty());
+        when(hostOwners.save(any(HostOwner.class)))
+                .thenThrow(new org.springframework.dao.DataIntegrityViolationException("dup"));
+
+        AuthException e = assertThrows(AuthException.class,
+                () -> service.registerHost(1L, 10L, "host-1"));
+        assertEquals(AuthException.Kind.DUPLICATE, e.getKind());
+    }
+
+    @Test
+    @DisplayName("registerHost: host 가 blank 면 400")
+    void registerHost_blank_400() {
+        AuthException e = assertThrows(AuthException.class,
+                () -> service.registerHost(1L, 10L, "  "));
+        assertEquals(AuthException.Kind.INVALID_INPUT, e.getKind());
+    }
+
+    @Test
+    @DisplayName("listHosts: 내 host 목록 반환")
+    void listHosts_returnsHosts() {
+        when(hostOwners.findByUserId(10L)).thenReturn(List.of(
+                HostOwner.of(1L, "host-a", 10L, Instant.now()),
+                HostOwner.of(1L, "host-b", 10L, Instant.now())));
+
+        assertThat(service.listHosts(10L)).containsExactly("host-a", "host-b");
+    }
+
+    @Test
+    @DisplayName("unregisterHost: 내 host 면 삭제")
+    void unregisterHost_mine_deletes() {
+        HostOwner owned = HostOwner.of(1L, "host-1", 10L, Instant.now());
+        when(hostOwners.findByTenantIdAndHost(1L, "host-1")).thenReturn(Optional.of(owned));
+
+        service.unregisterHost(1L, 10L, "host-1");
+
+        verify(hostOwners).delete(owned);
+    }
+
+    @Test
+    @DisplayName("unregisterHost: 내 host 아니면 404")
+    void unregisterHost_notMine_404() {
+        when(hostOwners.findByTenantIdAndHost(1L, "host-1"))
+                .thenReturn(Optional.of(HostOwner.of(1L, "host-1", 99L, Instant.now())));
+
+        AuthException e = assertThrows(AuthException.class,
+                () -> service.unregisterHost(1L, 10L, "host-1"));
+        assertEquals(AuthException.Kind.NOT_FOUND, e.getKind());
+    }
+
+    // --- 라우팅 대상 해결 ---
+
+    @Test
+    @DisplayName("resolveTarget: 소유자 있고 webhook 있으면 (userId, webhook)")
+    void resolveTarget_ownerWithWebhook() {
+        when(hostOwners.findByTenantIdAndHost(1L, "host-1"))
+                .thenReturn(Optional.of(HostOwner.of(1L, "host-1", 10L, Instant.now())));
+        AppUser u = newUser(1L);
+        u.updateWebhook("https://hooks/u");
+        when(users.findById(10L)).thenReturn(Optional.of(u));
+
+        Optional<AlertTarget> t = service.resolveTarget(1L, "host-1");
+
+        assertThat(t).isPresent();
+        assertEquals(10L, t.get().userId());
+        assertEquals("https://hooks/u", t.get().webhookUrl());
+    }
+
+    @Test
+    @DisplayName("resolveTarget: 소유자 없으면 empty (관리자 fallback 유도)")
+    void resolveTarget_noOwner_empty() {
+        when(hostOwners.findByTenantIdAndHost(1L, "host-x")).thenReturn(Optional.empty());
+        assertThat(service.resolveTarget(1L, "host-x")).isEmpty();
+    }
+
+    @Test
+    @DisplayName("resolveTarget: 소유자는 있으나 webhook 미설정이면 empty")
+    void resolveTarget_ownerNoWebhook_empty() {
+        when(hostOwners.findByTenantIdAndHost(1L, "host-1"))
+                .thenReturn(Optional.of(HostOwner.of(1L, "host-1", 10L, Instant.now())));
+        when(users.findById(10L)).thenReturn(Optional.of(newUser(1L)));
+
+        assertThat(service.resolveTarget(1L, "host-1")).isEmpty();
+    }
+}


### PR DESCRIPTION
## 개요
탐지 알림을 조직 채널 하나가 아니라 **host 소유 유저 각자의 Slack 으로** 라우팅한다.
기존 tenant 별 webhook 은 소유자 미등록 시 **관리자 채널 fallback** 으로 재사용한다.

## 동작
탐지 발생 → alert-service 가 그 `host` 의 소유 유저를 api-service 에 조회 → 소유자 개인 webhook 으로 발송 → 소유자 없으면 tenant webhook(관리자 채널) fallback → 둘 다 없으면 skip.

## 변경
**api-service**
- `AppUser.slackWebhookUrl` 컬럼 (유저별 목적지)
- `HostOwner(tenantId, host, userId)` 엔티티, `unique(tenant_id, host)`
- `PUT/GET /api/me/webhook`, `POST/GET/DELETE /api/me/hosts` (Bearer)
- `GET /api/internal/alert-target` (X-Internal-Key) — alert-service 조회용
- `ApiKeyPolicy` 에 `/api/me` 예외 추가

**alert-service**
- `AlertRouter`: host 소유자 webhook → tenant fallback → skip
- `HostTargetClient`: 소유자 목적지 조회 (기존 `TenantWebhookClient` 캐시 규칙 동일)
- `SlackNotifier` 는 주어진 URL 로 발송만 담당
- cooldown 키를 `user:{id}|host|rule` (fallback `tenant:{id}|...`) 단위로 전환

## 테스트
- 서비스/라우터/클라이언트 단위 테스트 추가, 양 모듈 전체 통과
- 동시 host 등록 경합(unique 제약) → 409 처리 포함

## 참고
- 회원가입 시 유저=조직 1:1 전제는 유지. 한 조직에 여러 유저(초대 등)는 별도 이슈.

Closes #60