### PR TITLE
feat: responder Fleet 스크립트 실행으로 실제 조치 (kill)

### DIFF
--- a/detector-service/src/main/java/com/edrdog/detectorservice/dto/Alert.java
+++ b/detector-service/src/main/java/com/edrdog/detectorservice/dto/Alert.java
@@ -13,6 +13,7 @@ import java.util.List;
  * @param ts       판정을 완성시킨 트리거 이벤트 시각 (epoch millis)
  * @param matched  판정 근거가 된 이벤트 요약들
  * @param tenantId 조직(tenant) 식별자 — 트리거 이벤트에서 물려받은 격리 태그
+ * @param target   조치 대상 프로세스명/경로 — responder 의 kill 실행에 사용 (kill 대상 없으면 null)
  */
 public record Alert(
         String host,
@@ -22,7 +23,8 @@ public record Alert(
         String action,
         long ts,
         List<String> matched,
-        String tenantId
+        String tenantId,
+        String target
 ) {
     public static final String SEV_MEDIUM = "MEDIUM";
     public static final String SEV_HIGH = "HIGH";

--- a/detector-service/src/main/java/com/edrdog/detectorservice/rule/Rules.java
+++ b/detector-service/src/main/java/com/edrdog/detectorservice/rule/Rules.java
@@ -89,7 +89,8 @@ public final class Rules {
                 Alert.actionFor(Alert.SEV_HIGH),
                 current.ts(),
                 List.of(summary(officeExec.get()), summary(current)),
-                current.tenantId()));
+                current.tenantId(),
+                actTarget(current)));
     }
 
     /** R2 T1105+T1204: 버퍼의 network 다운로드 → 이후 process 실행. */
@@ -112,7 +113,8 @@ public final class Rules {
                 Alert.actionFor(Alert.SEV_CRITICAL),
                 current.ts(),
                 List.of(summary(download.get()), summary(current)),
-                current.tenantId()));
+                current.tenantId(),
+                actTarget(current)));
     }
 
     /** R3 T1059: 임시/다운로드 경로에서 실행된 스크립트 (저심각 point 룰). */
@@ -128,7 +130,8 @@ public final class Rules {
                 Alert.actionFor(Alert.SEV_MEDIUM),
                 current.ts(),
                 List.of(summary(current)),
-                current.tenantId()));
+                current.tenantId(),
+                actTarget(current)));
     }
 
     /** R4 T1547: 자동실행/시작 경로에 생성된 파일 (지속성 확보, 저심각 point 룰). */
