### PR TITLE
chore: Kafka UI 추가 + CD 가 인프라 매니페스트도 적용

### DIFF
--- a/k8s/kafdrop.yaml
+++ b/k8s/kafdrop.yaml
@@ -1,0 +1,63 @@
+# Kafdrop — Kafka 토픽/메시지 웹 UI (운영 확인용).
+# 배포서버에서는 Caddy 가 https://<도메인>/kafdrop 으로 프록시한다.
+#   Caddyfile 예:  handle /kafdrop* { reverse_proxy localhost:30901 }   ← 접두어 유지(handle_path 아님)
+#   (서브패스로 서비스하므로 SERVER_SERVLET_CONTEXTPATH 를 /kafdrop 로 맞춰둔다)
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kafdrop
+  namespace: edrdog
+  labels:
+    app: kafdrop
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: kafdrop
+  template:
+    metadata:
+      labels:
+        app: kafdrop
+    spec:
+      containers:
+        - name: kafdrop
+          image: obsidiandynamics/kafdrop:4.1.0
+          ports:
+            - containerPort: 9000
+          env:
+            - name: KAFKA_BROKERCONNECT
+              value: "kafka.edrdog.svc.cluster.local:9094"
+            - name: SERVER_SERVLET_CONTEXTPATH
+              value: "/kafdrop"
+            - name: JVM_OPTS
+              value: "-Xms64M -Xmx256M"
+          readinessProbe:
+            httpGet:
+              path: /kafdrop/actuator/health
+              port: 9000
+            initialDelaySeconds: 20
+            periodSeconds: 10
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              memory: 512Mi
+---
+# NodePort 30901 — 호스트(EC2)에서 도는 Caddy 가 localhost:30901 로 프록시한다.
+# EC2 보안그룹에 30901 을 열지 않으면 외부에서 직접은 못 들어오고 Caddy 경유만 가능.
+apiVersion: v1
+kind: Service
+metadata:
+  name: kafdrop
+  namespace: edrdog
+  labels:
+    app: kafdrop
+spec:
+  type: NodePort
+  selector:
+    app: kafdrop
+  ports:
+    - port: 9000
+      targetPort: 9000
+      nodePort: 30901


### PR DESCRIPTION
## 요약
1. Kafka 토픽/메시지를 브라우저에서 보는 **UI for Apache Kafka**(kafbat/kafka-ui) 매니페스트 추가
2. CD deploy 잡이 인프라 매니페스트를 실제로 `kubectl apply` 하도록 수정

기존 deploy 잡은 기존 5개 deployment 에 `set image` 만 했다. `k8s/` 에 매니페스트를 새로 추가해도 서버에는 영원히 반영되지 않는 구조였다.

## 변경
### `k8s/kafka-ui.yaml` (신규)
- `ghcr.io/kafbat/kafka-ui:v1.5.0`, Deployment + Service(NodePort 30901)
- `SERVER_SERVLET_CONTEXT_PATH=/kafka-ui` 로 서브패스 서비스
- 브로커는 내부 리스너 `kafka.edrdog.svc.cluster.local:9094`
- 30900 은 ClickHouse native 가 쓰고 있어 30901 사용

### `.github/workflows/cicd.yml`
- deploy 잡에 `actions/checkout` 추가 (기존엔 없어서 러너에 매니페스트 파일 자체가 없었음)
- 인프라 매니페스트를 ssh 로 `sudo kubectl apply -f -` 에 흘려보냄
- 서비스 5개(detector/responder/archiver/api/alert)는 apply 대상에서 **제외**. 서버 api-service 는 NodePort 30084 로 떠 있는데 레포 매니페스트는 ClusterIP 80 이라, 그대로 apply 하면 사이트 전체가 죽는다.

## 검증 (로컬 kind)
- `deploy/kafka-ui` 롤아웃 성공, `/kafka-ui/actuator/health` → `UP`
- `/kafka-ui/api/clusters` → 클러스터 `edrdog` **ONLINE**, brokerCount 1, KRAFT
- 토픽 `events-raw` / `events` / `alerts` 조회됨
- 서브패스 정적자원 확인: `index.html` 이 `window.basePath = '/kafka-ui'` 로 렌더되고 `/kafka-ui/assets/index-*.js`(345KB) · favicon · manifest 모두 200
- CD 가 보내는 것과 동일한 병합 스트림으로 `kubectl apply --dry-run=server` → 전 오브젝트 `unchanged`
- 워크플로 YAML 파싱 OK, run 블록 `bash -n` OK

## 머지 후 서버에서 1회 수동 (CD 는 main 푸시에만 동작)
기존 Kafdrop 이 NodePort 30901 을 잡고 있어 먼저 지워야 한다.
```bash
sudo kubectl -n edrdog delete deploy/kafdrop svc/kafdrop --ignore-not-found
cd ~/Backend && git fetch origin dev
git show FETCH_HEAD:k8s/kafka-ui.yaml | sudo kubectl apply -f -
sudo kubectl -n edrdog rollout status deploy/kafka-ui
```
Caddyfile 경로도 `/kafdrop` → `/kafka-ui` 로 바꾸고 `sudo systemctl reload caddy`.

→ `https://edrdog-i-team.duckdns.org/kafka-ui/`

## 주의
인증 없음. URL 을 아는 사람은 누구나 이벤트 내용을 본다. 해커톤 데모 기간 한정으로 열어두는 것.