### PR TITLE
feat: 발표용 전체 플로우 시연 API (events → Streams → alerts)

### DIFF
--- a/api-service/src/main/java/com/edrdog/apiservice/demo/AlertArrivals.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/demo/AlertArrivals.java
@@ -1,0 +1,50 @@
+package com.edrdog.apiservice.demo;
+
+import com.edrdog.apiservice.alert.AlertId;
+import com.edrdog.apiservice.alert.dto.Alert;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * alerts 토픽에 판정 결과가 <b>도착한 시각</b>을 alert id 별로 기록한다 (데모 타임라인 계측용).
+ *
+ * <p>적재용 리스너(AlertIngestListener)와 별도 컨슈머 그룹이라 서로 간섭하지 않는다. 굳이 분리한 이유는
+ * 발표에서 보여줄 구간이 "Kafka → Streams → Kafka" 이기 때문이다. detector 가 판정을 alerts 토픽에
+ * 되돌려준 시점과, 그게 ClickHouse 에 적재돼 조회 가능해진 시점을 따로 찍어야 두 단계를 구분해 보여줄 수 있다.
+ *
+ * <p>id 계산은 적재 경로와 같은 {@link AlertId} 를 쓴다. 그래서 호출자는 발행 전에 기대 id 를 미리 계산해
+ * 이번 회차 alert 만 정확히 기다릴 수 있다(과거 회차의 같은 룰 alert 에 속지 않는다).
+ */
+@Component
+public class AlertArrivals {
+
+    /** 보관 상한. 발표용 계측이라 최근 것만 있으면 된다. */
+    private static final int MAX = 200;
+
+    private final Map<String, Long> arrivedAt = Collections.synchronizedMap(
+            new LinkedHashMap<>(16, 0.75f, false) {
+                @Override
+                protected boolean removeEldestEntry(Map.Entry<String, Long> eldest) {
+                    return size() > MAX;
+                }
+            });
+
+    @KafkaListener(topics = "${edrdog.kafka.alerts-topic}", groupId = "api-demo-arrivals")
+    public void onAlert(Alert alert) {
+        if (alert == null || alert.tenantId() == null || alert.host() == null || alert.ruleId() == null) {
+            return;
+        }
+        String id = AlertId.of(alert.tenantId(), alert.host(), alert.ruleId(), alert.ts());
+        arrivedAt.putIfAbsent(id, System.currentTimeMillis());
+    }
+
+    /** 그 alert 가 alerts 토픽에서 관측된 시각(epoch millis). 아직 안 왔으면 empty. */
+    public Optional<Long> arrivedAt(String alertId) {
+        return Optional.ofNullable(arrivedAt.get(alertId));
+    }
+}

--- a/api-service/src/main/java/com/edrdog/apiservice/demo/CollectedEvent.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/demo/CollectedEvent.java
@@ -1,0 +1,59 @@
+package com.edrdog.apiservice.demo;
+
+/**
+ * events 토픽 발행 스키마 사본 (detector 의 Event 와 동일 필드).
+ * 데모 수집 API 가 이 형태로 발행하면 detector Kafka Streams 가 그대로 상관분석한다.
+ *
+ * <p>detector/archiver 모듈이 각자 사본을 두는 것과 같은 이유로 여기에도 사본을 둔다(모듈 간 의존 없음).
+ * 필드명이 detector 의 Event 와 어긋나면 판정 입력이 null 로 들어가므로 바꿀 때 함께 맞춰야 한다.
+ *
+ * @param host      엔드포인트 식별자 (상관분석 키 = Kafka 파티션 키)
+ * @param type      process | network | file | script
+ * @param ts        발생 시각 (epoch millis) — detector 의 event-time 윈도우 기준
+ * @param process   프로세스명/파일명 (basename)
+ * @param parent    부모 프로세스명
+ * @param cmdline   명령행. file/script 는 판정에 쓰는 전체 경로를 여기 담는다.
+ * @param destIp    목적지 IP (network)
+ * @param destPort  목적지 포트 (network)
+ * @param tenantId  조직(tenant) 식별자 — api-service 의 tenant PK 문자열이어야 조회에서 보인다
+ */
+public record CollectedEvent(
+        String host,
+        String type,
+        long ts,
+        String process,
+        String parent,
+        String cmdline,
+        String destIp,
+        int destPort,
+        String tenantId
+) {
+
+    public static final String TYPE_PROCESS = "process";
+    public static final String TYPE_NETWORK = "network";
+    public static final String TYPE_FILE = "file";
+    public static final String TYPE_SCRIPT = "script";
+
+    /** process 이벤트. */
+    public static CollectedEvent process(String host, long ts, String process, String parent,
+                                         String cmdline, String tenantId) {
+        return new CollectedEvent(host, TYPE_PROCESS, ts, process, parent, cmdline, null, 0, tenantId);
+    }
+
+    /** network 이벤트. 소유 프로세스를 같이 담아야 lineage 가 process -> network 로 이어진다. */
+    public static CollectedEvent network(String host, long ts, String process, String destIp,
+                                         int destPort, String tenantId) {
+        return new CollectedEvent(host, TYPE_NETWORK, ts, process, null, null, destIp, destPort, tenantId);
+    }
+
+    /** script 이벤트. process 는 인터프리터 basename, cmdline 은 판정용 전체 경로. */
+    public static CollectedEvent script(String host, long ts, String process, String parent,
+                                        String cmdline, String tenantId) {
+        return new CollectedEvent(host, TYPE_SCRIPT, ts, process, parent, cmdline, null, 0, tenantId);
+    }
+
+    /** file 이벤트. process 는 파일명 basename, cmdline 은 판정용 전체 경로. */
+    public static CollectedEvent file(String host, long ts, String name, String fullPath, String tenantId) {
+        return new CollectedEvent(host, TYPE_FILE, ts, name, null, fullPath, null, 0, tenantId);
+    }
+}

