### PR TITLE
chore: api-service·alert-service 컨테이너화 및 배포 매니페스트

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -31,6 +31,8 @@ jobs:
             detector-service/build/libs/*.jar
             responder-service/build/libs/*.jar
             archiver-service/build/libs/*.jar
+            api-service/build/libs/*.jar
+            alert-service/build/libs/*.jar
 
   # 이미지 빌드 + GHCR 푸시 (main 푸시에만, 모듈별 matrix)
   image:
@@ -42,7 +44,7 @@ jobs:
       packages: write
     strategy:
       matrix:
-        module: [detector-service, responder-service, archiver-service]
+        module: [detector-service, responder-service, archiver-service, api-service, alert-service]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4
@@ -90,10 +92,12 @@ jobs:
           kubectl apply -n "$NS" \
             -f k8s/detector-service.yaml \
             -f k8s/responder-service.yaml \
-            -f k8s/archiver-service.yaml
-          for m in detector-service responder-service archiver-service; do
+            -f k8s/archiver-service.yaml \
+            -f k8s/api-service.yaml \
+            -f k8s/alert-service.yaml
+          for m in detector-service responder-service archiver-service api-service alert-service; do
             kubectl set image deployment/$m "$m=ghcr.io/${REPO,,}/$m:${SHA}" -n "$NS"
           done
-          for m in detector-service responder-service archiver-service; do
+          for m in detector-service responder-service archiver-service api-service alert-service; do
             kubectl rollout status deployment/$m -n "$NS" --timeout=120s
           done

--- a/alert-service/Dockerfile
+++ b/alert-service/Dockerfile
@@ -1,0 +1,6 @@
+FROM eclipse-temurin:21-jre
+WORKDIR /app
+# CI가 build/libs 에 boot jar 하나만 남겨 전달 (plain jar 는 제거됨)
+COPY build/libs/*.jar app.jar
+EXPOSE 8083
+ENTRYPOINT ["java", "-jar", "/app/app.jar"]

--- a/api-service/Dockerfile
+++ b/api-service/Dockerfile
@@ -1,0 +1,6 @@
+FROM eclipse-temurin:21-jre
+WORKDIR /app
+# CI가 build/libs 에 boot jar 하나만 남겨 전달 (plain jar 는 제거됨)
+COPY build/libs/*.jar app.jar
+EXPOSE 8084
+ENTRYPOINT ["java", "-jar", "/app/app.jar"]

--- a/api-service/src/main/resources/application.yml
+++ b/api-service/src/main/resources/application.yml
@@ -51,7 +51,7 @@ edrdog:
   internal:
     key: ${INTERNAL_API_KEY:dev-internal-key}   # 서비스 간 내부 조회 전용 키 (프론트 X-API-Key 와 분리, X-Internal-Key 헤더)
   clickhouse:
-    url: http://localhost:8123           # k8s NodePort HTTP (archiver 와 동일 DB, 읽기)
+    url: ${EDRDOG_CLICKHOUSE_URL:http://localhost:8123}   # 배포 시 clickhouse:8123 주입, 로컬은 host NodePort
     database: edrdog
     user: edrdog
     password: ${CLICKHOUSE_PASSWORD:edrdog}   # 시크릿은 Infisical 주입, 기본값은 로컬 kind ClickHouse 와 일치

--- a/k8s/alert-service.yaml
+++ b/k8s/alert-service.yaml
@@ -1,0 +1,62 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: alert-service
+  namespace: edrdog
+  labels:
+    app: alert-service
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: alert-service
+  template:
+    metadata:
+      labels:
+        app: alert-service
+    spec:
+      containers:
+        - name: alert-service
+          # 배포 시 CI 가 kubectl set image 로 실제 태그(:<sha>) 주입
+          image: ghcr.io/2026-siheung-bootcamp-team-i/backend/alert-service:latest
+          ports:
+            - containerPort: 8083
+          env:
+            - name: SPRING_KAFKA_BOOTSTRAP_SERVERS
+              value: "kafka:9094"
+            # tenant Slack webhook 조회용 api-service 내부 엔드포인트 (Service port 80)
+            - name: EDRDOG_API_BASE_URL
+              value: "http://api-service"
+          readinessProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8083
+            initialDelaySeconds: 15
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8083
+            initialDelaySeconds: 30
+            periodSeconds: 20
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: alert-service
+  namespace: edrdog
+  labels:
+    app: alert-service
+spec:
+  selector:
+    app: alert-service
+  ports:
+    - port: 80
+      targetPort: 8083

--- a/k8s/api-service.yaml
+++ b/k8s/api-service.yaml
@@ -1,0 +1,73 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: api-service
+  namespace: edrdog
+  labels:
+    app: api-service
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: api-service
+  template:
+    metadata:
+      labels:
+        app: api-service
+    spec:
+      containers:
+        - name: api-service
+          # 배포 시 CI 가 kubectl set image 로 실제 태그(:<sha>) 주입
+          image: ghcr.io/2026-siheung-bootcamp-team-i/backend/api-service:latest
+          ports:
+            - containerPort: 8084
+          env:
+            - name: KAFKA_BOOTSTRAP
+              value: "kafka:9094"
+            - name: DB_URL
+              value: "jdbc:mysql://mysql:3306/edrdog"
+            - name: DB_USER
+              value: "edrdog"
+            - name: DB_PASSWORD
+              value: "edrdog"
+            - name: EDRDOG_CLICKHOUSE_URL
+              value: "http://clickhouse:8123"
+            # 프론트 도메인 (배포 시 실제 값으로 교체)
+            - name: CORS_ALLOWED_ORIGINS
+              value: "http://localhost:5173"
+            # 발표 환경에서만 true (데모 계정 test/1234 + 과거 7일 시드)
+            - name: DEMO_SEED
+              value: "false"
+          readinessProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8084
+            initialDelaySeconds: 15
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8084
+            initialDelaySeconds: 30
+            periodSeconds: 20
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: api-service
+  namespace: edrdog
+  labels:
+    app: api-service
+spec:
+  selector:
+    app: api-service
+  ports:
+    - port: 80
+      targetPort: 8084


### PR DESCRIPTION
## 요약
detector·responder·archiver 만 컨테이너화돼 있던 상태에서, `api-service`·`alert-service` 를 배포 가능하게 만든다.

## 변경
- `api-service/Dockerfile` (EXPOSE 8084), `alert-service/Dockerfile` (EXPOSE 8083)
- `k8s/api-service.yaml` — MySQL(mysql:3306)·Kafka(kafka:9094)·ClickHouse(clickhouse:8123) 연결 env
- `k8s/alert-service.yaml` — Kafka + api-service webhook 조회(EDRDOG_API_BASE_URL=http://api-service) env
- `api-service` `clickhouse.url` 를 `EDRDOG_CLICKHOUSE_URL` 로 주입 가능하게 (k8s 에서 clickhouse:8123 필요)
- `cicd.yml` 아티팩트·이미지 매트릭스·배포 단계에 두 서비스 추가

## 검증
- 두 서비스 `bootJar` 빌드 성공 (exit 0)
- `k8s/*.yaml` `kubectl apply --dry-run=client` OK

## 배포 시 조치 (코드 아님)
- `CORS_ALLOWED_ORIGINS` 는 기본값(localhost:5173) → 실제 프론트 도메인으로 교체
- 발표 환경이면 api-service `DEMO_SEED=true`

Closes #65