### PR TITLE
fix: KillScript macOS 프로세스 매칭 (comm→args basename)

### DIFF
--- a/responder-service/src/main/java/com/edrdog/responderservice/response/KillScript.java
+++ b/responder-service/src/main/java/com/edrdog/responderservice/response/KillScript.java
@@ -5,11 +5,16 @@ package com.edrdog.responderservice.response;
  *
  * 안전 설계:
  * - 조치 시점 호스트에서 pid 를 실시간 해석 → 탐지 시점 PID 재사용 문제 회피.
- * - comm(basename) 정확 일치(==)로만 매칭 → 부분일치/정규식 오탐 차단.
+ * - 프로세스 basename 정확 일치(==)로만 매칭 → 부분일치/정규식 오탐 차단.
  * - 타깃을 작은따옴표로 감싸고 내부 작은따옴표를 이스케이프 → 셸 인젝션 차단.
  *
+ * 크로스플랫폼 매칭: ps 의 comm 은 macOS 에서 전체경로 + 16자 절단이라 basename 매칭이 깨진다.
+ * 그래서 args(argv0, 절단 없음)를 host 에서 basename 으로 정규화해 비교한다(Linux/macOS 공통 동작).
+ *
  * 한계(실제 osquery 수집 붙으면 정밀화): basename 매칭이라 같은 이름 프로세스가 여럿이면 모두 kill.
- * 전체 경로/PID+start_time 검증은 이벤트 스키마에 pid 가 실려오는 시점에 추가한다.
+ * argv0 경로에 공백이 있으면(예: macOS 앱번들 "…/Slack Helper.app/…/Slack Helper") ps args 의 첫
+ * 토큰이 공백에서 끊겨, 그 prefix 의 basename 으로 비교되어 형제 프로세스까지 과다매칭될 수 있다.
+ * 정밀 매칭(공백 경로/PID+start_time)은 osquery processes 테이블을 조회하는 시점에 추가한다.
  */
 public final class KillScript {
 
@@ -35,9 +40,10 @@ public final class KillScript {
         String name = shSingleQuote(basename(target));
         return """
                 #!/bin/sh
-                # EDRdog responder: 대상 프로세스명과 정확히 일치하는 실행 프로세스를 kill (trigger=response)
+                # EDRdog responder: 대상 프로세스명(basename)과 일치하는 실행 프로세스를 kill (trigger=response)
+                # args(argv0)를 basename 으로 정규화해 매칭한다(comm 은 macOS 에서 전체경로+절단이라 못 씀).
                 name=%s
-                pids=$(ps -Ao pid=,comm= | awk -v n="$name" '$2==n {print $1}')
+                pids=$(ps -Ao pid=,args= | awk -v n="$name" '{p=$2; sub(/.*\\//,"",p); if (p==n) print $1}')
                 if [ -z "$pids" ]; then
                   echo "EDRDOG_RESULT=NO_MATCH name=$name"
                   exit 0

--- a/responder-service/src/test/java/com/edrdog/responderservice/response/KillScriptTest.java
+++ b/responder-service/src/test/java/com/edrdog/responderservice/response/KillScriptTest.java
@@ -31,15 +31,26 @@ class KillScriptTest {
     }
 
     @Test
-    @DisplayName("스크립트는 정확 일치(comm==name)로만 pid 를 찾고 결과 마커를 출력한다")
+    @DisplayName("스크립트는 args(argv0) basename 정확 일치로만 pid 를 찾고 결과 마커를 출력한다")
     void script_exactMatchAndMarkers() {
         String script = KillScript.build("/usr/bin/powershell.exe");
 
         assertThat(script).startsWith("#!/bin/sh");
         assertThat(script).contains("name='powershell.exe'");
-        assertThat(script).contains("$2==n");          // awk 정확 일치
+        assertThat(script).contains("ps -Ao pid=,args=");       // comm 아닌 args 사용(macOS 절단 회피)
+        assertThat(script).contains("sub(/.*\\//,\"\",p)");      // argv0 → basename 정규화
+        assertThat(script).contains("if (p==n)");               // basename 정확 일치
         assertThat(script).contains("kill $pids");
         assertThat(script).contains("EDRDOG_RESULT=NO_MATCH");
         assertThat(script).contains("EDRDOG_RESULT=KILLED");
+    }
+
+    @Test
+    @DisplayName("comm 은 macOS 에서 전체경로+절단이라 쓰지 않는다(회귀 방지)")
+    void script_doesNotUseComm() {
+        String script = KillScript.build("/usr/bin/curl");
+
+        assertThat(script).doesNotContain("comm=");
+        assertThat(script).doesNotContain("$2==n");
     }
 }


### PR DESCRIPTION
## 문제
responder의 `KillScript`가 `ps -o comm=`으로 프로세스를 매칭했는데, **macOS에서 `comm`은 basename이 아니라 전체경로(+16자 절단)**다. KillScript는 target을 basename으로 만든 뒤 comm과 `==` 비교하므로, **macOS 엔드포인트에서는 항상 NO_MATCH → kill이 절대 실행되지 않았다.**

Linux는 `comm`=basename이라 정상 동작했기 때문에 그동안 안 드러남. 실기기(macOS) 검증에서 발견.

## 수정
`args`(argv0, 절단 없음)를 호스트에서 basename으로 정규화해 비교:
```
pids=$(ps -Ao pid=,args= | awk -v n="$name" '{p=$2; sub(/.*\//,"",p); if (p==n) print $1}')
```
Linux/macOS 공통 동작.

## 실기기 검증 (macOS, Fleet run-script)
로컬 Fleet(`fleetctl preview`) + fleetd `--enable-scripts` 설치한 실제 맥에서:
1. 더미 프로세스 `edrdog-victim` (PID 29715) 기동
2. 수정된 KillScript 실행 → `EDRDOG_RESULT=MATCH ... KILLED pids=29715`
3. 동일 매처로 재확인 → `EDRDOG_GONE`

수정 전 스크립트는 같은 조건에서 NO_MATCH(kill 안 됨).

## 테스트
`./gradlew :responder-service:test` 통과. `KillScriptTest`:
- `args=` 사용 + basename 정규화 + `p==n` 매칭 검증
- 회귀 방지: `comm=` / `$2==n` 미사용 확인

## 알려진 한계 (주석 명시)
- argv0 경로에 공백이 있으면(macOS 앱번들 `.../Slack Helper.app/.../Slack Helper`) `ps args` 첫 토큰이 공백에서 끊겨 prefix basename으로 과다매칭 가능. 정밀 매칭은 osquery `processes` 테이블 조회 시점에 후속.
- responder 서비스 끝단(FleetClient가 https 자체서명 Fleet에 붙는 TLS 처리)은 이 PR 범위 밖. 이번 검증은 `fleetctl run-script`(= 동일 실행 메커니즘)로 확인.