--- a/api-service/src/main/java/com/edrdog/apiservice/demo/DemoAccountSeeder.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/demo/DemoAccountSeeder.java
@@ -38,7 +38,8 @@ public class DemoAccountSeeder {
      */
     public static final long TENANT_ID = 99L;
 
-    static final String EMAIL = "test@edrdog.local";
+    /** 데모 계정 이메일. 데모 API 가 이 계정으로 쓸 tenant 를 찾는다(DemoTenant). */
+    public static final String EMAIL = "test@edrdog.local";
 
     /** 이메일 형식이 아니던 옛 데모 계정. 남아 있으면 정리한다. */
     static final String LEGACY_EMAIL = "test";

--- a/api-service/src/main/java/com/edrdog/apiservice/demo/DemoFlowService.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/demo/DemoFlowService.java
@@ -1,0 +1,171 @@
+package com.edrdog.apiservice.demo;
+
+import com.edrdog.apiservice.alert.AlertId;
+import com.edrdog.apiservice.alert.AlertService;
+import com.edrdog.apiservice.alert.web.AlertResponse;
+import com.edrdog.apiservice.auth.exception.AuthException;
+import com.edrdog.apiservice.demo.web.DemoFlowResponse;
+import com.edrdog.apiservice.demo.web.DemoFlowStep;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * 발표용 전체 플로우 실행. 엔드포인트가 로그를 보낸 것처럼 events 토픽에 발행하고,
+ * detector 가 alerts 토픽으로 되돌려준 판정이 저장돼 조회 가능해질 때까지 기다린 뒤 단계별 결과를 만든다.
+ *
+ * <p>세 단계를 각각 실측한다. 발표에서 보여줄 구간이 "Kafka → Streams → Kafka" 라, 판정이 토픽에 돌아온
+ * 시점(2단계)과 그게 저장돼 조회되는 시점(3단계)을 분리해야 스트림즈가 한 일이 눈에 보인다.
+ *
+ * <ol>
+ *   <li>수집 — api-service → Kafka(events). 발행에 걸린 시간</li>
+ *   <li>탐지 — detector Kafka Streams → Kafka(alerts). {@link AlertArrivals} 가 관측한 도착 시각</li>
+ *   <li>저장 — api-service → ClickHouse(판정기록) + MySQL(status). 조회 API 로 읽히는 시점</li>
+ * </ol>
+ *
+ * <p>alert id 는 발행 <b>전에</b> 계산한다({@link AlertId} 가 tenant|host|rule|ts 로 결정적이고, 판정 ts 는
+ * 마지막 이벤트의 ts 와 같다). 그래서 과거 회차의 같은 룰 alert 를 이번 결과로 착각하지 않는다.
+ */
+@Service
+public class DemoFlowService {
+
+    private static final Logger log = LoggerFactory.getLogger(DemoFlowService.class);
+
+    private static final long POLL_MS = 250;
+
+    private static final String PIPELINE =
+            "api-service → Kafka(events) → detector Kafka Streams → Kafka(alerts) → api-service(ClickHouse+MySQL)";
+
+    private final EventsProducer producer;
+    private final AlertArrivals arrivals;
+    private final AlertService alerts;
+    private final long detectTimeoutMs;
+    private final long storeTimeoutMs;
+
+    public DemoFlowService(EventsProducer producer, AlertArrivals arrivals, AlertService alerts,
+                           @Value("${edrdog.demo.detect-timeout-ms}") long detectTimeoutMs,
+                           @Value("${edrdog.demo.store-timeout-ms}") long storeTimeoutMs) {
+        this.producer = producer;
+        this.arrivals = arrivals;
+        this.alerts = alerts;
+        this.detectTimeoutMs = detectTimeoutMs;
+        this.storeTimeoutMs = storeTimeoutMs;
+    }
+
+    /**
+     * 시나리오 로그를 발행하고 판정이 조회 가능해질 때까지 기다린다.
+     *
+     * @param scenario 시나리오 이름 (미지원이면 IllegalArgumentException)
+     * @param host     엔드포인트 식별자. null/빈값이면 시나리오 기본 host
+     * @param tenantId 로그인 유저의 tenant PK 문자열
+     */
+    public DemoFlowResponse run(String scenario, String host, String tenantId) {
+        String target = (host == null || host.isBlank()) ? DemoScenario.defaultHost(scenario) : host.trim();
+        long start = System.currentTimeMillis();
+        List<CollectedEvent> logs = DemoScenario.build(scenario, target, start, tenantId);
+
+        logs.forEach(producer::publish);
+        long publishedAt = System.currentTimeMillis();
+
+        String ruleId = DemoScenario.expectedRuleId(scenario);
+        long triggerTs = logs.get(logs.size() - 1).ts();
+        String alertId = AlertId.of(tenantId, target, ruleId, triggerTs);
+
+        Optional<Long> detectedAt = awaitArrival(alertId, publishedAt + detectTimeoutMs);
+        Optional<AlertResponse> stored = detectedAt.isEmpty()
+                ? Optional.empty()
+                : awaitStored(tenantId, alertId, System.currentTimeMillis() + storeTimeoutMs);
+        long finishedAt = System.currentTimeMillis();
+
+        List<DemoFlowStep> steps = steps(logs, ruleId, start, publishedAt, detectedAt, stored, finishedAt);
+        if (stored.isEmpty()) {
+            log.warn("데모 플로우 미완료: scenario={} host={} alertId={} 탐지도착={} (detector/Kafka 상태 확인)",
+                    scenario, target, alertId, detectedAt.isPresent());
+        }
+        return new DemoFlowResponse(scenario, target, tenantId, PIPELINE, alertId,
+                finishedAt - start, steps, logs, stored.orElse(null), nextSteps(alertId));
+    }
+
+    private List<DemoFlowStep> steps(List<CollectedEvent> logs, String ruleId, long start, long publishedAt,
+                                     Optional<Long> detectedAt, Optional<AlertResponse> stored, long finishedAt) {
+        List<DemoFlowStep> steps = new ArrayList<>();
+        long normal = logs.stream().filter(e -> e.ts() < start).count();
+        steps.add(DemoFlowStep.ok(1, "수집", "api-service → Kafka(events)", publishedAt - start,
+                "엔드포인트 로그 " + logs.size() + "건 발행 (평소 배경 " + normal + "건 + 공격 "
+                        + (logs.size() - normal) + "건). 파티션 키 = host 라 순서가 보존된다"));
+
+        String detectPath = "Kafka(events) → detector Kafka Streams → Kafka(alerts)";
+        if (detectedAt.isEmpty()) {
+            steps.add(DemoFlowStep.timeout(2, "탐지", detectPath, finishedAt - publishedAt,
+                    detectTimeoutMs + "ms 안에 판정이 alerts 토픽으로 돌아오지 않았다. "
+                            + "detector-service 파드와 Kafka 연결을 확인하세요"));
+            return List.copyOf(steps);
+        }
+        steps.add(DemoFlowStep.ok(2, "탐지", detectPath, detectedAt.get() - publishedAt,
+                "상관분석이 " + ruleId + " 를 매칭해 alerts 토픽으로 발행, api-service 가 되받았다"));
+
+        String storePath = "api-service → ClickHouse(판정기록) + MySQL(트리아지 status)";
+        if (stored.isEmpty()) {
+            steps.add(DemoFlowStep.timeout(3, "저장", storePath, finishedAt - detectedAt.get(),
+                    storeTimeoutMs + "ms 안에 조회되지 않았다. ClickHouse 상태를 확인하세요"));
+            return List.copyOf(steps);
+        }
+        AlertResponse alert = stored.get();
+        steps.add(DemoFlowStep.ok(3, "저장", storePath, finishedAt - detectedAt.get(),
+                alert.threatName() + " / " + alert.mitre() + " / " + alert.severity()
+                        + " → 권고조치 " + alert.action() + ". GET /api/alerts 로 조회된다"));
+        return List.copyOf(steps);
+    }
+
+    /** 그 alert 가 alerts 토픽에 도착할 때까지 폴링. 제한시간을 넘기면 empty. */
+    private Optional<Long> awaitArrival(String alertId, long deadline) {
+        while (true) {
+            Optional<Long> at = arrivals.arrivedAt(alertId);
+            if (at.isPresent() || !sleepUntil(deadline)) {
+                return at;
+            }
+        }
+    }
+
+    /** 그 alert 가 조회 가능해질 때까지 폴링. 제한시간을 넘기면 empty. */
+    private Optional<AlertResponse> awaitStored(String tenantId, String alertId, long deadline) {
+        while (true) {
+            try {
+                return Optional.of(alerts.get(tenantId, alertId));
+            } catch (AuthException e) {
+                if (e.getKind() != AuthException.Kind.NOT_FOUND || !sleepUntil(deadline)) {
+                    return Optional.empty();   // 아직 적재 전(404) 이 아니면 재시도할 이유가 없다
+                }
+            }
+        }
+    }
+
+    /**
+     * 다음 폴링까지 대기. 제한시간이 남아 있으면 true(계속), 넘겼거나 인터럽트되면 false(중단).
+     */
+    private boolean sleepUntil(long deadline) {
+        if (System.currentTimeMillis() >= deadline) {
+            return false;
+        }
+        try {
+            Thread.sleep(POLL_MS);
+            return true;
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return false;
+        }
+    }
+
+    private static List<String> nextSteps(String alertId) {
+        return List.of(
+                "GET /api/alerts — 방금 만들어진 알림이 목록 맨 위에 있다",
+                "GET /api/alerts/" + alertId + "/lineage — 이 알림의 공격 경로 그래프",
+                "GET /api/alerts/summary — 대시보드 집계에 반영된 모습",
+                "POST /api/alerts/" + alertId + "/respond — responder 로 프로세스 종료 조치");
+    }
+}

--- a/api-service/src/main/java/com/edrdog/apiservice/demo/DemoScenario.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/demo/DemoScenario.java
@@ -1,0 +1,160 @@
+package com.edrdog.apiservice.demo;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * 발표용 공격 시나리오 생성 (순수 함수). baseTs 를 인자로 받아 결정적 — 테스트로 재현 가능.
+ *
+ * <p>실제 엔드포인트가 로그를 보내는 것처럼 보이게 하려고 공격 이벤트 앞에 <b>정상 배경 로그</b>를 붙인다.
+ * 대시보드에서 "이 호스트는 평소 이런 걸 돌리고 있었고, 그 중 이것만 탐지됐다" 로 보인다.
+ *
+ * <p>배경 로그에 network 이벤트를 넣지 않는 것이 이 클래스의 핵심 제약이다. detector 의 R2 는
+ * "선행 network(80/443/8080) + 이후 아무 process" 만으로 CRITICAL 을 내므로, 배경에 network 를 섞으면
+ * 뒤따르는 정상 프로세스가 전부 오탐으로 잡힌다. network 는 download-exec 시나리오에서만 의도적으로 쓴다.
+ *
+ * <p>판정을 트리거하는 이벤트는 항상 <b>마지막</b> 이벤트다. detector 가 만들 alert 의 ts 가 그 이벤트의 ts 와
+ * 같아지므로, 호출자는 alert id 를 미리 계산해 도착을 기다릴 수 있다.
+ */
+public final class DemoScenario {
+
+    private DemoScenario() {
+    }
+
+    /** R1 T1059 (HIGH): office 앱이 shell 을 자식으로 띄우는 매크로 침투. */
+    public static final String PROCESS_CHAIN = "process-chain";
+    /** R2 T1105+T1204 (CRITICAL): 다운로드 아웃바운드 후 그 파일 실행. */
+    public static final String DOWNLOAD_EXEC = "download-exec";
+    /** R3 T1059 (MEDIUM): 다운로드 경로의 스크립트 실행. */
+    public static final String SCRIPT_EXEC = "script-exec";
+    /** R4 T1547 (MEDIUM): 시작프로그램 경로에 파일 생성(지속성 확보). */
+    public static final String FILE_AUTORUN = "file-autorun";
+
+    private static final List<String> NAMES =
+            List.of(PROCESS_CHAIN, DOWNLOAD_EXEC, SCRIPT_EXEC, FILE_AUTORUN);
+
+    /**
+     * 시나리오별 기본 host. 서로 다르게 두는 이유가 있다. detector 의 상관 버퍼는 host 별 5분이라
+     * 같은 host 로 다른 시나리오를 연달아 돌리면 앞 시나리오의 선행 이벤트가 남아 의도한 룰이 아닌
+     * 다른 룰(주로 더 심각한 R2)이 먼저 매칭된다. 발표 중 클릭 순서를 신경 쓰지 않아도 되게 분리한다.
+     *
+     * <p>이름은 데모 시드가 쓰는 호스트({@link DemoData})와 같은 계열로 맞춰 과거 데이터와 이어져 보이게 한다.
+     */
+    private static final Map<String, String> DEFAULT_HOSTS = Map.of(
+            PROCESS_CHAIN, "DESKTOP-KIM",
+            DOWNLOAD_EXEC, "DESKTOP-CHOI",
+            SCRIPT_EXEC, "LAPTOP-PARK",
+            FILE_AUTORUN, "DESKTOP-LEE");
+
+    /** 시나리오가 트리거할 detector 룰 id. alert 도착을 기다릴 때 쓴다. */
+    private static final Map<String, String> RULE_IDS = Map.of(
+            PROCESS_CHAIN, "SUSPICIOUS_PROCESS_CHAIN",
+            DOWNLOAD_EXEC, "DOWNLOAD_AND_EXECUTE",
+            SCRIPT_EXEC, "SCRIPT_FROM_TEMP_PATH",
+            FILE_AUTORUN, "FILE_IN_AUTORUN_PATH");
+
+    private static final long SECOND = 1000L;
+
+    public static List<String> names() {
+        return NAMES;
+    }
+
+    public static boolean isSupported(String name) {
+        return name != null && NAMES.contains(name);
+    }
+
+    /** 시나리오 기본 host. 미지원 이름은 IllegalArgumentException. */
+    public static String defaultHost(String name) {
+        return require(DEFAULT_HOSTS, name);
+    }
+
+    /** 시나리오가 트리거할 룰 id. 미지원 이름은 IllegalArgumentException. */
+    public static String expectedRuleId(String name) {
+        return require(RULE_IDS, name);
+    }
+
+    /**
+     * 정상 배경 로그 + 공격 시퀀스를 시간 순서로 생성한다. 호출자는 이 순서 그대로 발행해야 한다
+     * (detector 는 host 파티션 안 도착 순서대로 상관하므로 선행 이벤트가 먼저 나가야 룰이 성립한다).
+     *
+     * @param name     시나리오 이름
+     * @param host     엔드포인트 식별자
+     * @param baseTs   공격 첫 이벤트 시각 (epoch millis). 배경 로그는 이보다 앞에 놓인다.
+     * @param tenantId 조직(tenant) 식별자 — 발행되는 모든 이벤트에 태깅
+     */
+    public static List<CollectedEvent> build(String name, String host, long baseTs, String tenantId) {
+        if (!isSupported(name)) {
+            throw new IllegalArgumentException(
+                    "미지원 시나리오: " + name + " (지원: " + String.join(", ", NAMES) + ")");
+        }
+        List<CollectedEvent> events = new ArrayList<>(background(host, baseTs, tenantId));
+        events.addAll(switch (name) {
+            case PROCESS_CHAIN -> processChain(host, baseTs, tenantId);
+            case DOWNLOAD_EXEC -> downloadExec(host, baseTs, tenantId);
+            case SCRIPT_EXEC -> scriptExec(host, baseTs, tenantId);
+            default -> fileAutorun(host, baseTs, tenantId);
+        });
+        return List.copyOf(events);
+    }
+
+    /**
+     * 평소 돌고 있는 정상 프로세스. detector 의 baseline 억제 목록(Rules.BASELINE_SAFE)에 있는 이름만 쓴다.
+     *
+     * <p>이름을 아무거나 쓰면 안 되는 이유가 있다. detector 의 상관 버퍼는 host 별 5분이라 같은 시나리오를
+     * 5분 안에 두 번 돌리면 앞 회차의 network 이벤트가 버퍼에 남아 있고, R2("선행 network + 이후 아무
+     * process")가 이번 회차의 <b>배경</b> 프로세스에 CRITICAL 오탐을 낸다. baseline 억제 대상 이름만 쓰면
+     * 그 경로가 원천적으로 막힌다.
+     *
+     * <p>다른 룰에는 애초에 걸리지 않는다 (R1 은 office 부모 + shell 자식, R3/R4 는 script/file 타입만 본다).
+     */
+    private static List<CollectedEvent> background(String host, long baseTs, String tenantId) {
+        return List.of(
+                CollectedEvent.process(host, baseTs - 12 * SECOND, "OneDrive.exe", "explorer.exe",
+                        "\"C:\\Program Files\\Microsoft OneDrive\\OneDrive.exe\" /background", tenantId),
+                CollectedEvent.process(host, baseTs - 8 * SECOND, "Teams.exe", "explorer.exe",
+                        "\"C:\\Users\\Public\\AppData\\Local\\Microsoft\\Teams\\Teams.exe\"", tenantId),
+                CollectedEvent.process(host, baseTs - 4 * SECOND, "MsEdgeUpdate.exe", "services.exe",
+                        "\"C:\\Program Files (x86)\\Microsoft\\EdgeUpdate\\MicrosoftEdgeUpdate.exe\" /svc", tenantId));
+    }
+
+    /** office 앱 실행 → 그 앱을 부모로 shell 실행 (매크로 문서 침투). */
+    private static List<CollectedEvent> processChain(String host, long baseTs, String tenantId) {
+        return List.of(
+                CollectedEvent.process(host, baseTs, "winword.exe", "explorer.exe",
+                        "\"C:\\Users\\kim\\Documents\\견적서_2026.docm\"", tenantId),
+                CollectedEvent.process(host, baseTs + SECOND, "powershell.exe", "winword.exe",
+                        "powershell -nop -w hidden -enc SQBFAFgAIAAoAE4AZQB3AC0ATwBiAGoA...", tenantId));
+    }
+
+    /** 외부 다운로드 아웃바운드 → 내려받은 파일 실행 (download-and-execute). */
+    private static List<CollectedEvent> downloadExec(String host, long baseTs, String tenantId) {
+        return List.of(
+                CollectedEvent.network(host, baseTs, "chrome.exe", "185.220.101.5", 443, tenantId),
+                CollectedEvent.process(host, baseTs + SECOND, "update32.exe", "explorer.exe",
+                        "C:\\Users\\choi\\Downloads\\update32.exe", tenantId));
+    }
+
+    /** 다운로드 경로의 스크립트 실행. 단일 이벤트 point 룰. */
+    private static List<CollectedEvent> scriptExec(String host, long baseTs, String tenantId) {
+        return List.of(CollectedEvent.script(host, baseTs, "powershell.exe", "explorer.exe",
+                "powershell -ExecutionPolicy Bypass -File C:\\Users\\park\\Downloads\\invoice_setup.ps1",
+                tenantId));
+    }
+
+    /** 시작프로그램 경로에 파일 생성. 단일 이벤트 point 룰. */
+    private static List<CollectedEvent> fileAutorun(String host, long baseTs, String tenantId) {
+        return List.of(CollectedEvent.file(host, baseTs, "svc-update.lnk",
+                "C:\\Users\\lee\\AppData\\Roaming\\Microsoft\\Windows\\Start Menu\\Programs\\Startup\\svc-update.lnk",
+                tenantId));
+    }
+
+    private static String require(Map<String, String> table, String name) {
+        String value = name == null ? null : table.get(name);
+        if (value == null) {
+            throw new IllegalArgumentException(
+                    "미지원 시나리오: " + name + " (지원: " + String.join(", ", NAMES) + ")");
+        }
+        return value;
+    }
+}

--- a/api-service/src/main/java/com/edrdog/apiservice/demo/DemoTenant.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/demo/DemoTenant.java
@@ -1,0 +1,40 @@
+package com.edrdog.apiservice.demo;
+
+import com.edrdog.apiservice.auth.repository.UserRepository;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+/**
+ * 데모 계정이 속한 tenant 를 찾는다. 데모 API 가 쓸 조직을 서버가 직접 결정하는 지점이다.
+ *
+ * <p>데모 API 는 로그인 토큰을 받지 않는다(발표자가 스웨거에서 토큰을 복사해 붙이는 건 실사용 흐름이 아니다).
+ * 대신 이 조회 결과가 두 가지를 동시에 해결한다.
+ *
+ * <ul>
+ *   <li>쓰기 대상 고정 — 발행되는 이벤트는 항상 데모 계정의 tenant 로만 태깅된다. 호출자가 tenant 를
+ *       지정할 수 없으니 남의 조직 데이터에 섞일 경로가 없다.</li>
+ *   <li>환경 게이팅 — 데모 계정은 시드({@code edrdog.demo.seed=true})로만 생긴다. 시드를 켠 적 없는
+ *       환경에서는 여기서 empty 가 나와 API 가 아무 일도 하지 않는다.</li>
+ * </ul>
+ *
+ * <p>PK 를 상수로 박지 않고 매번 조회하는 이유는, 데모 계정이 다른 tenant 에 붙어 있는 환경에서
+ * 상수(99)를 그대로 쓰면 엉뚱한 조직에 이벤트를 넣게 되기 때문이다.
+ */
+@Component
+public class DemoTenant {
+
+    private final UserRepository users;
+
+    public DemoTenant(UserRepository users) {
+        this.users = users;
+    }
+
+    /** 데모 계정의 tenant PK 문자열. 계정이 없는 환경이면 empty. */
+    @Transactional(readOnly = true)
+    public Optional<String> resolve() {
+        return users.findByEmail(DemoAccountSeeder.EMAIL)
+                .map(user -> String.valueOf(user.getTenantId()));
+    }
+}

--- a/api-service/src/main/java/com/edrdog/apiservice/demo/EventsProducer.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/demo/EventsProducer.java
@@ -1,0 +1,36 @@
+package com.edrdog.apiservice.demo;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+
+/**
+ * 데모 이벤트를 events 토픽으로 발행한다 (detector Kafka Streams 의 입력).
+ * host 를 파티션 키로 보내 같은 엔드포인트 이벤트의 순서를 보존한다 — 시퀀스 룰이 순서에 의존한다.
+ *
+ * <p>osquery 수집 입구(EventsRawProducer, events-raw)와 달리 정규화된 events 로 바로 보낸다.
+ * 발표에서 보여줄 구간이 "Kafka → Streams → Kafka" 라 collector 정규화 단계는 지나가지 않는다.
+ */
+@Component
+public class EventsProducer {
+
+    private final KafkaTemplate<String, String> template;
+    private final String eventsTopic;
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    public EventsProducer(KafkaTemplate<String, String> template,
+                          @Value("${edrdog.kafka.events-topic}") String eventsTopic) {
+        this.template = template;
+        this.eventsTopic = eventsTopic;
+    }
+
+    /** 이벤트 1건 발행. 인자 순서대로 같은 파티션에 쌓이므로 호출 순서가 곧 판정 순서다. */
+    public void publish(CollectedEvent event) {
+        try {
+            template.send(eventsTopic, event.host(), mapper.writeValueAsString(event));
+        } catch (Exception e) {
+            throw new IllegalStateException("데모 이벤트 발행 실패: " + event, e);
+        }
+    }
+}

--- a/api-service/src/main/java/com/edrdog/apiservice/demo/web/DemoController.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/demo/web/DemoController.java
@@ -1,0 +1,77 @@
+package com.edrdog.apiservice.demo.web;
+
+import com.edrdog.apiservice.demo.DemoAccountSeeder;
+import com.edrdog.apiservice.demo.DemoFlowService;
+import com.edrdog.apiservice.demo.DemoScenario;
+import com.edrdog.apiservice.demo.DemoTenant;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+
+/**
+ * 발표용 전체 플로우 시연 REST. 스웨거에서 Execute 한 번이면 끝난다 — 토큰을 받아 붙이는 단계가 없다.
+ *
+ * <p>엔드포인트 에이전트가 로그를 보낸 것처럼 events 토픽에 발행하고, detector 의 판정이 alerts 토픽으로
+ * 돌아와 저장되기까지를 한 번의 호출로 보여준다. 실제 파이프라인을 그대로 태우므로 Slack 알림(alert-service)과
+ * responder 조치 판단도 같이 흘러간다.
+ *
+ * <p>인증을 받지 않는 대신 할 수 있는 일을 좁혀 뒀다. 이 API 는
+ * <b>데모 계정의 tenant</b>({@link DemoTenant})에만 쓰고, <b>미리 정해진 시나리오 4종</b>만 발행한다.
+ * 호출자가 tenant 를 지정할 수도, 임의 이벤트를 넣을 수도 없어서 남의 조직 데이터에 닿을 경로가 없다.
+ * 데모 계정이 없는 환경(시드를 켠 적 없는 곳)에서는 403 으로 아무 일도 하지 않는다.
+ *
+ * <p>임의 이벤트를 발행하고 싶으면 detector 의 {@code POST /api/events} 를 쓴다. 그쪽은 발표용이 아니라
+ * 개발용이라 이 API 와 목적이 다르다.
+ */
+@RestController
+@RequestMapping("/api/demo")
+@Tag(name = "demo", description = "발표용 전체 플로우 시연 (데모 조직 전용, 인증 없이 클릭 한 번)")
+public class DemoController {
+
+    private final DemoFlowService flow;
+    private final DemoTenant demoTenant;
+
+    public DemoController(DemoFlowService flow, DemoTenant demoTenant) {
+        this.flow = flow;
+        this.demoTenant = demoTenant;
+    }
+
+    @Operation(summary = "엔드포인트 로그 수집 시연 (전체 플로우)",
+            description = "선택한 공격 시나리오의 로그를 엔드포인트가 보낸 것처럼 events 토픽으로 발행하고, "
+                    + "detector Kafka Streams 가 판정을 alerts 토픽으로 되돌려 저장되기까지 기다린 뒤 "
+                    + "단계별 소요시간과 결과를 한 번에 돌려준다. 평소 돌고 있던 정상 프로세스 로그도 함께 실려 "
+                    + "실제 수집처럼 보인다. 결과는 데모 계정으로 로그인한 대시보드에 그대로 나타난다.\n\n"
+                    + "- process-chain: 매크로 문서가 shell 실행 (T1059, HIGH)\n"
+                    + "- download-exec: 외부 다운로드 후 그 파일 실행 (T1105+T1204, CRITICAL)\n"
+                    + "- script-exec: 다운로드 경로 스크립트 실행 (T1059, MEDIUM)\n"
+                    + "- file-autorun: 시작프로그램 경로에 파일 생성 (T1547, MEDIUM)\n\n"
+                    + "host 를 비워두면 시나리오별 기본 호스트를 쓴다. 시나리오마다 기본 호스트를 다르게 둔 "
+                    + "이유는 detector 상관 버퍼가 host 별 5분이라 같은 호스트로 여러 시나리오를 연달아 돌리면 "
+                    + "의도한 룰이 아닌 다른 룰이 먼저 매칭될 수 있기 때문이다. "
+                    + "판정까지 기다리므로 응답에 수 초가 걸린다.")
+    @PostMapping("/collect/{scenario}")
+    public DemoFlowResponse collect(
+            @Parameter(description = "공격 시나리오",
+                    schema = @Schema(allowableValues = {"process-chain", "download-exec", "script-exec", "file-autorun"}))
+            @PathVariable String scenario,
+            @Parameter(description = "엔드포인트 식별자. 비우면 시나리오 기본 호스트")
+            @RequestParam(required = false) String host) {
+        if (!DemoScenario.isSupported(scenario)) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                    "미지원 시나리오: " + scenario + " (지원: " + String.join(", ", DemoScenario.names()) + ")");
+        }
+        String tenantId = demoTenant.resolve().orElseThrow(() -> new ResponseStatusException(
+                HttpStatus.FORBIDDEN,
+                "데모 계정(" + DemoAccountSeeder.EMAIL + ")이 없는 환경입니다. "
+                        + "발표 환경에서 DEMO_SEED=true 로 시드를 켜야 이 API 가 동작합니다"));
+        return flow.run(scenario, host, tenantId);
+    }
+}