@@ -144,7 +147,8 @@ public final class Rules {
                 Alert.actionFor(Alert.SEV_MEDIUM),
                 current.ts(),
                 List.of(summary(current)),
-                current.tenantId()));
+                current.tenantId(),
+                actTarget(current)));
     }
 
     private static boolean isProcess(Event e) {
@@ -180,6 +184,12 @@ public final class Rules {
 
     private static String lower(String s) {
         return s == null ? null : s.toLowerCase();
+    }
+
+    /** 조치 대상 프로세스 식별자 — 전체 경로(cmdline)가 있으면 우선, 없으면 프로세스명. responder 가 kill 에 사용. */
+    private static String actTarget(Event e) {
+        String cmd = e.cmdline();
+        return (cmd != null && !cmd.isBlank()) ? cmd : e.process();
     }
 
     /** 근거 이벤트를 사람이 읽을 요약으로. */

--- a/responder-service/build.gradle
+++ b/responder-service/build.gradle
@@ -1,6 +1,6 @@
-// Responder — alerts 를 소비해 권장 조치를 dry-run(표시만)으로 로그 출력 (group: responder)
+// Responder — alerts 소비 → 권장 조치 dry-run 표시 + 반자동 실제 조치(Fleet run-script) (group: responder)
 dependencies {
-    implementation 'org.springframework.boot:spring-boot-starter'
+    implementation 'org.springframework.boot:spring-boot-starter-web'  // 실행 트리거 API + RestClient(Fleet 호출)
     implementation 'org.springframework.kafka:spring-kafka'
     implementation 'com.fasterxml.jackson.core:jackson-databind'   // alerts JSON 역직렬화
 }

--- a/responder-service/src/main/java/com/edrdog/responderservice/api/KillController.java
+++ b/responder-service/src/main/java/com/edrdog/responderservice/api/KillController.java
@@ -1,0 +1,41 @@
+package com.edrdog.responderservice.api;
+
+import com.edrdog.responderservice.response.ExecuteResult;
+import com.edrdog.responderservice.response.ResponseExecutor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 반자동 실제 조치 트리거 API. 대시보드의 "실행" 버튼이 호출한다(자동 실행 아님).
+ * 실행 경로(권한·Fleet 호출·kill 검증)는 다 만들되 방아쇠는 사람이 당긴다.
+ */
+@RestController
+@RequestMapping("/api/responder")
+public class KillController {
+
+    private final ResponseExecutor executor;
+
+    public KillController(ResponseExecutor executor) {
+        this.executor = executor;
+    }
+
+    /** host 의 target 프로세스 kill 실행. */
+    @PostMapping("/kill")
+    public ResponseEntity<ExecuteResult> kill(@RequestBody KillRequest req) {
+        if (isBlank(req.host()) || isBlank(req.target())) {
+            return ResponseEntity.badRequest().build();
+        }
+        return ResponseEntity.ok(executor.killProcess(req.host(), req.target()));
+    }
+
+    private static boolean isBlank(String s) {
+        return s == null || s.isBlank();
+    }
+
+    /** kill 트리거 요청 본문. */
+    public record KillRequest(String host, String target) {
+    }
+}

--- a/responder-service/src/main/java/com/edrdog/responderservice/dto/Alert.java
+++ b/responder-service/src/main/java/com/edrdog/responderservice/dto/Alert.java
@@ -13,6 +13,7 @@ import java.util.List;
  * @param action   권고 대응: notify | kill | isolate
  * @param ts       판정을 완성시킨 트리거 이벤트 시각 (epoch millis)
  * @param matched  판정 근거가 된 이벤트 요약들
+ * @param target   조치 대상 프로세스명/경로 (kill 실행에 사용, 없으면 null)
  */
 public record Alert(
         String host,
@@ -21,7 +22,8 @@ public record Alert(
         String severity,
         String action,
         long ts,
-        List<String> matched
+        List<String> matched,
+        String target
 ) {
     public static final String ACTION_NOTIFY = "notify";
     public static final String ACTION_KILL = "kill";

--- a/responder-service/src/main/java/com/edrdog/responderservice/fleet/FleetClient.java
+++ b/responder-service/src/main/java/com/edrdog/responderservice/fleet/FleetClient.java
@@ -1,0 +1,58 @@
+package com.edrdog.responderservice.fleet;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+import java.util.Map;
+
+/**
+ * Fleet REST API 호출 래퍼. 자체 엔드포인트 에이전트를 만들지 않고 Fleet 의 스크립트 실행 기능을 통해
+ * 등록된 호스트에서 조치 스크립트를 실행한다.
+ *
+ * 사용 엔드포인트:
+ * - GET  /api/v1/fleet/hosts/identifier/{identifier} : 호스트 식별자 → Fleet host id
+ * - POST /api/v1/fleet/scripts/run/sync              : 스크립트 동기 실행(결과까지 대기)
+ *
+ * 지연 특성: Fleet 은 push 가 아니라 fleetd 폴링이라 sync 호출도 폴링 한 주기만큼 걸릴 수 있다(수초~수십초).
+ */
+@Component
+public class FleetClient {
+
+    private final RestClient http;
+
+    public FleetClient(@Value("${edrdog.fleet.base-url}") String baseUrl,
+                       @Value("${edrdog.fleet.token}") String token) {
+        this.http = RestClient.builder()
+                .baseUrl(baseUrl)
+                .defaultHeader("Authorization", "Bearer " + token)
+                .build();
+    }
+
+    /** 호스트 식별자(hostname/uuid)를 Fleet 내부 host id 로 변환. */
+    public int resolveHostId(String identifier) {
+        HostIdentifierResponse res = http.get()
+                .uri("/api/v1/fleet/hosts/identifier/{id}", identifier)
+                .retrieve()
+                .body(HostIdentifierResponse.class);
+        if (res == null || res.host() == null) {
+            throw new IllegalStateException("Fleet 에서 호스트를 찾지 못함: " + identifier);
+        }
+        return res.host().id();
+    }
+
+    /** 스크립트를 호스트에서 동기 실행하고 결과를 반환. */
+    public FleetScriptResult runScriptSync(int hostId, String scriptContents) {
+        return http.post()
+                .uri("/api/v1/fleet/scripts/run/sync")
+                .body(Map.of("host_id", hostId, "script_contents", scriptContents))
+                .retrieve()
+                .body(FleetScriptResult.class);
+    }
+
+    /** GET hosts/identifier 응답의 필요한 부분만. */
+    private record HostIdentifierResponse(Host host) {
+        private record Host(int id) {
+        }
+    }
+}

--- a/responder-service/src/main/java/com/edrdog/responderservice/fleet/FleetScriptResult.java
+++ b/responder-service/src/main/java/com/edrdog/responderservice/fleet/FleetScriptResult.java
@@ -1,0 +1,22 @@
+package com.edrdog.responderservice.fleet;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Fleet `POST /scripts/run/sync` 응답 (필요한 필드만).
+ * exit_code 는 스크립트가 아직 안 끝났으면 null 로 온다.
+ *
+ * @param executionId Fleet 실행 식별자
+ * @param exitCode    스크립트 종료 코드 (미완료면 null)
+ * @param hostTimeout 호스트가 제한시간 내 응답 못 함
+ * @param output      스크립트 표준출력
+ * @param message     Fleet 측 메시지 (오류 등)
+ */
+public record FleetScriptResult(
+        @JsonProperty("execution_id") String executionId,
+        @JsonProperty("exit_code") Integer exitCode,
+        @JsonProperty("host_timeout") boolean hostTimeout,
+        String output,
+        String message
+) {
+}

--- a/responder-service/src/main/java/com/edrdog/responderservice/response/ExecuteResult.java
+++ b/responder-service/src/main/java/com/edrdog/responderservice/response/ExecuteResult.java
@@ -1,0 +1,12 @@
+package com.edrdog.responderservice.response;
+
+/**
+ * 실제 조치 실행 결과(트리거 API 응답).
+ *
+ * @param host        대상 호스트
+ * @param target      대상 프로세스명/경로
+ * @param status      KILLED | NO_MATCH | TIMEOUT | FAILED | COOLDOWN | DISABLED
+ * @param executionId Fleet 실행 식별자 (없으면 null)
+ */
+public record ExecuteResult(String host, String target, String status, String executionId) {
+}

--- a/responder-service/src/main/java/com/edrdog/responderservice/response/KillOutcome.java
+++ b/responder-service/src/main/java/com/edrdog/responderservice/response/KillOutcome.java
@@ -1,0 +1,37 @@
+package com.edrdog.responderservice.response;
+
+import com.edrdog.responderservice.fleet.FleetScriptResult;
+
+/**
+ * Fleet 스크립트 실행 결과를 조치 결과로 해석하는 순수 로직.
+ */
+public enum KillOutcome {
+    /** 일치 프로세스를 kill 함. */
+    KILLED,
+    /** 일치 프로세스가 없어 아무것도 안 함(이미 종료 등). */
+    NO_MATCH,
+    /** 호스트 오프라인/제한시간 초과로 실행 확인 못 함. */
+    TIMEOUT,
+    /** 스크립트가 실패했거나 예상치 못한 출력. */
+    FAILED;
+
+    private static final String MARK_KILLED = "EDRDOG_RESULT=KILLED";
+    private static final String MARK_NO_MATCH = "EDRDOG_RESULT=NO_MATCH";
+
+    public static KillOutcome interpret(FleetScriptResult r) {
+        if (r.hostTimeout() || r.exitCode() == null) {
+            return TIMEOUT;
+        }
+        if (r.exitCode() != 0) {
+            return FAILED;
+        }
+        String out = r.output() == null ? "" : r.output();
+        if (out.contains(MARK_KILLED)) {
+            return KILLED;
+        }
+        if (out.contains(MARK_NO_MATCH)) {
+            return NO_MATCH;
+        }
+        return FAILED;
+    }
+}

--- a/responder-service/src/main/java/com/edrdog/responderservice/response/KillScript.java
+++ b/responder-service/src/main/java/com/edrdog/responderservice/response/KillScript.java
@@ -1,0 +1,50 @@
+package com.edrdog.responderservice.response;
+
+/**
+ * 대상 프로세스명과 "정확히 일치"하는 실행 중 프로세스만 kill 하는 POSIX sh 스크립트를 생성하는 순수 로직.
+ *
+ * 안전 설계:
+ * - 조치 시점 호스트에서 pid 를 실시간 해석 → 탐지 시점 PID 재사용 문제 회피.
+ * - comm(basename) 정확 일치(==)로만 매칭 → 부분일치/정규식 오탐 차단.
+ * - 타깃을 작은따옴표로 감싸고 내부 작은따옴표를 이스케이프 → 셸 인젝션 차단.
+ *
+ * 한계(실제 osquery 수집 붙으면 정밀화): basename 매칭이라 같은 이름 프로세스가 여럿이면 모두 kill.
+ * 전체 경로/PID+start_time 검증은 이벤트 스키마에 pid 가 실려오는 시점에 추가한다.
+ */
+public final class KillScript {
+
+    private KillScript() {
+    }
+
+    /** 경로에서 파일명만 추출 ('/' 와 '\' 모두 구분자로 취급). */
+    static String basename(String target) {
+        if (target == null) {
+            return "";
+        }
+        int slash = Math.max(target.lastIndexOf('/'), target.lastIndexOf('\\'));
+        return slash >= 0 ? target.substring(slash + 1) : target;
+    }
+
+    /** POSIX 작은따옴표 이스케이프: ' → '\'' (닫고, 이스케이프된 따옴표, 다시 열기). */
+    private static String shSingleQuote(String s) {
+        return "'" + s.replace("'", "'\\''") + "'";
+    }
+
+    /** target(프로세스명 또는 경로) → 정확 일치 kill 스크립트. */
+    public static String build(String target) {
+        String name = shSingleQuote(basename(target));
+        return """
+                #!/bin/sh
+                # EDRdog responder: 대상 프로세스명과 정확히 일치하는 실행 프로세스를 kill (trigger=response)
+                name=%s
+                pids=$(ps -Ao pid=,comm= | awk -v n="$name" '$2==n {print $1}')
+                if [ -z "$pids" ]; then
+                  echo "EDRDOG_RESULT=NO_MATCH name=$name"
+                  exit 0
+                fi
+                echo "EDRDOG_RESULT=MATCH name=$name pids=$pids"
+                kill $pids 2>/dev/null
+                echo "EDRDOG_RESULT=KILLED name=$name pids=$pids"
+                """.formatted(name);
+    }
+}

--- a/responder-service/src/main/java/com/edrdog/responderservice/response/ResponseExecutor.java
+++ b/responder-service/src/main/java/com/edrdog/responderservice/response/ResponseExecutor.java
@@ -1,0 +1,58 @@
+package com.edrdog.responderservice.response;
+
+import com.edrdog.responderservice.fleet.FleetClient;
+import com.edrdog.responderservice.fleet.FleetScriptResult;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+/**
+ * 실제 조치(프로세스 kill)를 Fleet run-script 로 실행하는 반자동 실행기.
+ *
+ * 안전장치:
+ * - enabled 기본 false → 켜기 전엔 실제 실행 안 함(dry-run 유지).
+ * - 사람이 트리거(대시보드 버튼 → API)해야 실행 → 오탐 리스크는 사람이 차단.
+ * - host 단위 쿨다운 → 동일 호스트 재조치/폭주 차단(무한 루프 2차 방어).
+ * - trigger=response 태깅 → 이 조치가 만든 이벤트는 판정에서 제외(무한 루프 1차 방어).
+ */
+@Service
+public class ResponseExecutor {
+
+    private static final Logger log = LoggerFactory.getLogger(ResponseExecutor.class);
+
+    private final FleetClient fleet;
+    private final boolean enabled;
+    private final Cooldown cooldown;
+
+    public ResponseExecutor(FleetClient fleet,
+                            @Value("${edrdog.responder.execute.enabled}") boolean enabled,
+                            @Value("${edrdog.responder.cooldown-ms}") long cooldownMs) {
+        this.fleet = fleet;
+        this.enabled = enabled;
+        this.cooldown = new Cooldown(cooldownMs);
+    }
+
+    /** host 의 target 프로세스를 kill. 실행 스위치·쿨다운을 통과할 때만 Fleet 을 호출한다. */
+    public ExecuteResult killProcess(String host, String target) {
+        if (!enabled) {
+            log.info("[EXECUTE-DISABLED] trigger=response host={} target={} (실행 스위치 꺼짐, 아무것도 안 함)", host, target);
+            return new ExecuteResult(host, target, "DISABLED", null);
+        }
+        if (!cooldown.allow(host, System.currentTimeMillis())) {
+            log.info("[EXECUTE-COOLDOWN] trigger=response host={} target={} (쿨다운, 재조치 억제)", host, target);
+            return new ExecuteResult(host, target, "COOLDOWN", null);
+        }
+        try {
+            int hostId = fleet.resolveHostId(host);
+            FleetScriptResult result = fleet.runScriptSync(hostId, KillScript.build(target));
+            KillOutcome outcome = KillOutcome.interpret(result);
+            log.info("[EXECUTE] trigger=response host={} target={} outcome={} execId={}",
+                    host, target, outcome, result.executionId());
+            return new ExecuteResult(host, target, outcome.name(), result.executionId());
+        } catch (Exception e) {
+            log.error("[EXECUTE-FAILED] trigger=response host={} target={} err={}", host, target, e.toString());
+            return new ExecuteResult(host, target, "FAILED", null);
+        }
+    }
+}

--- a/responder-service/src/main/resources/application.yml
+++ b/responder-service/src/main/resources/application.yml
@@ -19,7 +19,12 @@ edrdog:
   kafka:
     alerts-topic: alerts        # detector 가 발행한 판정 결과 (소비 입력)
   responder:
-    cooldown-ms: 60000          # 같은 host+action 중복 표시 억제 창
+    cooldown-ms: 60000          # 같은 host+action 중복 표시 / 재조치 억제 창
+    execute:
+      enabled: ${RESPONDER_EXECUTE_ENABLED:false}  # 실제 조치 실행 스위치 (기본 OFF = dry-run 유지)
+  fleet:
+    base-url: ${FLEET_BASE_URL:http://localhost:8080}  # Fleet 서버
+    token: ${FLEET_TOKEN:}                             # Fleet API 토큰 (Bearer)
 
 management:
   endpoints:

--- a/responder-service/src/test/java/com/edrdog/responderservice/response/KillOutcomeTest.java
+++ b/responder-service/src/test/java/com/edrdog/responderservice/response/KillOutcomeTest.java
@@ -1,0 +1,55 @@
+package com.edrdog.responderservice.response;
+
+import com.edrdog.responderservice.fleet.FleetScriptResult;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Fleet 스크립트 실행 결과(exit_code/host_timeout/output)를 조치 결과로 해석하는 순수 로직 검증.
+ */
+class KillOutcomeTest {
+
+    private FleetScriptResult result(Integer exitCode, boolean hostTimeout, String output) {
+        return new FleetScriptResult("exec-1", exitCode, hostTimeout, output, "");
+    }
+
+    @Test
+    @DisplayName("exit 0 + KILLED 마커면 KILLED")
+    void killed() {
+        var r = result(0, false, "EDRDOG_RESULT=MATCH name=x pids=42\nEDRDOG_RESULT=KILLED name=x pids=42");
+        assertThat(KillOutcome.interpret(r)).isEqualTo(KillOutcome.KILLED);
+    }
+
+    @Test
+    @DisplayName("exit 0 + NO_MATCH 마커면 NO_MATCH")
+    void noMatch() {
+        var r = result(0, false, "EDRDOG_RESULT=NO_MATCH name=x");
+        assertThat(KillOutcome.interpret(r)).isEqualTo(KillOutcome.NO_MATCH);
+    }
+
+    @Test
+    @DisplayName("host_timeout 이면 exit_code 와 무관하게 TIMEOUT")
+    void hostTimeout() {
+        assertThat(KillOutcome.interpret(result(null, true, ""))).isEqualTo(KillOutcome.TIMEOUT);
+    }
+
+    @Test
+    @DisplayName("exit_code 가 아직 없으면(비동기 대기) TIMEOUT 으로 간주")
+    void pendingExitCode() {
+        assertThat(KillOutcome.interpret(result(null, false, ""))).isEqualTo(KillOutcome.TIMEOUT);
+    }
+
+    @Test
+    @DisplayName("0 아닌 exit_code 는 FAILED")
+    void nonZeroExit() {
+        assertThat(KillOutcome.interpret(result(1, false, "some error"))).isEqualTo(KillOutcome.FAILED);
+    }
+
+    @Test
+    @DisplayName("exit 0 인데 마커가 없으면 FAILED(예상치 못한 출력)")
+    void exitZeroNoMarker() {
+        assertThat(KillOutcome.interpret(result(0, false, "garbage"))).isEqualTo(KillOutcome.FAILED);
+    }
+}

--- a/responder-service/src/test/java/com/edrdog/responderservice/response/KillScriptTest.java
+++ b/responder-service/src/test/java/com/edrdog/responderservice/response/KillScriptTest.java
@@ -1,0 +1,45 @@
+package com.edrdog.responderservice.response;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * 대상 프로세스명을 안전하게 박아 정확 일치 프로세스만 kill 하는 POSIX sh 스크립트 생성 검증 (순수 로직).
+ * 핵심은 셸 인젝션 차단(작은따옴표 이스케이프)과 경로→basename 정규화.
+ */
+class KillScriptTest {
+
+    @Test
+    @DisplayName("전체 경로 타깃은 basename 으로 매칭한다")
+    void path_reducedToBasename() {
+        assertThat(KillScript.basename("C:\\Windows\\System32\\powershell.exe")).isEqualTo("powershell.exe");
+        assertThat(KillScript.basename("/usr/bin/curl")).isEqualTo("curl");
+        assertThat(KillScript.basename("powershell.exe")).isEqualTo("powershell.exe");
+    }
+
+    @Test
+    @DisplayName("타깃은 작은따옴표로 감싸 셸 인젝션을 차단한다")
+    void target_singleQuotedToBlockInjection() {
+        // 슬래시 없는 페이로드(있으면 basename 이 먼저 잘라냄): 작은따옴표로 조기 종료를 노림
+        String script = KillScript.build("evil.exe'; rm -rf ~ #");
+
+        // 내부 작은따옴표가 '\'' 로 이스케이프되어 조기 종료가 무력화되어야 함
+        assertThat(script).contains("name='evil.exe'\\''; rm -rf ~ #'");
+        assertThat(script).doesNotContain("name='evil.exe'; rm -rf ~ #'");
+    }
+
+    @Test
+    @DisplayName("스크립트는 정확 일치(comm==name)로만 pid 를 찾고 결과 마커를 출력한다")
+    void script_exactMatchAndMarkers() {
+        String script = KillScript.build("/usr/bin/powershell.exe");
+
+        assertThat(script).startsWith("#!/bin/sh");
+        assertThat(script).contains("name='powershell.exe'");
+        assertThat(script).contains("$2==n");          // awk 정확 일치
+        assertThat(script).contains("kill $pids");
+        assertThat(script).contains("EDRDOG_RESULT=NO_MATCH");
+        assertThat(script).contains("EDRDOG_RESULT=KILLED");
+    }
+}

--- a/responder-service/src/test/java/com/edrdog/responderservice/response/ResponseExecutorTest.java
+++ b/responder-service/src/test/java/com/edrdog/responderservice/response/ResponseExecutorTest.java
@@ -1,0 +1,70 @@
+package com.edrdog.responderservice.response;
+
+import com.edrdog.responderservice.fleet.FleetClient;
+import com.edrdog.responderservice.fleet.FleetScriptResult;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+/** 실행 스위치·쿨다운·예외 가드 검증 (Fleet 호출은 목으로 대체). */
+class ResponseExecutorTest {
+
+    private final FleetClient fleet = mock(FleetClient.class);
+
+    private FleetScriptResult killed() {
+        return new FleetScriptResult("exec-1", 0, false, "EDRDOG_RESULT=KILLED name=x pids=1", "");
+    }
+
+    @Test
+    @DisplayName("실행 스위치 OFF 면 Fleet 을 호출하지 않고 DISABLED")
+    void disabled_noFleetCall() {
+        ResponseExecutor executor = new ResponseExecutor(fleet, false, 60_000);
+
+        ExecuteResult result = executor.killProcess("host-1", "powershell.exe");
+
+        assertThat(result.status()).isEqualTo("DISABLED");
+        verifyNoInteractions(fleet);
+    }
+
+    @Test
+    @DisplayName("스위치 ON 이면 Fleet 실행 후 결과 상태를 반환")
+    void enabled_runsAndReturnsOutcome() {
+        when(fleet.resolveHostId("host-1")).thenReturn(42);
+        when(fleet.runScriptSync(eq(42), anyString())).thenReturn(killed());
+        ResponseExecutor executor = new ResponseExecutor(fleet, true, 60_000);
+
+        ExecuteResult result = executor.killProcess("host-1", "powershell.exe");
+
+        assertThat(result.status()).isEqualTo("KILLED");
+        assertThat(result.executionId()).isEqualTo("exec-1");
+    }
+
+    @Test
+    @DisplayName("같은 호스트가 쿨다운 안에 다시 오면 COOLDOWN, Fleet 은 한 번만 호출")
+    void cooldown_suppressesSecondCall() {
+        when(fleet.resolveHostId(anyString())).thenReturn(42);
+        when(fleet.runScriptSync(anyInt(), anyString())).thenReturn(killed());
+        ResponseExecutor executor = new ResponseExecutor(fleet, true, 60_000);
+
+        executor.killProcess("host-1", "powershell.exe");
+        ExecuteResult second = executor.killProcess("host-1", "cmd.exe");
+
+        assertThat(second.status()).isEqualTo("COOLDOWN");
+        verify(fleet, times(1)).runScriptSync(anyInt(), anyString());
+    }
+
+    @Test
+    @DisplayName("Fleet 호출이 실패하면 FAILED")
+    void fleetError_returnsFailed() {
+        when(fleet.resolveHostId(anyString())).thenThrow(new IllegalStateException("호스트 없음"));
+        ResponseExecutor executor = new ResponseExecutor(fleet, true, 60_000);
+
+        ExecuteResult result = executor.killProcess("host-1", "powershell.exe");
+
+        assertThat(result.status()).isEqualTo("FAILED");
+    }
+}

--- a/responder-service/src/test/java/com/edrdog/responderservice/response/ResponsePlannerTest.java
+++ b/responder-service/src/test/java/com/edrdog/responderservice/response/ResponsePlannerTest.java
@@ -12,7 +12,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class ResponsePlannerTest {
 
     private Alert alert(String host, String ruleId, String action, long ts) {
-        return new Alert(host, ruleId, "T1059", "HIGH", action, ts, List.of("evidence"));
+        return new Alert(host, ruleId, "T1059", "HIGH", action, ts, List.of("evidence"), "powershell.exe");
     }
 
     @Test

--- a/scripts/fleet-verify.sh
+++ b/scripts/fleet-verify.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# responder 실제 조치(#59)의 선결 확인: Fleet 이 우리가 쓰는 방식으로 동작하는지 실기 검증한다.
+#   1) host 식별자 → Fleet 매핑이 되는지
+#   2) scripts 실행이 이 호스트에서 가능한지 (fleetd 가 --enable-scripts 로 배포됐는지)
+#   3) scripts 동기 실행 실제 지연 (= "수초냐" 의 실측값. Fleet 은 폴링이라 보통 수십초)
+#
+# fleetctl 로 호출한다(시스템 curl 의 LibreSSL 이 Fleet TLS 를 못 뚫는 문제 회피).
+# responder 의 Java RestClient(JSSE)는 이 문제가 없으므로 코드와 무관하다.
+#
+# 전제: Fleet 기동(예: fleetctl preview) + fleetctl login + 테스트 호스트 등록.
+#
+# 사용:
+#   ./scripts/fleet-verify.sh <host-식별자>
+#   (host-식별자 = osquery 가 보고하는 hostname. detector 이벤트의 host 와 같아야 함)
+set -euo pipefail
+
+HOST="${1:?호스트 식별자 인자 필요 (hostname). 예: my-macbook.local}"
+command -v fleetctl >/dev/null || { echo "fleetctl 필요 (npm i -g fleetctl 또는 brew install fleetctl)" >&2; exit 1; }
+
+echo "== 1) host 식별자 → Fleet 매핑 =="
+if fleetctl get host "${HOST}" >/dev/null 2>&1; then
+  echo "  OK: '${HOST}' 조회됨"
+else
+  echo "  실패: '${HOST}' 못 찾음. 등록된 호스트 목록:"
+  fleetctl get hosts || true
+  exit 1
+fi
+
+echo "== 2)+3) scripts 동기 실행 + 지연 =="
+SCRIPT="$(mktemp /tmp/edrdog-verify-XXXXXX.sh)"
+trap 'rm -f "${SCRIPT}"' EXIT
+printf '#!/bin/sh\necho EDRDOG_VERIFY_OK\n' > "${SCRIPT}"
+
+START="$(date +%s)"
+set +e
+OUT="$(fleetctl run-script --host "${HOST}" --script-path "${SCRIPT}" 2>&1)"
+set -e
+END="$(date +%s)"
+
+echo "  지연: $((END - START))s  (이 값이 '수초/수십초' 의 실측 답)"
+echo "  결과: ${OUT}"
+if echo "${OUT}" | grep -q EDRDOG_VERIFY_OK; then
+  echo "  OK: 호스트에서 실제 실행됨 → responder 실행 경로 성립"
+elif echo "${OUT}" | grep -qi 'disabled'; then
+  echo "  막힘: 이 호스트의 fleetd 가 scripts 비활성."
+  echo "        → fleetctl package ... --enable-scripts 로 만든 패키지로 재설치해야 함."
+else
+  echo "  주의: 예상 밖 결과(위 결과 참고). 호스트 오프라인/타임아웃 가능성."
+fi


### PR DESCRIPTION
## 요약
dry-run(표시만)에 더해 **반자동 실제 조치(프로세스 kill)** 를 Fleet run-script 로 실행.

## 변경
- detector: `Alert` 에 `target`(조치 대상 프로세스) 추가 → alerts 로 전달
- responder:
  - `FleetClient` — host id 매핑 + `scripts/run/sync` 호출
  - `KillScript` — 호스트에서 pid 실시간 해석 후 정확일치 프로세스만 kill (PID 재사용 회피, 셸 인젝션 차단)
  - `KillOutcome` — exit_code/host_timeout/마커 → 조치 결과 해석
  - `ResponseExecutor` — 실행 스위치(기본 OFF)·쿨다운·예외 가드 + `trigger=response` 태깅
  - `KillController` — 반자동 트리거 API `POST /api/responder/kill`
- `scripts/fleet-verify.sh` — Fleet 실기 검증(매핑·scripts 활성·지연)

## 설계 결정
- kill 대상은 **경로/이름으로 지정하고 호스트에서 실시간 pid 해석** → 탐지 시점 PID 재사용 문제 회피(파이프라인에 PID 없음).
- 격리·완전자동은 범위 밖(후속).

## 검증
- 순수 로직 TDD: `KillScript`/`KillOutcome`/`ResponseExecutor` (9 테스트 통과), 전체 모듈 컴파일 OK.
- 실기(fleetctl preview): host 매핑 동작 / scripts 는 fleetd `--enable-scripts` 필요 / 지연 폴링이라 수십초대.

## 안전장치
- 실행 스위치 기본 OFF(`RESPONDER_EXECUTE_ENABLED`), 반자동(사람이 방아쇠), 쿨다운, `trigger=response` 판정 제외.

Closes #59