### PR TITLE
feat: 대시보드 시각화 API - 추이 차트 + GeoIP 세계지도 (#56)

### DIFF
--- a/api-service/build.gradle
+++ b/api-service/build.gradle
@@ -7,5 +7,51 @@ dependencies {
     implementation 'org.springframework.kafka:spring-kafka'             // alerts 토픽 소비 → MySQL 적재
     runtimeOnly 'com.mysql:mysql-connector-j'                           // auth: MySQL 드라이버
     implementation 'org.springframework.security:spring-security-crypto'      // auth: BCrypt 비밀번호 해시(필터체인 없이)
+    implementation 'com.maxmind.geoip2:geoip2:4.2.1'                   // GeoLite2-Country mmdb 로 dest_ip -> 국가 코드 (world map)
     testImplementation 'com.h2database:h2'                             // auth: 테스트용 임베디드 DB
 }
+
+// --- GeoLite2-Country mmdb: 빌드 시 MaxMind 에서 다운로드해 jar 리소스로 번들 ---
+// 라이선스 키는 git 에 넣지 않는다. CI 시크릿 매니저 -> 환경변수 MAXMIND_LICENSE_KEY 로 주입.
+// 키가 없으면 다운로드를 건너뛰고 빌드는 성공한다(런타임에 geo API 는 빈 배열 반환).
+def geoipResourceDir = layout.buildDirectory.dir('geoip')
+
+tasks.register('downloadGeoLite2') {
+    description = 'MaxMind 에서 GeoLite2-Country.mmdb 다운로드 (MAXMIND_LICENSE_KEY 필요, 없으면 skip)'
+    group = 'geoip'
+    def outFile = geoipResourceDir.get().file('GeoLite2-Country.mmdb').asFile
+    outputs.file(outFile)
+    outputs.upToDateWhen { outFile.exists() }
+    doLast {
+        def key = System.getenv('MAXMIND_LICENSE_KEY') ?: project.findProperty('maxmindLicenseKey')
+        if (!key) {
+            logger.warn('[geoip] MAXMIND_LICENSE_KEY 미설정 -> GeoLite2 다운로드 skip. geo API 는 런타임에 빈 배열 반환.')
+            return
+        }
+        def outDir = outFile.parentFile
+        outDir.mkdirs()
+        def tarFile = new File(outDir, 'GeoLite2-Country.tar.gz')
+        def url = "https://download.maxmind.com/app/geoip_download?edition_id=GeoLite2-Country&license_key=${key}&suffix=tar.gz"
+        logger.lifecycle('[geoip] GeoLite2-Country 다운로드 중...')
+        tarFile.withOutputStream { os ->
+            new URI(url).toURL().openStream().withCloseable { input -> os << input }
+        }
+        // tar.gz 안의 GeoLite2-Country_YYYYMMDD/GeoLite2-Country.mmdb 를 평탄화해 추출
+        copy {
+            from tarTree(resources.gzip(tarFile))
+            include '**/*.mmdb'
+            eachFile { it.relativePath = new RelativePath(true, it.name) }
+            includeEmptyDirs = false
+            into outDir
+        }
+        tarFile.delete()
+        if (!outFile.exists()) {
+            throw new GradleException('[geoip] 다운로드는 됐으나 .mmdb 추출 실패')
+        }
+        logger.lifecycle("[geoip] 완료: ${outFile}")
+    }
+}
+
+// 다운로드 결과(build/geoip)를 main 리소스로 포함 -> jar 클래스패스에 mmdb 번들
+sourceSets.main.resources.srcDir geoipResourceDir
+tasks.named('processResources') { dependsOn 'downloadGeoLite2' }

--- a/api-service/src/main/java/com/edrdog/apiservice/alert/AlertRepository.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/alert/AlertRepository.java
@@ -63,4 +63,18 @@ public interface AlertRepository extends JpaRepository<AlertRecord, String> {
     List<RuleIdCount> countByRuleId(@Param("tenantId") String tenantId,
                                     @Param("from") Long from,
                                     @Param("to") Long to);
+
+    /**
+     * 기간 내 버킷(bucketMs 간격)×severity 별 카운트(대시보드 timeseries 용). tenant 격리 필수.
+     * bucketStart = floor(ts / bucketMs) * bucketMs (UTC 정렬, TimeseriesFill.alignStart 와 동일 규칙).
+     * JPQL 의 FLOOR 는 DB 방言 차이가 있어 native query 로 alerts 테이블에 직접 낸다(H2/MySQL 모두 지원).
+     */
+    @Query(value = "SELECT FLOOR(a.ts / :bucketMs) * :bucketMs AS bucketStart, a.severity AS severity, COUNT(*) AS cnt "
+            + "FROM alerts a WHERE a.tenant_id = :tenantId AND a.ts >= :from AND a.ts < :to "
+            + "GROUP BY FLOOR(a.ts / :bucketMs) * :bucketMs, a.severity",
+            nativeQuery = true)
+    List<TimeBucketSeverityCount> timeseries(@Param("tenantId") String tenantId,
+                                             @Param("from") long from,
+                                             @Param("to") long to,
+                                             @Param("bucketMs") long bucketMs);
 }

--- a/api-service/src/main/java/com/edrdog/apiservice/alert/AlertService.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/alert/AlertService.java
@@ -7,6 +7,8 @@ import com.edrdog.apiservice.alert.web.SummaryResponse;
 import com.edrdog.apiservice.auth.exception.AuthException;
 import com.edrdog.apiservice.clickhouse.ClickHouseReader;
 import com.edrdog.apiservice.query.EventQueryBuilder;
+import com.edrdog.apiservice.query.TimeBucket;
+import com.edrdog.apiservice.query.TimeseriesFill;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -14,6 +16,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Instant;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -150,6 +153,31 @@ public class AlertService {
                 .toList();
 
         return new SummaryResponse(total, new SummaryResponse.Severity(critical, high, medium), topThreats);
+    }
+
+    /**
+     * 시간대별 탐지 추이(대시보드 스택 차트용). tenant 격리 하에 bucket("hour"|"day") 간격으로
+     * severity 별 카운트를 집계한 뒤, 데이터 없는 버킷은 0으로 채워 from~to 전 구간을 반환한다.
+     */
+    @Transactional(readOnly = true)
+    public List<TimeBucket> timeseries(String tenantId, long from, long to, String bucket) {
+        long step = TimeseriesFill.stepFor(bucket);
+        Map<Long, long[]> byBucket = new HashMap<>(); // [critical, high, medium, total]
+        for (TimeBucketSeverityCount row : alerts.timeseries(tenantId, from, to, step)) {
+            long[] acc = byBucket.computeIfAbsent(row.getBucketStart(), k -> new long[4]);
+            acc[3] += row.getCnt();
+            if (SEV_CRITICAL.equals(row.getSeverity())) {
+                acc[0] += row.getCnt();
+            } else if (SEV_HIGH.equals(row.getSeverity())) {
+                acc[1] += row.getCnt();
+            } else if (SEV_MEDIUM.equals(row.getSeverity())) {
+                acc[2] += row.getCnt();
+            }
+        }
+        List<TimeBucket> populated = byBucket.entrySet().stream()
+                .map(e -> new TimeBucket(e.getKey(), e.getValue()[0], e.getValue()[1], e.getValue()[2], e.getValue()[3]))
+                .toList();
+        return TimeseriesFill.fill(populated, from, to, step);
     }
 
     /** id 로 찾되 tenant 소유가 아니면 404 로 숨긴다(없는 것과 구분 불가). */

--- a/api-service/src/main/java/com/edrdog/apiservice/alert/TimeBucketSeverityCount.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/alert/TimeBucketSeverityCount.java
@@ -1,0 +1,13 @@
+package com.edrdog.apiservice.alert;
+
+/**
+ * 버킷×severity 별 alert 집계 결과(Spring Data 인터페이스 projection). timeseries 조립에 쓴다.
+ */
+public interface TimeBucketSeverityCount {
+
+    long getBucketStart();
+
+    String getSeverity();
+
+    long getCnt();
+}

--- a/api-service/src/main/java/com/edrdog/apiservice/alert/web/AlertController.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/alert/web/AlertController.java
@@ -3,8 +3,10 @@ package com.edrdog.apiservice.alert.web;
 import com.edrdog.apiservice.alert.AlertService;
 import com.edrdog.apiservice.auth.service.AuthService;
 import com.edrdog.apiservice.auth.service.Principal;
+import com.edrdog.apiservice.query.TimeBucket;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -13,8 +15,10 @@ import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.util.List;
+import java.util.Set;
 
 /**
  * alert 조회·트리아지 REST. 모든 요청은 세션 Bearer 토큰으로 인증하고 그 tenant 로만 격리한다
@@ -26,6 +30,8 @@ import java.util.List;
 public class AlertController {
 
     private static final String BEARER_PREFIX = "Bearer ";
+    private static final Set<String> VALID_BUCKETS = Set.of("hour", "day");
+    private static final long DEFAULT_WINDOW_MS = 24 * 60 * 60 * 1000L;
 
     private final AlertService alerts;
     private final AuthService auth;
@@ -58,6 +64,25 @@ public class AlertController {
             @RequestParam(required = false) Long to) {
         String tenantId = currentTenantId(authorization);
         return alerts.summary(tenantId, from, to);
+    }
+
+    @Operation(summary = "알림 시간대별 추이",
+            description = "로그인 유저의 tenant 것만 bucket(hour|day) 간격으로 severity 별 탐지 추이를 집계한다. "
+                    + "from/to 미지정 시 최근 24시간, 빈 버킷은 0으로 채운다.")
+    @GetMapping("/timeseries")
+    public List<TimeBucket> timeseries(
+            @RequestHeader(name = "Authorization", required = false) String authorization,
+            @RequestParam(required = false) Long from,
+            @RequestParam(required = false) Long to,
+            @RequestParam(required = false, defaultValue = "hour") String bucket) {
+        if (!VALID_BUCKETS.contains(bucket)) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "허용되지 않는 bucket 입니다: " + bucket);
+        }
+        long now = System.currentTimeMillis();
+        long resolvedTo = to != null ? to : now;
+        long resolvedFrom = from != null ? from : resolvedTo - DEFAULT_WINDOW_MS;
+        String tenantId = currentTenantId(authorization);
+        return alerts.timeseries(tenantId, resolvedFrom, resolvedTo, bucket);
     }
 
     @Operation(summary = "알림 상세", description = "단건 상세(matched 포함). 남의 tenant 것이면 404.")

--- a/api-service/src/main/java/com/edrdog/apiservice/geoip/CountryCentroid.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/geoip/CountryCentroid.java
@@ -1,0 +1,78 @@
+package com.edrdog.apiservice.geoip;
+
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * ISO2 국가 코드 -> {표시 이름, 중심 위/경도} 매핑(순수). world map 마커 좌표로 쓴다.
+ * 지도 표시에 충분한 주요 국가 위주이며, 없는 코드는 Optional.empty.
+ */
+public final class CountryCentroid {
+
+    /** 국가 중심점. lat 위도, lng 경도(도 단위). */
+    public record Centroid(String country, double lat, double lng) {
+    }
+
+    private static final Map<String, Centroid> BY_ISO2 = Map.ofEntries(
+            Map.entry("US", new Centroid("United States", 37.09, -95.71)),
+            Map.entry("CA", new Centroid("Canada", 56.13, -106.35)),
+            Map.entry("MX", new Centroid("Mexico", 23.63, -102.55)),
+            Map.entry("BR", new Centroid("Brazil", -14.24, -51.93)),
+            Map.entry("AR", new Centroid("Argentina", -38.42, -63.62)),
+            Map.entry("CL", new Centroid("Chile", -35.68, -71.54)),
+            Map.entry("CO", new Centroid("Colombia", 4.57, -74.30)),
+            Map.entry("GB", new Centroid("United Kingdom", 55.38, -3.44)),
+            Map.entry("IE", new Centroid("Ireland", 53.41, -8.24)),
+            Map.entry("FR", new Centroid("France", 46.23, 2.21)),
+            Map.entry("DE", new Centroid("Germany", 51.17, 10.45)),
+            Map.entry("NL", new Centroid("Netherlands", 52.13, 5.29)),
+            Map.entry("BE", new Centroid("Belgium", 50.50, 4.47)),
+            Map.entry("ES", new Centroid("Spain", 40.46, -3.75)),
+            Map.entry("PT", new Centroid("Portugal", 39.40, -8.22)),
+            Map.entry("IT", new Centroid("Italy", 41.87, 12.57)),
+            Map.entry("CH", new Centroid("Switzerland", 46.82, 8.23)),
+            Map.entry("AT", new Centroid("Austria", 47.52, 14.55)),
+            Map.entry("SE", new Centroid("Sweden", 60.13, 18.64)),
+            Map.entry("NO", new Centroid("Norway", 60.47, 8.47)),
+            Map.entry("FI", new Centroid("Finland", 61.92, 25.75)),
+            Map.entry("DK", new Centroid("Denmark", 56.26, 9.50)),
+            Map.entry("PL", new Centroid("Poland", 51.92, 19.15)),
+            Map.entry("CZ", new Centroid("Czechia", 49.82, 15.47)),
+            Map.entry("RO", new Centroid("Romania", 45.94, 24.97)),
+            Map.entry("UA", new Centroid("Ukraine", 48.38, 31.17)),
+            Map.entry("RU", new Centroid("Russia", 61.52, 105.32)),
+            Map.entry("TR", new Centroid("Turkey", 38.96, 35.24)),
+            Map.entry("IL", new Centroid("Israel", 31.05, 34.85)),
+            Map.entry("SA", new Centroid("Saudi Arabia", 23.89, 45.08)),
+            Map.entry("AE", new Centroid("United Arab Emirates", 23.42, 53.85)),
+            Map.entry("ZA", new Centroid("South Africa", -30.56, 22.94)),
+            Map.entry("NG", new Centroid("Nigeria", 9.08, 8.68)),
+            Map.entry("EG", new Centroid("Egypt", 26.82, 30.80)),
+            Map.entry("KE", new Centroid("Kenya", -0.02, 37.91)),
+            Map.entry("IN", new Centroid("India", 20.59, 78.96)),
+            Map.entry("PK", new Centroid("Pakistan", 30.38, 69.35)),
+            Map.entry("CN", new Centroid("China", 35.86, 104.20)),
+            Map.entry("HK", new Centroid("Hong Kong", 22.32, 114.17)),
+            Map.entry("TW", new Centroid("Taiwan", 23.70, 120.96)),
+            Map.entry("JP", new Centroid("Japan", 36.20, 138.25)),
+            Map.entry("KR", new Centroid("South Korea", 35.91, 127.77)),
+            Map.entry("SG", new Centroid("Singapore", 1.35, 103.82)),
+            Map.entry("MY", new Centroid("Malaysia", 4.21, 101.98)),
+            Map.entry("TH", new Centroid("Thailand", 15.87, 100.99)),
+            Map.entry("VN", new Centroid("Vietnam", 14.06, 108.28)),
+            Map.entry("ID", new Centroid("Indonesia", -0.79, 113.92)),
+            Map.entry("PH", new Centroid("Philippines", 12.88, 121.77)),
+            Map.entry("AU", new Centroid("Australia", -25.27, 133.78)),
+            Map.entry("NZ", new Centroid("New Zealand", -40.90, 174.89)));
+
+    private CountryCentroid() {
+    }
+
+    /** ISO2 코드(대소문자 무관)의 중심점. 없으면 empty. */
+    public static Optional<Centroid> of(String iso2) {
+        if (iso2 == null) {
+            return Optional.empty();
+        }
+        return Optional.ofNullable(BY_ISO2.get(iso2.trim().toUpperCase()));
+    }
+}

--- a/api-service/src/main/java/com/edrdog/apiservice/geoip/GeoAggregator.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/geoip/GeoAggregator.java
@@ -1,0 +1,57 @@
+package com.edrdog.apiservice.geoip;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * 목적지 IP 별 건수를 국가 단위로 합산하는 순수 로직. resolver(ip -> ISO2)를 함수형으로 주입받아
+ * 실제 mmdb 없이도 테스트 가능하다. 비공인 IP, geoip 미해석, 중심점 없는 국가는 건너뛴다.
+ */
+public final class GeoAggregator {
+
+    /** world map 마커 한 점. */
+    public record GeoPoint(String country, String countryCode, double lat, double lng, long count) {
+    }
+
+    /** IP -> ISO2 국가 코드 해석기(없으면 empty). GeoIpResolver::countryCode 를 넘긴다. */
+    @FunctionalInterface
+    public interface CountryResolver {
+        Optional<String> countryCode(String ip);
+    }
+
+    private GeoAggregator() {
+    }
+
+    /**
+     * ipCounts(목적지 IP -> 건수)를 국가별로 합산한다.
+     * 각 IP 는 공인이어야 하고(PrivateIp), resolver 가 ISO2 를 주고, 그 ISO2 가 중심점 맵에 있어야 집계된다.
+     */
+    public static List<GeoPoint> aggregate(Map<String, Long> ipCounts, CountryResolver resolver) {
+        Map<String, Long> byCountry = new LinkedHashMap<>();
+        for (Map.Entry<String, Long> e : ipCounts.entrySet()) {
+            String ip = e.getKey();
+            if (!PrivateIp.isPublic(ip)) {
+                continue;
+            }
+            Optional<String> iso = resolver.countryCode(ip);
+            if (iso.isEmpty()) {
+                continue;
+            }
+            String code = iso.get().trim().toUpperCase();
+            if (CountryCentroid.of(code).isEmpty()) {
+                continue;
+            }
+            byCountry.merge(code, e.getValue(), Long::sum);
+        }
+
+        List<GeoPoint> out = new ArrayList<>();
+        for (Map.Entry<String, Long> e : byCountry.entrySet()) {
+            CountryCentroid.Centroid c = CountryCentroid.of(e.getKey()).orElseThrow();
+            out.add(new GeoPoint(c.country(), e.getKey(), c.lat(), c.lng(), e.getValue()));
+        }
+        return out;
+    }
+}

--- a/api-service/src/main/java/com/edrdog/apiservice/geoip/GeoIpResolver.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/geoip/GeoIpResolver.java
@@ -1,0 +1,91 @@
+package com.edrdog.apiservice.geoip;
+
+import com.maxmind.geoip2.DatabaseReader;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.io.File;
+import java.io.InputStream;
+import java.net.InetAddress;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * GeoLite2-Country mmdb 로 IP -> ISO2 국가 코드를 해석한다.
+ * 로드 우선순위: (1) db-path(env GEOIP_DB_PATH) 파일 -> (2) 클래스패스 번들(빌드 시 다운로드된 mmdb).
+ * 둘 다 없으면 "비활성"으로 두고(경고 1회) 기동은 막지 않는다.
+ * 조회는 ConcurrentHashMap 에 캐시해 같은 IP 의 반복 mmdb 조회를 피한다.
+ * mmdb 접근을 이 클래스 뒤에 가둬, 집계 로직(GeoAggregator)은 스텁 resolver 로 테스트한다.
+ */
+@Component
+public class GeoIpResolver {
+
+    private static final Logger log = LoggerFactory.getLogger(GeoIpResolver.class);
+
+    /** 빌드 시 downloadGeoLite2 태스크가 build/geoip 에 받아 jar 에 번들하는 파일명(클래스패스 루트). */
+    private static final String CLASSPATH_DB = "GeoLite2-Country.mmdb";
+
+    private final DatabaseReader reader;
+    private final ConcurrentHashMap<String, Optional<String>> cache = new ConcurrentHashMap<>();
+
+    public GeoIpResolver(@Value("${edrdog.geoip.db-path:}") String dbPath) {
+        this.reader = load(dbPath);
+    }
+
+    private static DatabaseReader load(String dbPath) {
+        // (1) 외부 경로 우선: 운영에서 GEOIP_DB_PATH 로 번들 mmdb 를 덮어쓸 수 있다.
+        if (dbPath != null && !dbPath.isBlank()) {
+            File f = new File(dbPath.trim());
+            if (f.isFile()) {
+                try {
+                    DatabaseReader r = new DatabaseReader.Builder(f).build();
+                    log.info("GeoIP DB 로드(파일): {}", dbPath);
+                    return r;
+                } catch (Exception e) {
+                    log.warn("GeoIP DB 파일 로드 실패: {}. 클래스패스 번들 시도.", dbPath, e);
+                }
+            } else {
+                log.warn("GeoIP DB 파일 없음: {}. 클래스패스 번들 시도.", dbPath);
+            }
+        }
+        // (2) 클래스패스 번들: 빌드 시 다운로드된 mmdb(build/geoip -> jar).
+        try (InputStream in = GeoIpResolver.class.getResourceAsStream("/" + CLASSPATH_DB)) {
+            if (in != null) {
+                DatabaseReader r = new DatabaseReader.Builder(in).build();
+                log.info("GeoIP DB 로드(클래스패스): {}", CLASSPATH_DB);
+                return r;
+            }
+        } catch (Exception e) {
+            log.warn("GeoIP DB 클래스패스 로드 실패.", e);
+        }
+        log.warn("GeoIP DB 사용 불가(외부 경로·클래스패스 모두 없음). geo 조회 비활성(빈 배열 반환).");
+        return null;
+    }
+
+    /** mmdb 가 로드됐는지. false 면 컨트롤러는 빈 배열(200)을 준다. */
+    public boolean isAvailable() {
+        return reader != null;
+    }
+
+    /** IP 의 ISO2 국가 코드. 비활성/사설/미해석이면 empty. 결과는 캐시된다. */
+    public Optional<String> countryCode(String ip) {
+        if (reader == null || !PrivateIp.isPublic(ip)) {
+            return Optional.empty();
+        }
+        return cache.computeIfAbsent(ip.trim(), this::lookup);
+    }
+
+    private Optional<String> lookup(String ip) {
+        try {
+            InetAddress addr = InetAddress.getByName(ip);
+            return reader.tryCountry(addr)
+                    .map(r -> r.getCountry())
+                    .map(c -> c.getIsoCode())
+                    .filter(code -> code != null && !code.isBlank());
+        } catch (Exception e) {
+            return Optional.empty();
+        }
+    }
+}

--- a/api-service/src/main/java/com/edrdog/apiservice/geoip/PrivateIp.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/geoip/PrivateIp.java
@@ -1,0 +1,69 @@
+package com.edrdog.apiservice.geoip;
+
+import java.net.InetAddress;
+
+/**
+ * IP 가 "공인(라우팅 가능한)" 주소인지 판별하는 순수 로직.
+ * loopback / private(RFC1918) / link-local / IPv6 ULA / multicast / any-local 은 공인이 아니다.
+ * geo 매핑 대상(외부로 나간 목적지 IP)만 통과시키는 데 쓴다.
+ */
+public final class PrivateIp {
+
+    private PrivateIp() {
+    }
+
+    /** null/blank/파싱불가/사설/loopback/link-local/ULA 는 false, 그 외 공인 IP 는 true. */
+    public static boolean isPublic(String ip) {
+        if (ip == null) {
+            return false;
+        }
+        String s = ip.trim();
+        if (s.isEmpty() || !looksNumeric(s)) {
+            return false;
+        }
+        InetAddress addr;
+        try {
+            addr = InetAddress.getByName(s);
+        } catch (Exception e) {
+            return false;
+        }
+        if (addr.isLoopbackAddress() || addr.isLinkLocalAddress() || addr.isSiteLocalAddress()
+                || addr.isAnyLocalAddress() || addr.isMulticastAddress()) {
+            return false;
+        }
+        byte[] b = addr.getAddress();
+        if (b.length == 4) {
+            // 172.16.0.0/12 (isSiteLocalAddress 가 대부분 잡지만 명시적으로 한 번 더 확인)
+            int o0 = b[0] & 0xff;
+            int o1 = b[1] & 0xff;
+            if (o0 == 172 && o1 >= 16 && o1 <= 31) {
+                return false;
+            }
+        } else {
+            // IPv6 ULA fc00::/7 -> 첫 바이트 0xfc 또는 0xfd
+            int f = b[0] & 0xff;
+            if (f == 0xfc || f == 0xfd) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * 숫자 IP 리터럴처럼 보이는지(16진수 + '.' ':' '%')만 통과. 호스트명 형태를 거르면
+     * InetAddress.getByName 이 DNS 조회로 새는 것을 막는다.
+     */
+    private static boolean looksNumeric(String s) {
+        for (int i = 0; i < s.length(); i++) {
+            char c = s.charAt(i);
+            boolean ok = (c >= '0' && c <= '9')
+                    || (c >= 'a' && c <= 'f')
+                    || (c >= 'A' && c <= 'F')
+                    || c == '.' || c == ':' || c == '%';
+            if (!ok) {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/api-service/src/main/java/com/edrdog/apiservice/query/EventQueryBuilder.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/query/EventQueryBuilder.java
@@ -76,6 +76,22 @@ public class EventQueryBuilder {
         return new ClickHouseQuery(sql, params);
     }
 
+    /**
+     * tenant 격리 하에 시간 윈도우[from,to) 안의 목적지 IP 별 건수를 집계한다(world map 용).
+     * 네트워크 이벤트가 아닌 행은 dest_ip 가 ""(빈 문자열)이므로 제외한다. tenantId 는 필수.
+     */
+    public ClickHouseQuery geo(String tenant, long from, long to) {
+        Map<String, String> params = new LinkedHashMap<>();
+        String where = where(tenant, null, null, null, null, params);
+        params.put("from", String.valueOf(from));
+        params.put("to", String.valueOf(to));
+        String sql = "SELECT dest_ip, count() AS cnt FROM " + table
+                + where
+                + " AND ts >= {from:UInt64} AND ts < {to:UInt64} AND dest_ip != ''"
+                + " GROUP BY dest_ip";
+        return new ClickHouseQuery(sql, params);
+    }
+
     private static String where(String tenantId, String host, String type, Long from, Long to,
                                 Map<String, String> params) {
         if (!hasText(tenantId)) {

--- a/api-service/src/main/java/com/edrdog/apiservice/query/TimeBucket.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/query/TimeBucket.java
@@ -1,0 +1,8 @@
+package com.edrdog.apiservice.query;
+
+/**
+ * timeseries 한 버킷의 집계 결과. bucketStart 는 버킷 시작 시각(epoch millis, UTC 정렬).
+ * severity 별 카운트(critical/high/medium)와 전체 count 를 담는다(count 는 미분류 severity 도 포함).
+ */
+public record TimeBucket(long bucketStart, long critical, long high, long medium, long count) {
+}

--- a/api-service/src/main/java/com/edrdog/apiservice/query/TimeseriesFill.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/query/TimeseriesFill.java
@@ -1,0 +1,47 @@
+package com.edrdog.apiservice.query;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * timeseries 빈 버킷 0 채우기(순수 로직). DB 는 데이터가 있는 버킷만 돌려주므로,
+ * 정렬된 시작 버킷부터 to 직전까지 버킷 간격만큼 걸어가며 없는 구간은 0 으로 채운다.
+ * 버킷 경계는 UTC 기준(epoch 0 = UTC 자정/정시)이라 floorDiv 로 정렬한다.
+ */
+public final class TimeseriesFill {
+
+    public static final long HOUR_MS = 3_600_000L;
+    public static final long DAY_MS = 86_400_000L;
+
+    private TimeseriesFill() {
+    }
+
+    /** bucket 문자열("day" 면 하루, 그 외 한 시간)의 간격(ms). */
+    public static long stepFor(String bucket) {
+        return "day".equals(bucket) ? DAY_MS : HOUR_MS;
+    }
+
+    /** epochMillis 를 step 경계(UTC 정시/자정)로 내림. */
+    public static long alignStart(long epochMillis, long step) {
+        return Math.floorDiv(epochMillis, step) * step;
+    }
+
+    /**
+     * from(정렬 후)부터 to 직전까지 step 간격으로 모든 버킷을 만들고, rows 에 있는 버킷은 그 값을,
+     * 없는 버킷은 0 으로 채워 시간순으로 돌려준다.
+     */
+    public static List<TimeBucket> fill(List<TimeBucket> rows, long from, long to, long step) {
+        Map<Long, TimeBucket> byBucket = new HashMap<>();
+        for (TimeBucket r : rows) {
+            byBucket.put(r.bucketStart(), r);
+        }
+        List<TimeBucket> out = new ArrayList<>();
+        for (long b = alignStart(from, step); b < to; b += step) {
+            TimeBucket r = byBucket.get(b);
+            out.add(r != null ? r : new TimeBucket(b, 0, 0, 0, 0));
+        }
+        return out;
+    }
+}

--- a/api-service/src/main/java/com/edrdog/apiservice/web/EventGeoController.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/web/EventGeoController.java
@@ -1,0 +1,91 @@
+package com.edrdog.apiservice.web;
+
+import com.edrdog.apiservice.auth.service.AuthService;
+import com.edrdog.apiservice.auth.service.Principal;
+import com.edrdog.apiservice.clickhouse.ClickHouseReader;
+import com.edrdog.apiservice.geoip.GeoAggregator;
+import com.edrdog.apiservice.geoip.GeoIpResolver;
+import com.edrdog.apiservice.geoip.PrivateIp;
+import com.edrdog.apiservice.query.EventQueryBuilder;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * 목적지 IP 를 국가별로 집계해 world map 마커로 제공하는 읽기 전용 REST.
+ * ClickHouse(edrdog.events)의 dest_ip 를 GeoLite2-Country 로 해석하며, 로그인 유저의 tenant 로만 격리한다.
+ * mmdb 가 없으면(라이선스 키 미설정 등) 빈 배열(200)을 준다.
+ */
+@RestController
+@RequestMapping("/api")
+@Tag(name = "events", description = "이벤트 조회 및 요약 (ClickHouse, tenant 격리)")
+public class EventGeoController {
+
+    private static final String BEARER_PREFIX = "Bearer ";
+    private static final long DAY_MILLIS = 24L * 60 * 60 * 1000;
+
+    private final ClickHouseReader reader;
+    private final EventQueryBuilder builder;
+    private final GeoIpResolver resolver;
+    private final AuthService auth;
+
+    public EventGeoController(ClickHouseReader reader, EventQueryBuilder builder,
+                             GeoIpResolver resolver, AuthService auth) {
+        this.reader = reader;
+        this.builder = builder;
+        this.resolver = resolver;
+        this.auth = auth;
+    }
+
+    @Operation(summary = "목적지 국가 지도",
+            description = "로그인 유저의 tenant 것만 시간범위(from/to, epoch millis, 기본 최근 24시간) 안에서 목적지 IP 를 "
+                    + "국가별로 집계해 world map 마커(국가명/좌표/건수)로 준다. GeoIP DB 가 없으면 빈 배열.")
+    @GetMapping("/events/geo")
+    public List<GeoAggregator.GeoPoint> geo(
+            @RequestHeader(name = "Authorization", required = false) String authorization,
+            @RequestParam(required = false) Long from,
+            @RequestParam(required = false) Long to) {
+        String tenantId = currentTenantId(authorization);
+        long now = System.currentTimeMillis();
+        long toMillis = to != null ? to : now;
+        long fromMillis = from != null ? from : now - DAY_MILLIS;
+
+        // mmdb 미로드면 조회 없이 빈 배열(200).
+        if (!resolver.isAvailable()) {
+            return List.of();
+        }
+
+        Map<String, Long> ipCounts = new LinkedHashMap<>();
+        for (Map<String, Object> row : reader.query(builder.geo(tenantId, fromMillis, toMillis))) {
+            String ip = String.valueOf(row.get("dest_ip"));
+            if (!PrivateIp.isPublic(ip)) {
+                continue;
+            }
+            long cnt = Long.parseLong(String.valueOf(row.get("cnt")));
+            ipCounts.merge(ip, cnt, Long::sum);
+        }
+        return GeoAggregator.aggregate(ipCounts, resolver::countryCode);
+    }
+
+    /** Bearer 토큰을 검증해 현재 유저의 tenant 를 문자열로 반환. 토큰이 없거나 만료면 AuthService 가 401. */
+    private String currentTenantId(String authorization) {
+        Principal principal = auth.resolve(bearerToken(authorization));
+        return String.valueOf(principal.tenantId());
+    }
+
+    /** "Bearer " 접두어를 떼서 토큰만 반환. 없으면 null. */
+    private static String bearerToken(String authorization) {
+        if (authorization == null || !authorization.startsWith(BEARER_PREFIX)) {
+            return null;
+        }
+        return authorization.substring(BEARER_PREFIX.length()).trim();
+    }
+}

--- a/api-service/src/main/resources/application.yml
+++ b/api-service/src/main/resources/application.yml
@@ -56,6 +56,8 @@ edrdog:
     user: edrdog
     password: edrdog
     table: edrdog.events                 # 조회 대상 테이블 (archiver 가 적재)
+  geoip:
+    db-path: ${GEOIP_DB_PATH:}           # GeoLite2-Country.mmdb 외부 경로. 비면 클래스패스 번들 사용, 둘 다 없으면 geo API 빈 배열
 
 management:
   endpoints:

--- a/api-service/src/test/java/com/edrdog/apiservice/alert/AlertRepositoryTest.java
+++ b/api-service/src/test/java/com/edrdog/apiservice/alert/AlertRepositoryTest.java
@@ -128,4 +128,39 @@ class AlertRepositoryTest {
         assertEquals(1, a.size());
         assertEquals(0L, find(a, "h1").getOpenCritical());
     }
+
+    // --- timeseries(버킷×severity 집계) ---
+
+    private static final long HOUR = 3_600_000L;
+
+    private static TimeBucketSeverityCount find(List<TimeBucketSeverityCount> rows, long bucketStart, String severity) {
+        return rows.stream()
+                .filter(r -> r.getBucketStart() == bucketStart && severity.equals(r.getSeverity()))
+                .findFirst().orElseThrow();
+    }
+
+    @Test
+    void timeseries_는_버킷과_severity로_묶어_카운트한다() {
+        seed("A", "h1", "CRITICAL", AlertStatus.OPEN, 100L);
+        seed("A", "h1", "HIGH", AlertStatus.OPEN, 200L);
+        seed("A", "h1", "HIGH", AlertStatus.OPEN, HOUR + 50L);
+
+        List<TimeBucketSeverityCount> rows = alerts.timeseries("A", 0L, 2 * HOUR, HOUR);
+
+        assertEquals(1L, find(rows, 0L, "CRITICAL").getCnt());
+        assertEquals(1L, find(rows, 0L, "HIGH").getCnt());
+        assertEquals(1L, find(rows, HOUR, "HIGH").getCnt());
+    }
+
+    @Test
+    void timeseries_도_tenant_격리와_시간범위_필터를_지킨다() {
+        seed("A", "h1", "HIGH", AlertStatus.OPEN, 100L);
+        seed("B", "h1", "CRITICAL", AlertStatus.OPEN, 100L);
+        seed("A", "h1", "CRITICAL", AlertStatus.OPEN, 3 * HOUR);
+
+        List<TimeBucketSeverityCount> rows = alerts.timeseries("A", 0L, 2 * HOUR, HOUR);
+
+        assertEquals(1, rows.size());
+        assertEquals(1L, find(rows, 0L, "HIGH").getCnt());
+    }
 }

--- a/api-service/src/test/java/com/edrdog/apiservice/geoip/CountryCentroidTest.java
+++ b/api-service/src/test/java/com/edrdog/apiservice/geoip/CountryCentroidTest.java
@@ -1,0 +1,35 @@
+package com.edrdog.apiservice.geoip;
+
+import com.edrdog.apiservice.geoip.CountryCentroid.Centroid;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * ISO2 -> 국가 중심점 매핑 순수 로직 검증.
+ */
+class CountryCentroidTest {
+
+    @Test
+    void 알려진_국가는_이름과_좌표를_준다() {
+        Centroid us = CountryCentroid.of("US").orElseThrow();
+        assertEquals("United States", us.country());
+        Centroid kr = CountryCentroid.of("KR").orElseThrow();
+        assertEquals("South Korea", kr.country());
+    }
+
+    @Test
+    void 소문자_코드도_찾는다() {
+        assertTrue(CountryCentroid.of("kr").isPresent());
+        assertTrue(CountryCentroid.of(" jp ").isPresent());
+    }
+
+    @Test
+    void 없는_코드나_null은_empty() {
+        assertEquals(Optional.empty(), CountryCentroid.of("ZZ"));
+        assertEquals(Optional.empty(), CountryCentroid.of(null));
+    }
+}

--- a/api-service/src/test/java/com/edrdog/apiservice/geoip/GeoAggregatorTest.java
+++ b/api-service/src/test/java/com/edrdog/apiservice/geoip/GeoAggregatorTest.java
@@ -1,0 +1,93 @@
+package com.edrdog.apiservice.geoip;
+
+import com.edrdog.apiservice.geoip.GeoAggregator.CountryResolver;
+import com.edrdog.apiservice.geoip.GeoAggregator.GeoPoint;
+import org.junit.jupiter.api.Test;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * 목적지 IP -> 국가 집계 순수 로직 검증. resolver 를 스텁으로 주입해 mmdb 없이 검증한다.
+ */
+class GeoAggregatorTest {
+
+    /** 미리 지정한 IP->ISO2 만 아는 스텁 resolver. */
+    private static CountryResolver stub(Map<String, String> ipToIso) {
+        return ip -> Optional.ofNullable(ipToIso.get(ip));
+    }
+
+    @Test
+    void 같은_국가의_여러_IP는_건수가_합산된다() {
+        Map<String, Long> counts = new LinkedHashMap<>();
+        counts.put("8.8.8.8", 3L);
+        counts.put("1.1.1.1", 2L);
+        CountryResolver r = stub(Map.of("8.8.8.8", "US", "1.1.1.1", "US"));
+
+        List<GeoPoint> out = GeoAggregator.aggregate(counts, r);
+
+        assertEquals(1, out.size());
+        GeoPoint us = out.get(0);
+        assertEquals("US", us.countryCode());
+        assertEquals("United States", us.country());
+        assertEquals(5L, us.count());
+    }
+
+    @Test
+    void 국가별로_나뉜다() {
+        Map<String, Long> counts = new LinkedHashMap<>();
+        counts.put("8.8.8.8", 4L);
+        counts.put("203.0.113.9", 1L);
+        CountryResolver r = stub(Map.of("8.8.8.8", "US", "203.0.113.9", "KR"));
+
+        List<GeoPoint> out = GeoAggregator.aggregate(counts, r);
+
+        assertEquals(2, out.size());
+    }
+
+    @Test
+    void 사설IP는_resolver를_거치지않고_제외() {
+        Map<String, Long> counts = new LinkedHashMap<>();
+        counts.put("10.0.0.1", 9L);
+        // 사설이면 애초에 집계 대상이 아니다(스텁이 US 를 줘도 무시)
+        CountryResolver r = stub(Map.of("10.0.0.1", "US"));
+
+        assertTrue(GeoAggregator.aggregate(counts, r).isEmpty());
+    }
+
+    @Test
+    void geoip_미해석_IP는_제외() {
+        Map<String, Long> counts = new LinkedHashMap<>();
+        counts.put("8.8.8.8", 5L);
+        CountryResolver r = stub(Map.of()); // 아무것도 모름
+
+        assertTrue(GeoAggregator.aggregate(counts, r).isEmpty());
+    }
+
+    @Test
+    void 중심점_없는_국가코드는_제외() {
+        Map<String, Long> counts = new LinkedHashMap<>();
+        counts.put("8.8.8.8", 5L);
+        CountryResolver r = stub(Map.of("8.8.8.8", "ZZ")); // 중심점 맵에 없음
+
+        assertTrue(GeoAggregator.aggregate(counts, r).isEmpty());
+    }
+
+    @Test
+    void 좌표는_중심점_맵에서_채워진다() {
+        Map<String, Long> counts = new LinkedHashMap<>();
+        counts.put("203.0.113.9", 7L);
+        CountryResolver r = stub(Map.of("203.0.113.9", "KR"));
+
+        GeoPoint kr = GeoAggregator.aggregate(counts, r).get(0);
+        CountryCentroid.Centroid expected = CountryCentroid.of("KR").orElseThrow();
+        assertEquals(expected.lat(), kr.lat());
+        assertEquals(expected.lng(), kr.lng());
+        assertEquals(7L, kr.count());
+    }
+}

--- a/api-service/src/test/java/com/edrdog/apiservice/geoip/PrivateIpTest.java
+++ b/api-service/src/test/java/com/edrdog/apiservice/geoip/PrivateIpTest.java
@@ -1,0 +1,81 @@
+package com.edrdog.apiservice.geoip;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * 공인/사설/garbage IP 판별 순수 로직 검증.
+ */
+class PrivateIpTest {
+
+    // --- 공인 ---
+
+    @Test
+    void 공인_IPv4는_true() {
+        assertTrue(PrivateIp.isPublic("8.8.8.8"));
+        assertTrue(PrivateIp.isPublic("1.1.1.1"));
+        assertTrue(PrivateIp.isPublic("203.0.113.7"));
+    }
+
+    @Test
+    void 공인_IPv6는_true() {
+        assertTrue(PrivateIp.isPublic("2001:4860:4860::8888"));
+    }
+
+    @Test
+    void 앞뒤_공백은_무시() {
+        assertTrue(PrivateIp.isPublic("  8.8.8.8 "));
+    }
+
+    // --- 사설/특수 ---
+
+    @Test
+    void loopback은_false() {
+        assertFalse(PrivateIp.isPublic("127.0.0.1"));
+        assertFalse(PrivateIp.isPublic("::1"));
+    }
+
+    @Test
+    void private_IPv4_대역은_false() {
+        assertFalse(PrivateIp.isPublic("10.0.0.5"));
+        assertFalse(PrivateIp.isPublic("172.16.0.1"));
+        assertFalse(PrivateIp.isPublic("172.31.255.255"));
+        assertFalse(PrivateIp.isPublic("192.168.1.1"));
+    }
+
+    @Test
+    void link_local은_false() {
+        assertFalse(PrivateIp.isPublic("169.254.1.1"));
+        assertFalse(PrivateIp.isPublic("fe80::1"));
+    }
+
+    @Test
+    void IPv6_ULA는_false() {
+        assertFalse(PrivateIp.isPublic("fc00::1"));
+        assertFalse(PrivateIp.isPublic("fd12:3456::1"));
+    }
+
+    @Test
+    void 경계값_172_15와_172_32는_공인() {
+        assertTrue(PrivateIp.isPublic("172.15.0.1"));
+        assertTrue(PrivateIp.isPublic("172.32.0.1"));
+    }
+
+    // --- garbage / null ---
+
+    @Test
+    void null_blank는_false() {
+        assertFalse(PrivateIp.isPublic(null));
+        assertFalse(PrivateIp.isPublic(""));
+        assertFalse(PrivateIp.isPublic("   "));
+    }
+
+    @Test
+    void 파싱불가_문자열은_false() {
+        assertFalse(PrivateIp.isPublic("notanip"));
+        assertFalse(PrivateIp.isPublic("garbage"));
+        assertFalse(PrivateIp.isPublic("example.com"));
+    }
+}

--- a/api-service/src/test/java/com/edrdog/apiservice/query/TimeseriesFillTest.java
+++ b/api-service/src/test/java/com/edrdog/apiservice/query/TimeseriesFillTest.java
@@ -1,0 +1,83 @@
+package com.edrdog.apiservice.query;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * 빈 버킷 0 채우기 순수 로직 검증. DB 없이 검증된다.
+ */
+class TimeseriesFillTest {
+
+    private static final long HOUR = TimeseriesFill.HOUR_MS;
+    private static final long DAY = TimeseriesFill.DAY_MS;
+
+    @Test
+    void stepFor_는_day면_하루_그외_한시간() {
+        assertEquals(DAY, TimeseriesFill.stepFor("day"));
+        assertEquals(HOUR, TimeseriesFill.stepFor("hour"));
+        assertEquals(HOUR, TimeseriesFill.stepFor("anything"));
+    }
+
+    @Test
+    void alignStart_는_시간경계로_내림() {
+        // 1시간 5분 -> 1시간 경계
+        assertEquals(HOUR, TimeseriesFill.alignStart(HOUR + 5 * 60_000L, HOUR));
+        // 이미 경계면 그대로
+        assertEquals(2 * HOUR, TimeseriesFill.alignStart(2 * HOUR, HOUR));
+    }
+
+    @Test
+    void alignStart_는_일경계로_내림() {
+        assertEquals(DAY, TimeseriesFill.alignStart(DAY + 3 * HOUR, DAY));
+    }
+
+    @Test
+    void 빈_입력이면_from_to_사이_버킷을_모두_0으로_채운다() {
+        // from=0, to=3시간 -> 3개 버킷 (0h,1h,2h) 모두 0
+        List<TimeBucket> out = TimeseriesFill.fill(List.of(), 0, 3 * HOUR, HOUR);
+        assertEquals(3, out.size());
+        assertEquals(new TimeBucket(0, 0, 0, 0, 0), out.get(0));
+        assertEquals(new TimeBucket(HOUR, 0, 0, 0, 0), out.get(1));
+        assertEquals(new TimeBucket(2 * HOUR, 0, 0, 0, 0), out.get(2));
+    }
+
+    @Test
+    void 있는_버킷은_값을_유지하고_없는_버킷만_0으로_채운다() {
+        // 가운데 버킷(1h)만 데이터 있음
+        TimeBucket mid = new TimeBucket(HOUR, 2, 3, 1, 6);
+        List<TimeBucket> out = TimeseriesFill.fill(List.of(mid), 0, 3 * HOUR, HOUR);
+        assertEquals(3, out.size());
+        assertEquals(new TimeBucket(0, 0, 0, 0, 0), out.get(0));
+        assertEquals(mid, out.get(1));
+        assertEquals(new TimeBucket(2 * HOUR, 0, 0, 0, 0), out.get(2));
+    }
+
+    @Test
+    void from_이_경계가_아니면_정렬된_시작부터_채운다() {
+        // from 이 1h+10분 -> 시작 버킷은 1h
+        List<TimeBucket> out = TimeseriesFill.fill(List.of(), HOUR + 10 * 60_000L, 3 * HOUR, HOUR);
+        assertEquals(2, out.size());
+        assertEquals(HOUR, out.get(0).bucketStart());
+        assertEquals(2 * HOUR, out.get(1).bucketStart());
+    }
+
+    @Test
+    void 결과는_버킷시작_오름차순() {
+        List<TimeBucket> out = TimeseriesFill.fill(
+                List.of(new TimeBucket(2 * HOUR, 1, 0, 0, 1)), 0, 4 * HOUR, HOUR);
+        for (int i = 1; i < out.size(); i++) {
+            assertEquals(true, out.get(i - 1).bucketStart() < out.get(i).bucketStart());
+        }
+    }
+
+    @Test
+    void 일단위도_채운다() {
+        List<TimeBucket> out = TimeseriesFill.fill(List.of(), 0, 2 * DAY, DAY);
+        assertEquals(2, out.size());
+        assertEquals(0, out.get(0).bucketStart());
+        assertEquals(DAY, out.get(1).bucketStart());
+    }
+}


### PR DESCRIPTION
## 요약
이슈 #56 대시보드 시각화 API 2종을 현재 dev 구조(멀티테넌트, MySQL alert 저장) 위에 구현.

## 추가된 엔드포인트 (둘 다 Bearer 인증 + tenant 격리)
- `GET /api/alerts/timeseries?from=&to=&bucket=hour|day` — MySQL alerts 시간버킷 + severity(critical/high/medium) 집계, 빈 버킷 0채움, 기본 최근 24h
- `GET /api/events/geo?from=&to=` — ClickHouse events의 dest_ip를 GeoLite2-Country로 국가 집계 + 대표좌표, 공인 IP만

## 설계 메모
- 추이는 alert(MySQL) 기준, 지도는 dest_ip가 events(ClickHouse)에만 있어 events 기준 집계 (dev alert에는 dest_ip 없음)
- GeoLite2-Country mmdb는 빌드 시 다운로드(`MAXMIND_LICENSE_KEY`)해 jar 번들, `GEOIP_DB_PATH`로 오버라이드 가능, 미설정 시 geo는 빈 배열(200)
- GeoIP 순수 로직(사설IP필터/centroid/집계)은 단위테스트 커버

## 검증
- `./gradlew clean build` 통과, api-service 190 테스트 0 실패
- 라이브 통합: 실제 MySQL+ClickHouse에 데모 시드로 로그인→timeseries(실제 MySQL 집계)→geo(graceful) end-to-end 확인, 400/401/tenant 격리 확인