--- a/api-service/src/main/java/com/edrdog/apiservice/demo/web/DemoFlowResponse.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/demo/web/DemoFlowResponse.java
@@ -1,0 +1,34 @@
+package com.edrdog.apiservice.demo.web;
+
+import com.edrdog.apiservice.alert.web.AlertResponse;
+import com.edrdog.apiservice.demo.CollectedEvent;
+
+import java.util.List;
+
+/**
+ * 데모 수집 API 응답. 한 번의 호출로 "엔드포인트 로그 발행 → 판정 → 저장" 전 구간을 담는다.
+ *
+ * @param scenario       실행한 시나리오 이름
+ * @param host           로그를 보낸 것으로 꾸민 엔드포인트
+ * @param tenantId       조직(tenant) 식별자
+ * @param pipeline       지나간 경로 한 줄 요약 (발표 슬라이드와 대조용)
+ * @param alertId        기대한 alert id — 발행 전에 결정되므로 조회 API 에 그대로 넣어볼 수 있다
+ * @param totalElapsedMs 전체 소요 시간
+ * @param steps          단계별 결과
+ * @param collectedLogs  발행한 이벤트 원본 (수집된 로그 그 자체)
+ * @param alert          저장까지 끝난 판정 결과. 아직 안 왔으면 null
+ * @param nextSteps      발표에서 이어서 눌러볼 API 안내
+ */
+public record DemoFlowResponse(
+        String scenario,
+        String host,
+        String tenantId,
+        String pipeline,
+        String alertId,
+        long totalElapsedMs,
+        List<DemoFlowStep> steps,
+        List<CollectedEvent> collectedLogs,
+        AlertResponse alert,
+        List<String> nextSteps
+) {
+}

