### PR TITLE
chore: ClickHouse 비밀번호를 env(CLICKHOUSE_PASSWORD)로 분리

### DIFF
--- a/api-service/src/main/resources/application.yml
+++ b/api-service/src/main/resources/application.yml
@@ -54,7 +54,7 @@ edrdog:
     url: http://localhost:8123           # k8s NodePort HTTP (archiver 와 동일 DB, 읽기)
     database: edrdog
     user: edrdog
-    password: edrdog
+    password: ${CLICKHOUSE_PASSWORD:edrdog}   # 시크릿은 Infisical 주입, 기본값은 로컬 kind ClickHouse 와 일치
     table: edrdog.events                 # 조회 대상 테이블 (archiver 가 적재)
   geoip:
     db-path: ${GEOIP_DB_PATH:}           # GeoLite2-Country.mmdb 외부 경로. 비면 클래스패스 번들 사용, 둘 다 없으면 geo API 빈 배열

--- a/archiver-service/src/main/resources/application.yml
+++ b/archiver-service/src/main/resources/application.yml
@@ -22,7 +22,7 @@ edrdog:
     url: http://localhost:8123        # k8s NodePort HTTP
     database: edrdog
     user: edrdog
-    password: edrdog
+    password: ${CLICKHOUSE_PASSWORD:edrdog}   # 시크릿은 Infisical 주입, 기본값은 로컬 kind ClickHouse 와 일치
     table: edrdog.events              # 적재 대상 테이블
 
 management:


### PR DESCRIPTION
## 변경
하드코딩 `password: edrdog` → `${CLICKHOUSE_PASSWORD:edrdog}` (api-service, archiver-service).

## 이유
Infisical 의 `CLICKHOUSE_PASSWORD` 가 코드에서 안 읽혀 "죽어 있던" 상태 → env 로 빼서 주입값이 실제 적용되게 함.

## 안전
- 기본값 `edrdog` = 로컬 kind ClickHouse 비번과 동일 → env 미설정 시 기존과 동일 동작(안 깨짐).
- api-service·archiver-service 테스트 통과.

## ⚠️ 운영 주의
Infisical 에 `edrdog` 가 아닌 값을 넣으면, **ClickHouse 서버(k8s clickhouse.yaml) 비번도 같은 값**으로 맞춰야 연결됨. 로컬 데모는 양쪽 `edrdog` 유지.