### PR TITLE
feat: responder 실제 강제조치 인증·격리 (kill 프록시 + tenant 격리 + Fleet TLS) (#71)

### DIFF
--- a/api-service/src/main/java/com/edrdog/apiservice/alert/web/AlertController.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/alert/web/AlertController.java
@@ -1,15 +1,19 @@
 package com.edrdog.apiservice.alert.web;
 
 import com.edrdog.apiservice.alert.AlertService;
+import com.edrdog.apiservice.auth.exception.AuthException;
 import com.edrdog.apiservice.auth.service.AuthService;
 import com.edrdog.apiservice.auth.service.Principal;
 import com.edrdog.apiservice.query.TimeBucket;
+import com.edrdog.apiservice.responder.KillResult;
+import com.edrdog.apiservice.responder.ResponderClient;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -35,10 +39,12 @@ public class AlertController {
 
     private final AlertService alerts;
     private final AuthService auth;
+    private final ResponderClient responder;
 
-    public AlertController(AlertService alerts, AuthService auth) {
+    public AlertController(AlertService alerts, AuthService auth, ResponderClient responder) {
         this.alerts = alerts;
         this.auth = auth;
+        this.responder = responder;
     }
 
     @Operation(summary = "알림 목록", description = "로그인 유저의 tenant 것만 host/severity/status/from/to 필터로 최신순 조회. limit 기본 100, 상한 1000.")
@@ -115,6 +121,23 @@ public class AlertController {
         return alerts.triage(tenantId, id, request.status());
     }
 
+    @Operation(summary = "알림 실제 조치(kill)",
+            description = "대시보드 실행 버튼용 반자동 조치. 로그인 유저의 tenant 가 소유한 알림일 때만(타 tenant 404) "
+                    + "그 알림의 host 를 대상으로 target 프로세스 kill 을 responder 에 위임한다. host 는 알림에서 가져오므로 "
+                    + "클라이언트가 지정할 수 없다. 실제 kill 실행 여부는 responder 실행 스위치(RESPONDER_EXECUTE_ENABLED)에 달려 있다.")
+    @PostMapping("/{id}/respond")
+    public KillResult respond(
+            @RequestHeader(name = "Authorization", required = false) String authorization,
+            @PathVariable String id,
+            @RequestBody RespondRequest request) {
+        String tenantId = currentTenantId(authorization);
+        if (request == null || request.target() == null || request.target().isBlank()) {
+            throw AuthException.invalidInput("target 프로세스가 필요합니다");
+        }
+        AlertResponse alert = alerts.get(tenantId, id);   // 타 tenant 면 404, 통과하면 권위 있는 host 확보
+        return responder.kill(alert.host(), request.target());
+    }
+
     /** Bearer 토큰을 검증해 현재 유저의 tenant 를 문자열로 반환. 토큰이 없거나 만료면 AuthService 가 401. */
     private String currentTenantId(String authorization) {
         Principal principal = auth.resolve(bearerToken(authorization));
@@ -131,5 +154,9 @@ public class AlertController {
 
     /** PATCH 본문: 바꿀 status. */
     public record TriageRequest(String status) {
+    }
+
+    /** kill 요청 본문: 종료할 대상 프로세스명/경로. host 는 알림에서 가져오므로 클라이언트가 지정하지 않는다. */
+    public record RespondRequest(String target) {
     }
 }

--- a/api-service/src/main/java/com/edrdog/apiservice/responder/KillResult.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/responder/KillResult.java
@@ -1,0 +1,12 @@
+package com.edrdog.apiservice.responder;
+
+/**
+ * responder-service kill 실행 결과(responder 의 ExecuteResult 와 동일 필드 사본).
+ *
+ * @param host        대상 호스트
+ * @param target      대상 프로세스명/경로
+ * @param status      KILLED | NO_MATCH | TIMEOUT | FAILED | COOLDOWN | DISABLED
+ * @param executionId Fleet 실행 식별자 (없으면 null)
+ */
+public record KillResult(String host, String target, String status, String executionId) {
+}

--- a/api-service/src/main/java/com/edrdog/apiservice/responder/ResponderClient.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/responder/ResponderClient.java
@@ -1,0 +1,52 @@
+package com.edrdog.apiservice.responder;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientException;
+
+/**
+ * responder-service 내부 kill 엔드포인트 호출 래퍼.
+ *
+ * <p>responder 는 클러스터 내부(ClusterIP)로만 노출되고 앱 레벨 인증이 없다. 접근 통제는 이 프록시
+ * (api-service)의 Bearer 세션 인증 + tenant 소유 검증으로 대신한다(AlertController).
+ * 다른 내부 RestClient(ClickHouseReader 등)와 같은 per-component builder 패턴을 따른다.
+ */
+@Component
+public class ResponderClient {
+
+    private static final Logger log = LoggerFactory.getLogger(ResponderClient.class);
+
+    private final RestClient http;
+
+    public ResponderClient(@Value("${edrdog.responder.url}") String baseUrl) {
+        this.http = RestClient.builder().baseUrl(baseUrl).build();
+    }
+
+    /**
+     * host 의 target 프로세스 kill 을 responder 에 요청하고 실행 결과를 그대로 돌려준다.
+     * responder 가 죽어있거나 오류를 주면(연결 실패·4xx/5xx) 불투명한 500 대신 FAILED 결과로 매핑한다
+     * (responder 상태 어휘와 동일). 실패해도 실제 kill 은 일어나지 않으므로 fail-closed 다.
+     */
+    public KillResult kill(String host, String target) {
+        try {
+            KillResult result = http.post()
+                    .uri("/api/responder/kill")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .body(new KillCommand(host, target))
+                    .retrieve()
+                    .body(KillResult.class);
+            return result != null ? result : new KillResult(host, target, "FAILED", null);
+        } catch (RestClientException e) {
+            log.error("responder kill 위임 실패 host={} target={} err={}", host, target, e.toString());
+            return new KillResult(host, target, "FAILED", null);
+        }
+    }
+
+    /** responder kill 요청 본문(responder KillController.KillRequest 와 동일 필드). */
+    private record KillCommand(String host, String target) {
+    }
+}

--- a/api-service/src/main/resources/application.yml
+++ b/api-service/src/main/resources/application.yml
@@ -50,6 +50,8 @@ edrdog:
     allowed-origins: ${CORS_ALLOWED_ORIGINS:http://localhost:5173}
   internal:
     key: ${INTERNAL_API_KEY:dev-internal-key}   # 서비스 간 내부 조회 전용 키 (프론트 X-API-Key 와 분리, X-Internal-Key 헤더)
+  responder:
+    url: ${RESPONDER_URL:http://responder-service}   # 내부 responder-service(kill 프록시 대상, ClusterIP). 로컬은 http://localhost:8082
   clickhouse:
     url: ${EDRDOG_CLICKHOUSE_URL:http://localhost:8123}   # 배포 시 clickhouse:8123 주입, 로컬은 host NodePort
     database: edrdog

--- a/api-service/src/test/java/com/edrdog/apiservice/alert/web/AlertApiIntegrationTest.java
+++ b/api-service/src/test/java/com/edrdog/apiservice/alert/web/AlertApiIntegrationTest.java
@@ -4,6 +4,8 @@ import com.edrdog.apiservice.alert.AlertId;
 import com.edrdog.apiservice.alert.AlertStatus;
 import com.edrdog.apiservice.clickhouse.ClickHouseReader;
 import com.edrdog.apiservice.query.ClickHouseQuery;
+import com.edrdog.apiservice.responder.KillResult;
+import com.edrdog.apiservice.responder.ResponderClient;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -22,6 +24,9 @@ import java.util.List;
 import java.util.Map;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
@@ -50,6 +55,9 @@ class AlertApiIntegrationTest {
 
     @MockitoBean
     private ClickHouseReader reader;
+
+    @MockitoBean
+    private ResponderClient responder;
 
     /** 목 ClickHouse 의 판정기록(alerts 테이블) 시드. tenant/id 필터는 목이 쿼리 파라미터로 반영한다. */
     private final List<Map<String, Object>> alertRows = new ArrayList<>();
@@ -160,6 +168,64 @@ class AlertApiIntegrationTest {
     @Test
     void 토큰_없으면_401() throws Exception {
         mvc.perform(get("/api/alerts")).andExpect(status().isUnauthorized());
+    }
+
+    // --- respond (kill 프록시) ---
+
+    @Test
+    void 자기_alert_respond_는_알림host로_responder에_위임한다() throws Exception {
+        String[] a = signup("a-respond@edrdog.com");
+        String id = seedAlert(a[1], "hostA", 100L);
+        when(responder.kill(eq("hostA"), eq("evil.exe")))
+                .thenReturn(new KillResult("hostA", "evil.exe", "KILLED", "exec-1"));
+
+        mvc.perform(post("/api/alerts/" + id + "/respond").header("Authorization", "Bearer " + a[0])
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"target\":\"evil.exe\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.host").value("hostA"))
+                .andExpect(jsonPath("$.status").value("KILLED"))
+                .andExpect(jsonPath("$.executionId").value("exec-1"));
+
+        // host 는 알림에서 오고 클라이언트 입력이 아님을 확인
+        verify(responder).kill("hostA", "evil.exe");
+    }
+
+    @Test
+    void 남의_alert_respond_는_404이고_responder를_호출하지_않는다() throws Exception {
+        String[] a = signup("a-presp@edrdog.com");
+        String[] b = signup("b-presp@edrdog.com");
+        String bId = seedAlert(b[1], "hostB", 200L);
+
+        mvc.perform(post("/api/alerts/" + bId + "/respond").header("Authorization", "Bearer " + a[0])
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"target\":\"evil.exe\"}"))
+                .andExpect(status().isNotFound());
+
+        verify(responder, never()).kill(any(), any());
+    }
+
+    @Test
+    void respond_target_없으면_400() throws Exception {
+        String[] a = signup("a-respnotarget@edrdog.com");
+        String id = seedAlert(a[1], "hostA", 100L);
+
+        mvc.perform(post("/api/alerts/" + id + "/respond").header("Authorization", "Bearer " + a[0])
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"target\":\"  \"}"))
+                .andExpect(status().isBadRequest());
+
+        verify(responder, never()).kill(any(), any());
+    }
+
+    @Test
+    void respond_토큰_없으면_401() throws Exception {
+        mvc.perform(post("/api/alerts/anything/respond")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"target\":\"evil.exe\"}"))
+                .andExpect(status().isUnauthorized());
+
+        verify(responder, never()).kill(any(), any());
     }
 
     // --- lineage ---

--- a/k8s/responder-service.yaml
+++ b/k8s/responder-service.yaml
@@ -24,6 +24,17 @@ spec:
           env:
             - name: SPRING_KAFKA_BOOTSTRAP_SERVERS
               value: "kafka:9094"
+            # 실제 조치(kill) 실행은 기본 OFF(dry-run). 신뢰가 쌓인 뒤 아래를 채워 켠다.
+            # 켤 때 FLEET_BASE_URL 은 https 여야 하며(FleetTls), 자가서명 인증서면 FLEET_TLS_TRUSTSTORE 를 지정한다.
+            # - name: RESPONDER_EXECUTE_ENABLED
+            #   value: "true"
+            # - name: FLEET_BASE_URL
+            #   value: "https://fleet.내부주소"
+            # - name: FLEET_TOKEN
+            #   valueFrom:
+            #     secretKeyRef: { name: fleet, key: token }
+            # - name: FLEET_TLS_TRUSTSTORE
+            #   value: "/etc/fleet/truststore.p12"
           readinessProbe:
             httpGet:
               path: /actuator/health

--- a/responder-service/src/main/java/com/edrdog/responderservice/fleet/FleetClient.java
+++ b/responder-service/src/main/java/com/edrdog/responderservice/fleet/FleetClient.java
@@ -1,9 +1,17 @@
 package com.edrdog.responderservice.fleet;
 
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.FileSystemResource;
+import org.springframework.http.client.JdkClientHttpRequestFactory;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
 
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManagerFactory;
+import java.io.InputStream;
+import java.net.http.HttpClient;
+import java.security.KeyStore;
 import java.util.Map;
 
 /**
@@ -15,6 +23,10 @@ import java.util.Map;
  * - POST /api/v1/fleet/scripts/run/sync              : 스크립트 동기 실행(결과까지 대기)
  *
  * 지연 특성: Fleet 은 push 가 아니라 fleetd 폴링이라 sync 호출도 폴링 한 주기만큼 걸릴 수 있다(수초~수십초).
+ *
+ * 전송 보안: Bearer 토큰을 싣기 때문에 실제 조치가 켜진 경우 https 를 강제한다(FleetTls). 인증서 검증은
+ * 기본적으로 시스템 신뢰저장소를 쓰고, Fleet 이 자가서명 인증서면 edrdog.fleet.tls.truststore 로 신뢰할
+ * 인증서를 지정한다.
  */
 @Component
 public class FleetClient {
@@ -22,11 +34,51 @@ public class FleetClient {
     private final RestClient http;
 
     public FleetClient(@Value("${edrdog.fleet.base-url}") String baseUrl,
-                       @Value("${edrdog.fleet.token}") String token) {
+                       @Value("${edrdog.fleet.token}") String token,
+                       @Value("${edrdog.responder.execute.enabled}") boolean executeEnabled,
+                       @Value("${edrdog.fleet.tls.truststore:}") String truststore,
+                       @Value("${edrdog.fleet.tls.truststore-password:}") String truststorePassword,
+                       @Value("${edrdog.fleet.tls.truststore-type:PKCS12}") String truststoreType) {
+        FleetTls.requireHttpsWhenExecuting(baseUrl, executeEnabled);
         this.http = RestClient.builder()
                 .baseUrl(baseUrl)
                 .defaultHeader("Authorization", "Bearer " + token)
+                .requestFactory(new JdkClientHttpRequestFactory(
+                        httpClient(truststore, truststorePassword, truststoreType)))
                 .build();
+    }
+
+    /** truststore 가 지정되면 그 인증서만 신뢰하는 HttpClient, 아니면 시스템 신뢰저장소를 쓰는 기본 HttpClient. */
+    private static HttpClient httpClient(String truststore, String password, String type) {
+        HttpClient.Builder builder = HttpClient.newBuilder();
+        if (truststore != null && !truststore.isBlank()) {
+            builder.sslContext(trustContext(truststore, password, type));
+        }
+        return builder.build();
+    }
+
+    /** 지정한 truststore 로 Fleet 서버 인증서를 검증하는 SSLContext 를 만든다. */
+    private static SSLContext trustContext(String location, String password, String type) {
+        try {
+            KeyStore ks = KeyStore.getInstance(type == null || type.isBlank() ? "PKCS12" : type);
+            try (InputStream in = openTruststore(location)) {
+                ks.load(in, password == null ? new char[0] : password.toCharArray());
+            }
+            TrustManagerFactory tmf = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+            tmf.init(ks);
+            SSLContext ctx = SSLContext.getInstance("TLS");
+            ctx.init(null, tmf.getTrustManagers(), null);
+            return ctx;
+        } catch (Exception e) {
+            throw new IllegalStateException("Fleet TLS truststore 로드 실패: " + location, e);
+        }
+    }
+
+    /** classpath: 접두어면 클래스패스 리소스로, 아니면 파일 경로로 truststore 를 연다. */
+    private static InputStream openTruststore(String location) throws Exception {
+        return location.startsWith("classpath:")
+                ? new ClassPathResource(location.substring("classpath:".length())).getInputStream()
+                : new FileSystemResource(location).getInputStream();
     }
 
     /** 호스트 식별자(hostname/uuid)를 Fleet 내부 host id 로 변환. */

--- a/responder-service/src/main/java/com/edrdog/responderservice/fleet/FleetTls.java
+++ b/responder-service/src/main/java/com/edrdog/responderservice/fleet/FleetTls.java
@@ -1,0 +1,30 @@
+package com.edrdog.responderservice.fleet;
+
+/**
+ * Fleet 연결 전송 보안 판단(순수 로직).
+ *
+ * <p>Fleet 호출은 Authorization: Bearer 토큰을 싣는다. 실제 조치(kill)를 켠 상태에서 평문 http 로
+ * 나가면 토큰이 그대로 노출되므로, 실행 스위치가 켜진 경우에는 https 를 강제한다.
+ * dry-run(스위치 off) 이면 Fleet 을 실제로 부르지 않으므로 로컬 http 기본값을 그대로 둔다.
+ */
+public final class FleetTls {
+
+    private static final String HTTPS_PREFIX = "https://";
+
+    private FleetTls() {
+    }
+
+    /** base-url 이 https 스킴이면 true (대소문자·앞뒤 공백 무시). null/blank 는 false. */
+    public static boolean isHttps(String baseUrl) {
+        return baseUrl != null && baseUrl.trim().toLowerCase().startsWith(HTTPS_PREFIX);
+    }
+
+    /** 실제 조치 실행이 켜졌는데 Fleet 연결이 https 가 아니면 거부한다(평문 토큰 노출 차단). */
+    public static void requireHttpsWhenExecuting(String baseUrl, boolean executeEnabled) {
+        if (executeEnabled && !isHttps(baseUrl)) {
+            throw new IllegalStateException(
+                    "실제 조치 실행(RESPONDER_EXECUTE_ENABLED=true)에는 Fleet 연결이 https 여야 합니다. "
+                            + "현재 base-url=" + baseUrl);
+        }
+    }
+}

--- a/responder-service/src/main/resources/application.yml
+++ b/responder-service/src/main/resources/application.yml
@@ -23,8 +23,14 @@ edrdog:
     execute:
       enabled: ${RESPONDER_EXECUTE_ENABLED:false}  # 실제 조치 실행 스위치 (기본 OFF = dry-run 유지)
   fleet:
-    base-url: ${FLEET_BASE_URL:http://localhost:8080}  # Fleet 서버
+    base-url: ${FLEET_BASE_URL:http://localhost:8080}  # Fleet 서버 (실행 스위치 ON 시 https 필수)
     token: ${FLEET_TOKEN:}                             # Fleet API 토큰 (Bearer)
+    tls:
+      # Fleet 서버 인증서 검증용 truststore. 비우면 시스템 신뢰저장소(공인 CA)로 검증한다.
+      # Fleet 이 자가서명 인증서면 그 인증서를 담은 PKCS12 를 지정한다(파일 경로 또는 classpath:).
+      truststore: ${FLEET_TLS_TRUSTSTORE:}
+      truststore-password: ${FLEET_TLS_TRUSTSTORE_PASSWORD:}
+      truststore-type: ${FLEET_TLS_TRUSTSTORE_TYPE:PKCS12}
 
 management:
   endpoints:

--- a/responder-service/src/test/java/com/edrdog/responderservice/fleet/FleetClientTest.java
+++ b/responder-service/src/test/java/com/edrdog/responderservice/fleet/FleetClientTest.java
@@ -1,0 +1,42 @@
+package com.edrdog.responderservice.fleet;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * FleetClient 생성 시 전송 보안 배선 검증.
+ * 순수 판단(FleetTls)은 FleetTlsTest 에서 다루고, 여기서는 truststore 로딩·https 강제가
+ * 생성자에서 실제로 걸리는지(보안 실패는 부팅에서 걸러야 한다) 확인한다.
+ */
+class FleetClientTest {
+
+    @Test
+    @DisplayName("실행 스위치 ON + http base-url 이면 생성 자체가 막힌다(평문 토큰 노출 차단)")
+    void executingOverHttp_failsFast() {
+        assertThatThrownBy(() -> new FleetClient(
+                "http://localhost:8080", "tok", true, "", "", "PKCS12"))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("https");
+    }
+
+    @Test
+    @DisplayName("지정한 truststore 를 찾지 못하면 경로를 담은 IllegalStateException 으로 실패한다")
+    void missingTruststore_throwsWithLocation() {
+        String location = "/no/such/fleet-truststore.p12";
+        assertThatThrownBy(() -> new FleetClient(
+                "https://fleet.example", "tok", false, location, "", "PKCS12"))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining(location);
+    }
+
+    @Test
+    @DisplayName("truststore 미지정이면 시스템 신뢰저장소로 정상 생성된다")
+    void noTruststore_buildsWithSystemTrust() {
+        assertThatCode(() -> new FleetClient(
+                "https://fleet.example", "tok", false, "", "", "PKCS12"))
+                .doesNotThrowAnyException();
+    }
+}

--- a/responder-service/src/test/java/com/edrdog/responderservice/fleet/FleetTlsTest.java
+++ b/responder-service/src/test/java/com/edrdog/responderservice/fleet/FleetTlsTest.java
@@ -1,0 +1,47 @@
+package com.edrdog.responderservice.fleet;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Fleet 연결의 https 강제 판단(순수 로직).
+ * 실제 조치가 켜졌을 때 평문 http 로 Bearer 토큰을 흘리지 않도록 막는 게 핵심이다.
+ */
+class FleetTlsTest {
+
+    @Test
+    @DisplayName("https 스킴만 https 로 인정한다(대소문자·공백 무시, null/blank 는 아님)")
+    void isHttps_onlyHttpsScheme() {
+        assertThat(FleetTls.isHttps("https://fleet.example")).isTrue();
+        assertThat(FleetTls.isHttps("  HTTPS://fleet.example ")).isTrue();
+        assertThat(FleetTls.isHttps("http://localhost:8080")).isFalse();
+        assertThat(FleetTls.isHttps(null)).isFalse();
+        assertThat(FleetTls.isHttps("")).isFalse();
+    }
+
+    @Test
+    @DisplayName("실행 스위치가 켜졌는데 http 면 거부한다")
+    void requireHttps_executingOverPlainHttp_throws() {
+        assertThatThrownBy(() -> FleetTls.requireHttpsWhenExecuting("http://localhost:8080", true))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("https");
+    }
+
+    @Test
+    @DisplayName("실행 스위치가 켜졌고 https 면 통과한다")
+    void requireHttps_executingOverHttps_ok() {
+        assertThatCode(() -> FleetTls.requireHttpsWhenExecuting("https://fleet.example", true))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("실행 스위치가 꺼져 있으면(dry-run) http 여도 통과한다")
+    void requireHttps_disabledOverHttp_ok() {
+        assertThatCode(() -> FleetTls.requireHttpsWhenExecuting("http://localhost:8080", false))
+                .doesNotThrowAnyException();
+    }
+}


### PR DESCRIPTION
close #71

## 개요
무인증으로 노출되던 responder kill 경로를 안전하게 만든다. responder 는 클러스터 내부(ClusterIP)로만 두고, 접근 통제는 api-service 프록시의 Bearer 세션 인증 + tenant 소유 검증으로 대신한다. Fleet 통신에는 TLS 를 강제한다.

## 변경 (이슈 #71 항목 1~3)
- **1·2 api 프록시 + tenant 격리**: `POST /api/alerts/{id}/respond` 추가. Bearer 로 tenant 확인 → `alerts.get(tenant,id)` 로 소유 검증(타 tenant 404) → 알림의 host 를 대상으로 responder 에 kill 위임. host 는 알림에서 가져오므로 클라이언트가 위조할 수 없다. responder 연결 실패·오류는 불투명한 500 대신 `FAILED` 로 매핑(fail-closed).
- **3 Fleet TLS**: 실행 스위치 ON 시 Fleet 연결을 https 로 강제(`FleetTls`, 부팅 단계 검사로 평문 토큰 노출 창 제거). 자가서명 Fleet 대비 선택적 커스텀 truststore(`edrdog.fleet.tls.*`), 미지정 시 시스템 신뢰저장소.

## 범위 밖
- **항목 4 (실행 스위치 ON)**: 배포 env 설정 영역이라 켜지 않음. k8s 에 켜는 방법(`RESPONDER_EXECUTE_ENABLED`/`FLEET_*`) 주석 문서화. 기본 OFF(dry-run) 유지.
- 프론트(#30): base 를 api-service 로 되돌리고 경로를 `/api/alerts/{id}/respond` (body `{target}`) 로 교체.

## 테스트
- `FleetTlsTest`(4), `FleetClientTest`(3): https 강제 + truststore 로딩 실패 경로
- `AlertApiIntegrationTest`(+4): 위임/타 tenant 404/target 400/무토큰 401
- `:responder-service:test` `:api-service:test` BUILD SUCCESSFUL