--- a/api-service/src/main/java/com/edrdog/apiservice/demo/web/DemoFlowStep.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/demo/web/DemoFlowStep.java
@@ -1,0 +1,32 @@
+package com.edrdog.apiservice.demo.web;
+
+/**
+ * 데모 플로우 한 단계의 결과. 발표에서 "지금 어디까지 갔는지" 를 그대로 읽어 보여주는 용도다.
+ *
+ * @param no        단계 번호 (1부터)
+ * @param name      단계 이름 (수집 / 탐지 / 저장)
+ * @param path      그 단계가 지나간 경로 (예: api-service → Kafka(events))
+ * @param status    OK 또는 TIMEOUT
+ * @param elapsedMs 앞 단계 끝난 시점부터 이 단계까지 걸린 시간
+ * @param detail    사람이 읽을 설명 (무엇이 몇 건, 어떤 룰에 걸렸는지)
+ */
+public record DemoFlowStep(
+        int no,
+        String name,
+        String path,
+        String status,
+        long elapsedMs,
+        String detail
+) {
+
+    public static final String OK = "OK";
+    public static final String TIMEOUT = "TIMEOUT";
+
+    public static DemoFlowStep ok(int no, String name, String path, long elapsedMs, String detail) {
+        return new DemoFlowStep(no, name, path, OK, elapsedMs, detail);
+    }
+
+    public static DemoFlowStep timeout(int no, String name, String path, long elapsedMs, String detail) {
+        return new DemoFlowStep(no, name, path, TIMEOUT, elapsedMs, detail);
+    }
+}

