### PR TITLE
fix: CD deploy 잡 SSH 배포로 교체 (#74)

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -69,35 +69,35 @@ jobs:
             ${{ steps.vars.outputs.image_base }}:${{ github.sha }}
             ${{ steps.vars.outputs.image_base }}:latest
 
-  # CD: Kubernetes 배포 (main 푸시에만, 전 모듈)
+  # CD: EC2(k3s) 에 SSH 로 접속해 새 이미지(:SHA)로 롤링. k3s API 를 외부에 노출하지 않는다.
+  # 필요한 secret: EC2_HOST(도메인/공인IP), EC2_SSH_KEY(개인키). 선택: EC2_USER(기본 ubuntu).
   deploy:
     needs: image
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: azure/setup-kubectl@v4
-      - name: Configure kubeconfig
-        run: |
-          mkdir -p "$HOME/.kube"
-          echo "${{ secrets.KUBE_CONFIG }}" | base64 -d > "$HOME/.kube/config"
-      - name: Deploy
+      - name: Deploy over SSH
         env:
           REPO: ${{ github.repository }}
           SHA: ${{ github.sha }}
-          NS: edrdog
+          SSH_HOST: ${{ secrets.EC2_HOST }}
+          SSH_USER: ${{ secrets.EC2_USER || 'ubuntu' }}
+          SSH_KEY: ${{ secrets.EC2_SSH_KEY }}
         run: |
-          # 앱 매니페스트만 적용 (인프라/ kind-cluster.yaml 제외)
-          kubectl apply -f k8s/00-namespace.yaml
-          kubectl apply -n "$NS" \
-            -f k8s/detector-service.yaml \
-            -f k8s/responder-service.yaml \
-            -f k8s/archiver-service.yaml \
-            -f k8s/api-service.yaml \
-            -f k8s/alert-service.yaml
-          for m in detector-service responder-service archiver-service api-service alert-service; do
-            kubectl set image deployment/$m "$m=ghcr.io/${REPO,,}/$m:${SHA}" -n "$NS"
+          mkdir -p ~/.ssh
+          printf '%s\n' "$SSH_KEY" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          # GHCR 는 소문자 경로만 받으므로 repo 이름을 소문자로 바꿔 원격에 넘긴다.
+          REPO_LC="${REPO,,}"
+          ssh -o StrictHostKeyChecking=no -o ConnectTimeout=20 \
+            -i ~/.ssh/deploy_key "$SSH_USER@$SSH_HOST" \
+            "REPO='$REPO_LC' SHA='$SHA' NS=edrdog bash -s" <<'REMOTE'
+          set -euo pipefail
+          MODULES="detector-service responder-service archiver-service api-service alert-service"
+          for m in $MODULES; do
+          sudo kubectl -n "$NS" set image "deployment/$m" "$m=ghcr.io/$REPO/$m:$SHA"
           done
-          for m in detector-service responder-service archiver-service api-service alert-service; do
-            kubectl rollout status deployment/$m -n "$NS" --timeout=120s
+          for m in $MODULES; do
+          sudo kubectl -n "$NS" rollout status "deployment/$m" --timeout=120s
           done
+          REMOTE


### PR DESCRIPTION
Closes #74

## 변경
- deploy 잡: kubeconfig 주입 → **SSH 접속 후 박스 내부 kubectl** 방식
- 이미지 롤링만 수행(`set image :SHA` + `rollout status`), 매니페스트 apply 제외
- k3s API 외부 노출 불필요(22번만 사용)

## 머지 전 필수: repo secret 등록
```
gh secret set EC2_HOST   --repo 2026-Siheung-Bootcamp-Team-I/Backend --body 'edrdog-i-team.duckdns.org'
gh secret set EC2_SSH_KEY --repo 2026-Siheung-Bootcamp-Team-I/Backend < /path/to/ec2-key.pem
# (SSH 유저가 ubuntu 아니면) gh secret set EC2_USER --repo ... --body 'ec2-user'
```

## 검증
- bash `-n` 통과, YAML 파싱 OK
- 머지 후 main 푸시 → deploy 잡 성공 + `kubectl rollout` 반영 확인 예정