--- a/api-service/src/main/java/com/edrdog/apiservice/security/ApiKeyPolicy.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/security/ApiKeyPolicy.java
@@ -16,6 +16,7 @@ public class ApiKeyPolicy {
             "/api/alerts",  // 알림 조회·트리아지도 세션 Bearer 로 인증(AlertController)
             "/api/hosts",   // 호스트 목록·요약도 세션 Bearer 로 인증(HostController)
             "/api/me",      // 유저 개인 알림 설정도 세션 Bearer 로 인증(UserNotifyController)
+            "/api/demo/",   // 발표용 데모 시연도 세션 Bearer 로 인증하고 데모 계정만 통과시킨다(DemoController)
             "/api/internal/",  // 서비스 간 조회는 별도 X-Internal-Key 로 인증(TenantController), 프론트 키와 분리
             "/api/osquery/"  // 엔드포인트 수집은 자체 enroll_secret/node_key 로 인증(OsqueryController), 프론트 키와 분리
     );

--- a/api-service/src/main/resources/application.yml
+++ b/api-service/src/main/resources/application.yml
@@ -30,6 +30,7 @@ edrdog:
   kafka:
     alerts-topic: alerts                 # detector 가 발행한 판정 결과 (소비 → MySQL 적재)
     events-raw-topic: events-raw         # osquery 수집 원시 result-log (발행 → collector 정규화)
+    events-topic: events                 # 정규화된 이벤트 (발표용 데모 수집 API 가 발행 → detector 판정)
   osquery:
     tls:                                 # osquery 전용 HTTPS 커넥터 (프론트 HTTP 8084 와 별도 포트)
       enabled: ${OSQUERY_TLS_ENABLED:false}          # 켜면 keystore 필수 (scripts/gen-dev-keystore.sh)
@@ -44,6 +45,10 @@ edrdog:
     # 발표용 시드. 켜면 부팅 시 데모 계정(test/1234, tenantId=1)과 최근 7일치 과거 데이터를 만든다.
     # 운영에 test/1234 가 새면 안 되므로 기본은 off. 발표 환경에서만 DEMO_SEED=true 로 켠다.
     seed: ${DEMO_SEED:false}
+    # /api/demo/collect 가 판정을 기다리는 상한. Kafka 왕복(발행→스트림즈→alerts)과 ClickHouse 적재를
+    # 각각 기다린다. 발표 환경이 느려 TIMEOUT 이 뜨면 늘린다.
+    detect-timeout-ms: ${DEMO_DETECT_TIMEOUT_MS:12000}
+    store-timeout-ms: ${DEMO_STORE_TIMEOUT_MS:8000}
   cors:
     # 브라우저에서 API 를 호출할 프론트 출처 (쉼표 구분). 기본값은 Vite dev 서버.
     # 배포 시엔 실제 프론트 도메인을 환경변수로 주입한다.

--- a/api-service/src/test/java/com/edrdog/apiservice/demo/CollectedEventTest.java
+++ b/api-service/src/test/java/com/edrdog/apiservice/demo/CollectedEventTest.java
@@ -1,0 +1,39 @@
+package com.edrdog.apiservice.demo;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * events 토픽 발행 형태를 못박는다. detector 는 자기 사본 레코드(Event)로 역직렬화하므로 필드명이
+ * 하나라도 어긋나면 그 필드가 null 로 들어가 <b>아무 alert 도 안 뜨고 조용히 실패</b>한다.
+ *
+ * <p>detector 쪽 짝은 DemoCollectContractTest(같은 JSON 을 토폴로지에 흘려 alert 를 확인). 이 두 테스트가
+ * 같은 문자열을 각자 적고 있어야 한쪽만 바뀌었을 때 드러난다.
+ */
+class CollectedEventTest {
+
+    private final ObjectMapper mapper = new ObjectMapper();   // EventsProducer 와 같은 기본 설정
+
+    @Test
+    void process_이벤트_직렬화_형태() throws Exception {
+        CollectedEvent event = CollectedEvent.process("PC-01", 1000L, "powershell.exe", "winword.exe",
+                "powershell -enc AAA", "99");
+
+        assertEquals("{\"host\":\"PC-01\",\"type\":\"process\",\"ts\":1000,\"process\":\"powershell.exe\","
+                        + "\"parent\":\"winword.exe\",\"cmdline\":\"powershell -enc AAA\","
+                        + "\"destIp\":null,\"destPort\":0,\"tenantId\":\"99\"}",
+                mapper.writeValueAsString(event));
+    }
+
+    @Test
+    void network_이벤트_직렬화_형태() throws Exception {
+        CollectedEvent event = CollectedEvent.network("PC-01", 1000L, "chrome.exe", "185.220.101.5", 443, "99");
+
+        assertEquals("{\"host\":\"PC-01\",\"type\":\"network\",\"ts\":1000,\"process\":\"chrome.exe\","
+                        + "\"parent\":null,\"cmdline\":null,\"destIp\":\"185.220.101.5\","
+                        + "\"destPort\":443,\"tenantId\":\"99\"}",
+                mapper.writeValueAsString(event));
+    }
+}

--- a/api-service/src/test/java/com/edrdog/apiservice/demo/DemoApiWithoutSeedTest.java
+++ b/api-service/src/test/java/com/edrdog/apiservice/demo/DemoApiWithoutSeedTest.java
@@ -1,0 +1,50 @@
+package com.edrdog.apiservice.demo;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * 데모 계정이 없는 환경에서는 데모 API 가 아무 일도 하지 않는다는 계약.
+ *
+ * <p>이 API 는 인증을 받지 않으므로, "쓸 수 있는 환경" 을 가르는 것은 데모 계정의 존재 여부다.
+ * 계정은 시드({@code edrdog.demo.seed=true})로만 생기니, 시드를 켠 적 없는 환경에서는 tenant 를
+ * 찾지 못해 403 이 되고 이벤트가 한 건도 나가지 않는다. 시드 플래그로 빈을 끄는 것과 같은 효과이면서,
+ * 발표 환경에서는 파드 재시작 없이 바로 쓸 수 있다.
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.ANY)
+@TestPropertySource(properties = {
+        "spring.kafka.listener.auto-startup=false",
+        "edrdog.demo.seed=false"
+})
+class DemoApiWithoutSeedTest {
+
+    @Autowired
+    private MockMvc mvc;
+
+    @MockitoBean
+    private EventsProducer producer;
+
+    @Test
+    void 데모_계정이_없으면_403_이고_이벤트를_발행하지_않는다() throws Exception {
+        // 404 가 아니라 403 이어야 한다. 404 면 빈이 안 올라온 것이고, 그러면 발표 환경에서
+        // 시드만 켜서 쓸 수 있다는 성질(파드 재시작 불필요)이 깨진다.
+        mvc.perform(post("/api/demo/collect/script-exec"))
+                .andExpect(status().isForbidden());
+
+        verify(producer, never()).publish(any());
+    }
+}

--- a/api-service/src/test/java/com/edrdog/apiservice/demo/DemoCollectIntegrationTest.java
+++ b/api-service/src/test/java/com/edrdog/apiservice/demo/DemoCollectIntegrationTest.java
@@ -1,0 +1,149 @@
+package com.edrdog.apiservice.demo;
+
+import com.edrdog.apiservice.alert.AlertService;
+import com.edrdog.apiservice.alert.web.AlertResponse;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultMatcher;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * 발표용 데모 수집 API 배선 검증. 데모 시드를 켜고 전체 컨텍스트를 띄운다 — 발표 당일에 빈 배선이
+ * 어긋나 있는 것보다 여기서 깨지는 게 낫다.
+ *
+ * <p>인증 헤더 없이 호출된다는 것 자체가 계약이다(스웨거에서 Execute 한 번). 대신 발행 대상 tenant 를
+ * 호출자가 못 정하고 서버가 데모 계정에서 찾아 쓴다는 것을 함께 확인한다.
+ *
+ * <p>Kafka/ClickHouse 없이 확인하려고 발행(EventsProducer)·도착 관측(AlertArrivals)·조회(AlertService)를
+ * 목으로 대체하고, 컨트롤러가 무엇을 어떤 순서로 발행하고 어떤 타임라인을 만드는지만 검증한다.
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.ANY)
+@TestPropertySource(properties = {
+        "spring.kafka.listener.auto-startup=false",
+        "edrdog.demo.seed=true",
+        // 대기 상한을 짧게: 테스트가 실제 12초를 흘려보낼 이유가 없다
+        "edrdog.demo.detect-timeout-ms=300",
+        "edrdog.demo.store-timeout-ms=300"
+})
+class DemoCollectIntegrationTest {
+
+    @Autowired
+    private MockMvc mvc;
+
+    @Autowired
+    private ObjectMapper om;
+
+    @MockitoBean
+    private EventsProducer producer;     // Kafka 대신 목: 발행 인자와 순서만 검증
+
+    @MockitoBean
+    private AlertArrivals arrivals;      // alerts 토픽 도착 관측 대체
+
+    @MockitoBean
+    private AlertService alerts;         // ClickHouse 조회 대체
+
+    @Test
+    void 인증_없이_호출해도_수집부터_저장까지_타임라인이_나온다() throws Exception {
+        givenDetectionSucceeds();
+
+        JsonNode res = collect(DemoScenario.DOWNLOAD_EXEC, status().isOk());
+
+        assertEquals("download-exec", res.get("scenario").asText());
+        assertEquals("DESKTOP-CHOI", res.get("host").asText());   // 시나리오 기본 host
+        assertEquals(3, res.get("steps").size());
+        for (JsonNode step : res.get("steps")) {
+            assertEquals("OK", step.get("status").asText(), step.toString());
+        }
+        assertEquals("DOWNLOAD_AND_EXECUTE", res.get("alert").get("ruleId").asText());
+        assertTrue(res.get("alertId").asText().length() > 0);
+    }
+
+    @Test
+    void 발행_대상_tenant_는_데모_계정에서_찾은_값이다() throws Exception {
+        // 호출자가 tenant 를 지정할 방법이 없다는 것이 이 API 의 안전장치다.
+        givenDetectionSucceeds();
+
+        JsonNode res = collect(DemoScenario.DOWNLOAD_EXEC, status().isOk());
+
+        String demoTenant = String.valueOf(DemoAccountSeeder.TENANT_ID);
+        assertEquals(demoTenant, res.get("tenantId").asText());
+        ArgumentCaptor<CollectedEvent> captor = ArgumentCaptor.forClass(CollectedEvent.class);
+        verify(producer, Mockito.atLeastOnce()).publish(captor.capture());
+        assertTrue(captor.getAllValues().stream().allMatch(e -> demoTenant.equals(e.tenantId())));
+    }
+
+    @Test
+    void 발행_순서가_배경_로그_다음_공격_이벤트다() throws Exception {
+        givenDetectionSucceeds();
+
+        collect(DemoScenario.DOWNLOAD_EXEC, status().isOk());
+
+        ArgumentCaptor<CollectedEvent> captor = ArgumentCaptor.forClass(CollectedEvent.class);
+        verify(producer, Mockito.times(5)).publish(captor.capture());
+        List<CollectedEvent> published = captor.getAllValues();
+        assertEquals(List.of("OneDrive.exe", "Teams.exe", "MsEdgeUpdate.exe", "chrome.exe", "update32.exe"),
+                published.stream().map(CollectedEvent::process).toList());
+        assertEquals(CollectedEvent.TYPE_NETWORK, published.get(3).type());
+        assertTrue(published.stream().allMatch(e -> "DESKTOP-CHOI".equals(e.host())));
+    }
+
+    @Test
+    void 판정이_돌아오지_않으면_탐지_단계가_TIMEOUT_으로_남는다() throws Exception {
+        when(arrivals.arrivedAt(anyString())).thenReturn(Optional.empty());
+
+        JsonNode res = collect(DemoScenario.SCRIPT_EXEC, status().isOk());
+
+        assertEquals(2, res.get("steps").size());   // 수집 OK + 탐지 TIMEOUT (저장은 시도하지 않는다)
+        assertEquals("OK", res.get("steps").get(0).get("status").asText());
+        assertEquals("TIMEOUT", res.get("steps").get(1).get("status").asText());
+        assertTrue(res.get("steps").get(1).get("detail").asText().contains("300ms"));
+        assertTrue(res.get("alert").isNull());
+    }
+
+    @Test
+    void 미지원_시나리오는_400_이고_아무것도_발행하지_않는다() throws Exception {
+        collect("ransomware", status().isBadRequest());
+
+        verify(producer, Mockito.never()).publish(any());
+    }
+
+    /** 판정이 alerts 토픽으로 돌아오고 조회까지 되는 정상 경로. */
+    private void givenDetectionSucceeds() {
+        when(arrivals.arrivedAt(anyString())).thenReturn(Optional.of(System.currentTimeMillis()));
+        when(alerts.get(anyString(), anyString())).thenAnswer(inv -> new AlertResponse(
+                inv.getArgument(1), "DESKTOP-CHOI", "DOWNLOAD_AND_EXECUTE", "다운로드 후 실행",
+                "T1105+T1204", "CRITICAL", "kill", System.currentTimeMillis(), "open",
+                List.of("network 185.220.101.5:443", "process update32.exe")));
+    }
+
+    /** 헤더 하나 없이 호출한다 — 발표에서 스웨거 Execute 를 누르는 것과 같다. */
+    private JsonNode collect(String scenario, ResultMatcher expected) throws Exception {
+        String body = mvc.perform(post("/api/demo/collect/" + scenario))
+                .andExpect(expected)
+                .andReturn().getResponse().getContentAsString();
+        return body.isEmpty() ? om.createObjectNode() : om.readTree(body);
+    }
+}

--- a/api-service/src/test/java/com/edrdog/apiservice/demo/DemoScenarioTest.java
+++ b/api-service/src/test/java/com/edrdog/apiservice/demo/DemoScenarioTest.java
@@ -1,0 +1,155 @@
+package com.edrdog.apiservice.demo;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * 발표용 수집 시나리오 생성(순수). baseTs 를 받아 결정적으로 만들고,
+ * detector 룰을 의도한 것만 트리거하도록(배경 로그가 오탐을 만들지 않도록) 보장한다.
+ */
+class DemoScenarioTest {
+
+    private static final String TENANT = "99";
+    private static final long BASE = 1_770_000_000_000L;   // 고정 기준 시각 (결정성 확인용)
+
+    @Test
+    void 지원_시나리오는_네_종류다() {
+        assertEquals(List.of(DemoScenario.PROCESS_CHAIN, DemoScenario.DOWNLOAD_EXEC,
+                DemoScenario.SCRIPT_EXEC, DemoScenario.FILE_AUTORUN), DemoScenario.names());
+        assertTrue(DemoScenario.names().stream().allMatch(DemoScenario::isSupported));
+        assertFalse(DemoScenario.isSupported("ransomware"));
+        assertFalse(DemoScenario.isSupported(null));
+    }
+
+    @Test
+    void 미지원_시나리오는_예외다() {
+        assertThrows(IllegalArgumentException.class,
+                () -> DemoScenario.build("ransomware", "PC-01", BASE, TENANT));
+    }
+
+    @Test
+    void 같은_입력이면_항상_같은_결과다() {
+        for (String name : DemoScenario.names()) {
+            assertEquals(DemoScenario.build(name, "PC-01", BASE, TENANT),
+                    DemoScenario.build(name, "PC-01", BASE, TENANT));
+        }
+    }
+
+    @Test
+    void 모든_이벤트가_지정_host_와_tenant_로_태깅된다() {
+        for (String name : DemoScenario.names()) {
+            List<CollectedEvent> events = DemoScenario.build(name, "PC-01", BASE, TENANT);
+            assertTrue(events.stream().allMatch(e -> "PC-01".equals(e.host())), name);
+            assertTrue(events.stream().allMatch(e -> TENANT.equals(e.tenantId())), name);
+        }
+    }
+
+    @Test
+    void 발행_순서가_시간_순서와_같다() {
+        // detector 는 host 파티션 안 순서대로 상관하므로 선행 이벤트가 먼저 나가야 룰이 성립한다.
+        for (String name : DemoScenario.names()) {
+            List<CollectedEvent> events = DemoScenario.build(name, "PC-01", BASE, TENANT);
+            for (int i = 1; i < events.size(); i++) {
+                assertTrue(events.get(i - 1).ts() <= events.get(i).ts(), name + " #" + i);
+            }
+        }
+    }
+
+    @Test
+    void 배경_로그는_공격보다_앞서고_공격은_baseTs_부터_시작한다() {
+        for (String name : DemoScenario.names()) {
+            List<CollectedEvent> events = DemoScenario.build(name, "PC-01", BASE, TENANT);
+            assertTrue(events.stream().anyMatch(e -> e.ts() < BASE), name + " 배경 로그 없음");
+            assertTrue(events.stream().anyMatch(e -> e.ts() >= BASE), name + " 공격 이벤트 없음");
+        }
+    }
+
+    @Test
+    void 배경_로그에는_network_이벤트가_없다() {
+        // R2(다운로드 후 실행)는 "선행 network(80/443/8080) + 이후 process" 만으로 CRITICAL 을 낸다.
+        // 배경 소음에 network 를 섞으면 뒤따르는 정상 프로세스가 R2 오탐으로 잡힌다.
+        for (String name : DemoScenario.names()) {
+            List<CollectedEvent> background = DemoScenario.build(name, "PC-01", BASE, TENANT).stream()
+                    .filter(e -> e.ts() < BASE)
+                    .toList();
+            assertTrue(background.stream().noneMatch(e -> CollectedEvent.TYPE_NETWORK.equals(e.type())), name);
+        }
+    }
+
+    @Test
+    void 배경_프로세스는_detector_baseline_억제_대상_이름만_쓴다() {
+        // detector Rules.BASELINE_SAFE = {onedrive.exe, teams.exe, gupdate.exe, msedgeupdate.exe, update.exe}.
+        // 같은 시나리오를 5분 안에 재실행하면 앞 회차 network 이벤트가 버퍼에 남아 R2 가 배경 프로세스에
+        // CRITICAL 오탐을 낸다. 억제 대상 이름만 쓰면 그 경로가 막힌다.
+        Set<String> baselineSafe = Set.of("onedrive.exe", "teams.exe", "gupdate.exe", "msedgeupdate.exe", "update.exe");
+        for (String name : DemoScenario.names()) {
+            List<CollectedEvent> background = DemoScenario.build(name, "PC-01", BASE, TENANT).stream()
+                    .filter(e -> e.ts() < BASE)
+                    .toList();
+            assertFalse(background.isEmpty(), name);
+            assertTrue(background.stream().allMatch(e -> baselineSafe.contains(e.process().toLowerCase())),
+                    name + " 배경 프로세스가 baseline 억제 대상이 아니다");
+        }
+    }
+
+    @Test
+    void network_이벤트는_download_exec_에만_있다() {
+        for (String name : DemoScenario.names()) {
+            boolean hasNetwork = DemoScenario.build(name, "PC-01", BASE, TENANT).stream()
+                    .anyMatch(e -> CollectedEvent.TYPE_NETWORK.equals(e.type()));
+            assertEquals(DemoScenario.DOWNLOAD_EXEC.equals(name), hasNetwork, name);
+        }
+    }
+
+    @Test
+    void 판정을_트리거하는_이벤트는_마지막_이벤트다() {
+        // 기대 alert 의 ts = 마지막 이벤트 ts. 이 계약으로 alert id 를 미리 계산해 도착을 기다린다.
+        List<CollectedEvent> chain = DemoScenario.build(DemoScenario.PROCESS_CHAIN, "PC-01", BASE, TENANT);
+        CollectedEvent trigger = chain.get(chain.size() - 1);
+        assertEquals("powershell.exe", trigger.process());
+        assertEquals("winword.exe", trigger.parent());
+
+        List<CollectedEvent> download = DemoScenario.build(DemoScenario.DOWNLOAD_EXEC, "PC-01", BASE, TENANT);
+        assertEquals(CollectedEvent.TYPE_PROCESS, download.get(download.size() - 1).type());
+    }
+
+    @Test
+    void 시나리오별_기대_룰이_있다() {
+        assertEquals("SUSPICIOUS_PROCESS_CHAIN", DemoScenario.expectedRuleId(DemoScenario.PROCESS_CHAIN));
+        assertEquals("DOWNLOAD_AND_EXECUTE", DemoScenario.expectedRuleId(DemoScenario.DOWNLOAD_EXEC));
+        assertEquals("SCRIPT_FROM_TEMP_PATH", DemoScenario.expectedRuleId(DemoScenario.SCRIPT_EXEC));
+        assertEquals("FILE_IN_AUTORUN_PATH", DemoScenario.expectedRuleId(DemoScenario.FILE_AUTORUN));
+    }
+
+    @Test
+    void 시나리오별_기본_host_가_서로_다르다() {
+        // detector 상관 버퍼는 host 별 5분이라 같은 host 로 다른 시나리오를 연달아 돌리면
+        // 앞 시나리오의 선행 이벤트가 남아 다른 룰이 먼저 매칭될 수 있다.
+        Set<String> hosts = new HashSet<>();
+        for (String name : DemoScenario.names()) {
+            assertTrue(hosts.add(DemoScenario.defaultHost(name)), name + " host 중복");
+        }
+    }
+
+    @Test
+    void script_와_file_시나리오는_판정_경로를_cmdline_에_담는다() {
+        // R3/R4 는 cmdline 의 경로 표식으로 판정한다(process 는 basename).
+        List<CollectedEvent> script = DemoScenario.build(DemoScenario.SCRIPT_EXEC, "PC-01", BASE, TENANT);
+        CollectedEvent scriptTrigger = script.get(script.size() - 1);
+        assertEquals(CollectedEvent.TYPE_SCRIPT, scriptTrigger.type());
+        assertTrue(scriptTrigger.cmdline().toLowerCase().contains("\\downloads\\"));
+
+        List<CollectedEvent> file = DemoScenario.build(DemoScenario.FILE_AUTORUN, "PC-01", BASE, TENANT);
+        CollectedEvent fileTrigger = file.get(file.size() - 1);
+        assertEquals(CollectedEvent.TYPE_FILE, fileTrigger.type());
+        assertTrue(fileTrigger.cmdline().toLowerCase().contains("\\startup\\"));
+    }
+}

--- a/detector-service/src/test/java/com/edrdog/detectorservice/kafkastreams/topology/DemoCollectContractTest.java
+++ b/detector-service/src/test/java/com/edrdog/detectorservice/kafkastreams/topology/DemoCollectContractTest.java
@@ -1,0 +1,184 @@
+package com.edrdog.detectorservice.kafkastreams.topology;
+
+import com.edrdog.detectorservice.dto.Alert;
+import com.edrdog.detectorservice.dto.Event;
+import com.edrdog.detectorservice.kafkastreams.serde.JsonSerde;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.streams.TestInputTopic;
+import org.apache.kafka.streams.TestOutputTopic;
+import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.TopologyTestDriver;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Properties;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * api-service 의 발표용 수집 API(POST /api/demo/collect/{scenario})가 events 토픽에 넣는
+ * <b>실제 JSON 그대로</b>를 토폴로지에 흘려 의도한 alert 가 나오는지 검증한다.
+ *
+ * <p>api-service 는 자기 사본 레코드(CollectedEvent)를 직렬화해 발행한다. 필드명이 detector 의
+ * {@link Event} 와 하나라도 어긋나면 그 필드가 null 로 역직렬화돼 <b>아무 alert 도 안 뜨고 조용히 실패</b>한다.
+ * 발표 당일에 그걸 발견하는 대신 여기서 깨지게 한다. JSON 을 문자열 리터럴로 박는 것이 요점이다 —
+ * 양쪽 레코드를 공유하면 이름이 같이 바뀌어 어긋남을 못 잡는다.
+ *
+ * <p>배경 로그가 어떤 룰도 트리거하지 않는다는 것(정확히 1건만 발행된다는 것)도 같이 확인한다.
+ */
+class DemoCollectContractTest {
+
+    private static final String EVENTS = "events";
+    private static final String ALERTS = "alerts";
+
+    /** 발표용 배경 로그 3건. detector 의 baseline 억제 대상 이름이라 어떤 룰도 트리거하지 않아야 한다. */
+    private static final List<String> BACKGROUND = List.of(
+            json("DESKTOP-DEMO", "process", 88_000, "OneDrive.exe", "explorer.exe",
+                    "\\\"C:\\\\Program Files\\\\Microsoft OneDrive\\\\OneDrive.exe\\\" /background", null, 0),
+            json("DESKTOP-DEMO", "process", 92_000, "Teams.exe", "explorer.exe",
+                    "\\\"C:\\\\Users\\\\Public\\\\AppData\\\\Local\\\\Microsoft\\\\Teams\\\\Teams.exe\\\"", null, 0),
+            json("DESKTOP-DEMO", "process", 96_000, "MsEdgeUpdate.exe", "services.exe",
+                    "\\\"C:\\\\Program Files (x86)\\\\Microsoft\\\\EdgeUpdate\\\\MicrosoftEdgeUpdate.exe\\\" /svc", null, 0));
+
+    private TopologyTestDriver driver;
+    private TestInputTopic<String, String> events;
+    private TestOutputTopic<String, Alert> alerts;
+
+    @BeforeEach
+    void setUp() {
+        StreamsBuilder builder = new StreamsBuilder();
+        DetectionTopology.build(builder, EVENTS, ALERTS, DetectionTopology.WINDOW_MS);
+
+        Properties props = new Properties();
+        props.put("application.id", "detector-demo-contract");
+        props.put("bootstrap.servers", "dummy:9092");
+
+        driver = new TopologyTestDriver(builder.build(), props);
+        // api-service 는 JSON 문자열로 발행한다. 역직렬화까지 포함해 검증하려고 String 으로 넣는다.
+        events = driver.createInputTopic(EVENTS, Serdes.String().serializer(), Serdes.String().serializer());
+        alerts = driver.createOutputTopic(ALERTS, Serdes.String().deserializer(),
+                new JsonSerde<>(Alert.class).deserializer());
+    }
+
+    @AfterEach
+    void tearDown() {
+        driver.close();
+    }
+
+    @Test
+    @DisplayName("배경 로그만 흘리면 어떤 alert 도 안 뜬다")
+    void background_noAlert() {
+        BACKGROUND.forEach(this::send);
+
+        assertThat(alerts.isEmpty()).isTrue();
+    }
+
+    @Test
+    @DisplayName("process-chain: 배경 로그 + 매크로 문서 체인 → HIGH 1건만")
+    void processChain() {
+        BACKGROUND.forEach(this::send);
+        send(json("DESKTOP-DEMO", "process", 100_000, "winword.exe", "explorer.exe",
+                "\\\"C:\\\\Users\\\\kim\\\\Documents\\\\견적서_2026.docm\\\"", null, 0));
+        send(json("DESKTOP-DEMO", "process", 101_000, "powershell.exe", "winword.exe",
+                "powershell -nop -w hidden -enc SQBFAFgAIAAoAE4AZQB3AC0ATwBiAGoA...", null, 0));
+
+        Alert alert = onlyAlert();
+        assertThat(alert.ruleId()).isEqualTo("SUSPICIOUS_PROCESS_CHAIN");
+        assertThat(alert.mitre()).isEqualTo("T1059");
+        assertThat(alert.severity()).isEqualTo(Alert.SEV_HIGH);
+        assertThat(alert.ts()).isEqualTo(101_000);      // 판정 ts = 마지막 이벤트 ts (alert id 계산 근거)
+        assertThat(alert.tenantId()).isEqualTo("99");
+    }
+
+    @Test
+    @DisplayName("download-exec: 배경 로그 + 다운로드 후 실행 → CRITICAL 1건만")
+    void downloadExec() {
+        BACKGROUND.forEach(this::send);
+        send(json("DESKTOP-DEMO", "network", 100_000, "chrome.exe", null, null, "185.220.101.5", 443));
+        send(json("DESKTOP-DEMO", "process", 101_000, "update32.exe", "explorer.exe",
+                "C:\\\\Users\\\\choi\\\\Downloads\\\\update32.exe", null, 0));
+
+        Alert alert = onlyAlert();
+        assertThat(alert.ruleId()).isEqualTo("DOWNLOAD_AND_EXECUTE");
+        assertThat(alert.severity()).isEqualTo(Alert.SEV_CRITICAL);
+        assertThat(alert.ts()).isEqualTo(101_000);
+    }
+
+    @Test
+    @DisplayName("script-exec: 다운로드 경로 스크립트 → MEDIUM 1건만")
+    void scriptExec() {
+        BACKGROUND.forEach(this::send);
+        send(json("DESKTOP-DEMO", "script", 100_000, "powershell.exe", "explorer.exe",
+                "powershell -ExecutionPolicy Bypass -File C:\\\\Users\\\\park\\\\Downloads\\\\invoice_setup.ps1",
+                null, 0));
+
+        Alert alert = onlyAlert();
+        assertThat(alert.ruleId()).isEqualTo("SCRIPT_FROM_TEMP_PATH");
+        assertThat(alert.severity()).isEqualTo(Alert.SEV_MEDIUM);
+        assertThat(alert.ts()).isEqualTo(100_000);
+    }
+
+    @Test
+    @DisplayName("file-autorun: 시작프로그램 경로 파일 생성 → MEDIUM 1건만")
+    void fileAutorun() {
+        BACKGROUND.forEach(this::send);
+        send(json("DESKTOP-DEMO", "file", 100_000, "svc-update.lnk", null,
+                "C:\\\\Users\\\\lee\\\\AppData\\\\Roaming\\\\Microsoft\\\\Windows\\\\Start Menu"
+                        + "\\\\Programs\\\\Startup\\\\svc-update.lnk", null, 0));
+
+        Alert alert = onlyAlert();
+        assertThat(alert.ruleId()).isEqualTo("FILE_IN_AUTORUN_PATH");
+        assertThat(alert.mitre()).isEqualTo("T1547");
+        assertThat(alert.ts()).isEqualTo(100_000);
+    }
+
+    @Test
+    @DisplayName("같은 시나리오를 윈도우 안에서 두 번 돌려도 배경 로그가 오탐을 만들지 않는다")
+    void repeatedRun_noFalsePositiveOnBackground() {
+        // 1회차 network 이벤트가 버퍼에 남은 상태에서 2회차 배경 로그가 들어온다.
+        // 배경 프로세스가 baseline 억제 대상이 아니면 여기서 R2 오탐이 잡힌다.
+        BACKGROUND.forEach(this::send);
+        send(json("DESKTOP-DEMO", "network", 100_000, "chrome.exe", null, null, "185.220.101.5", 443));
+        send(json("DESKTOP-DEMO", "process", 101_000, "update32.exe", "explorer.exe",
+                "C:\\\\Users\\\\choi\\\\Downloads\\\\update32.exe", null, 0));
+        assertThat(alerts.getQueueSize()).isEqualTo(1);
+        alerts.readValue();
+
+        BACKGROUND.forEach(this::send);   // 2회차 배경 로그 — 오탐이 나오면 안 된다
+
+        assertThat(alerts.isEmpty()).isTrue();
+    }
+
+    private void send(String eventJson) {
+        events.pipeInput("DESKTOP-DEMO", eventJson);
+    }
+
+    private Alert onlyAlert() {
+        assertThat(alerts.getQueueSize()).isEqualTo(1);
+        return alerts.readValue();
+    }
+
+    /**
+     * api-service 의 CollectedEvent 를 Jackson 이 직렬화한 형태 그대로. 필드명을 손으로 적는 것이 요점이다
+     * (레코드를 공유하면 이름이 같이 바뀌어 어긋남을 못 잡는다).
+     */
+    private static String json(String host, String type, long ts, String process, String parent,
+                               String cmdline, String destIp, int destPort) {
+        return "{\"host\":" + quoted(host)
+                + ",\"type\":" + quoted(type)
+                + ",\"ts\":" + ts
+                + ",\"process\":" + quoted(process)
+                + ",\"parent\":" + quoted(parent)
+                + ",\"cmdline\":" + quoted(cmdline)
+                + ",\"destIp\":" + quoted(destIp)
+                + ",\"destPort\":" + destPort
+                + ",\"tenantId\":\"99\"}";
+    }
+
+    private static String quoted(String value) {
+        return value == null ? "null" : "\"" + value + "\"";
+    }
+}


### PR DESCRIPTION
## 무엇

`POST /api/demo/collect/{scenario}` 하나. 스웨거에서 Execute 한 번 누르면 엔드포인트 로그 수집부터 판정·저장까지 전 구간이 실제로 돌고, 단계별 소요시간과 결과가 응답으로 돌아온다. 발표 중에 파이프라인 전체를 한 화면에서 보여주기 위한 API다.

```
api-service ─(events)─▶ detector Kafka Streams ─(alerts)─▶ api-service(ClickHouse+MySQL)
```

시나리오는 드롭다운에서 고른다.

| scenario | 내용 | 결과 |
|---|---|---|
| `process-chain` | 매크로 문서가 shell 실행 | T1059 HIGH |
| `download-exec` | 외부 다운로드 후 그 파일 실행 | T1105+T1204 CRITICAL |
| `script-exec` | 다운로드 경로 스크립트 실행 | T1059 MEDIUM |
| `file-autorun` | 시작프로그램 경로에 파일 생성 | T1547 MEDIUM |

응답에는 발행한 로그 원본, 3단계 타임라인(수집 / 탐지 / 저장), 만들어진 alert, 이어서 눌러볼 API 목록이 들어간다. 판정이 안 돌아오면 해당 단계가 `TIMEOUT`으로 남아 어디서 막혔는지 바로 보인다.

## 왜 이렇게 했는지

**판정 도착과 저장을 따로 계측한다.** 그래야 스트림즈가 한 일이 응답에서 보인다. 도착 관측은 적재용 리스너와 별도 컨슈머 그룹(`api-demo-arrivals`)을 둬 서로 간섭하지 않게 했다. alert id는 발행 전에 계산하므로(`tenant|host|rule|ts` 결정적) 과거 회차 판정을 이번 결과로 착각하지 않는다.

**배경 로그를 함께 발행한다.** 공격 이벤트 2건만 보내면 수집처럼 안 보여서, 평소 돌던 정상 프로세스 3건을 앞에 붙였다. 단 배경 프로세스 이름은 detector의 baseline 억제 대상만 쓴다. 상관 버퍼가 host별 5분이라, 그렇지 않으면 같은 시나리오를 5분 안에 재실행할 때 앞 회차 network 이벤트가 버퍼에 남아 R2("선행 network + 이후 아무 process")가 이번 회차 **배경** 프로세스에 CRITICAL 오탐을 낸다. 시나리오별 기본 host를 다르게 둔 것도 같은 버퍼 오염을 피하려는 것이다.

**인증을 받지 않는다.** 발표자가 스웨거에서 토큰을 복사해 붙이는 건 실사용 흐름이 아니다. 대신 할 수 있는 일을 좁혔다.

- 쓰기 대상은 데모 계정이 속한 tenant로 고정. 호출자가 tenant를 지정할 파라미터가 없다.
- 발행 가능한 것은 정해진 시나리오 4종뿐. 임의 이벤트는 넣을 수 없다.
- 데모 계정은 시드로만 생기므로, 시드를 켠 적 없는 환경에서는 403으로 아무 일도 하지 않는다. 플래그로 빈을 끄는 것과 같은 효과이면서 발표 환경에서는 파드 재시작이 필요 없다.

남는 위험은 외부인이 URL을 알아내면 데모 조직에 가짜 알림을 쌓고 데모 조직 Slack으로 알림을 보낼 수 있다는 것. 실제 조직 데이터에는 닿지 않는다. 발표 후 닫으려면 `DEMO_SEED=false`로 되돌리면 403이 된다.

## 검증

`./gradlew build` 전체 통과.

- **`DemoCollectContractTest`** (detector): api-service가 발행하는 JSON 문자열 그대로를 TopologyTestDriver에 흘려 4종 모두 의도한 룰 1건만 나오는 것, 재실행 시 배경 로그가 오탐을 만들지 않는 것을 확인. 필드명이 어긋나면 detector가 null로 역직렬화해서 알림이 조용히 안 뜨는 게 가장 큰 리스크라, 발행 형태도 `CollectedEventTest`에서 문자열로 못박았다. 두 테스트가 같은 문자열을 각자 적고 있어야 한쪽만 바뀌었을 때 드러난다.
- **`DemoScenarioTest`**: 결정성, 발행 순서, 배경 로그 제약(network 없음 / baseline 억제 이름만), 시나리오별 host 분리
- **`DemoCollectIntegrationTest`**: 무헤더 호출 200, tenant 고정, 발행 순서, TIMEOUT 표기, 미지원 시나리오 400
- **`DemoApiWithoutSeedTest`**: 데모 계정 없는 환경 403 + 이벤트 미발행

## 배포

머지만 하면 된다. CD가 새 이미지를 롤링하고 나면 스웨거 `demo` 태그에 나타난다. 배포서버에 데모 계정이 이미 있어(tenantId=99) `kubectl set env`나 `k8s/` apply는 필요 없다.

## 안 한 것

`collector-service`는 손대지 않았다. Dockerfile도 없고 CI 이미지 matrix와 `k8s/`에도 없어서 배포 환경에서 `events-raw → events` 정규화가 돌지 않는다. 이 API는 정규화된 `events`로 바로 발행하므로 collector 없이 동작한다. 다만 **실제 osquery 에이전트 수집 경로는 현재 배포에서 죽어 있는 상태**다. 별도 이슈로 다뤄야 한다.
