### PR TITLE
feat: 모니터링 스택 도입 (OTLP 계측 + otel-lgtm + Alloy 로그 수집)

### DIFF
--- a/alert-service/src/main/resources/application.yml
+++ b/alert-service/src/main/resources/application.yml
@@ -11,6 +11,8 @@ spring:
       properties:
         spring.json.value.default.type: com.edrdog.alertservice.dto.Alert
         spring.json.trusted.packages: com.edrdog.alertservice.dto
+    listener:
+      observation-enabled: true         # 컨슈머 스팬 생성 → 발행 측 traceId 를 이어받아 한 트레이스로 연결
 
 server:
   port: 8083
@@ -31,3 +33,11 @@ management:
     web:
       exposure:
         include: health, info
+  # 관측 — 트레이스만 보낸다(메트릭 익스포터는 api/detector/archiver 에만).
+  tracing:
+    enabled: ${OTEL_ENABLED:true}
+    sampling:
+      probability: ${OTEL_TRACE_SAMPLING:1.0}
+  otlp:
+    tracing:
+      endpoint: ${OTEL_EXPORTER_OTLP_ENDPOINT:http://localhost:4318}/v1/traces

--- a/api-service/build.gradle
+++ b/api-service/build.gradle
@@ -9,6 +9,7 @@ dependencies {
     implementation 'org.springframework.security:spring-security-crypto'      // auth: BCrypt 비밀번호 해시(필터체인 없이)
     implementation 'com.maxmind.geoip2:geoip2:4.2.1'                   // GeoLite2-Country mmdb 로 dest_ip -> 국가 코드 (world map)
     testImplementation 'com.h2database:h2'                             // auth: 테스트용 임베디드 DB
+    implementation 'io.micrometer:micrometer-registry-otlp'            // 메트릭 OTLP 전송 (프론트 진입점이라 RED 지표 필요)
 }
 
 // --- GeoLite2-Country mmdb: 빌드 시 MaxMind 에서 다운로드해 jar 리소스로 번들 ---

--- a/api-service/src/main/resources/application.yml
+++ b/api-service/src/main/resources/application.yml
@@ -22,6 +22,11 @@ spring:
     producer:                            # osquery 수집 원시 로그를 events-raw 로 발행(문자열)
       key-serializer: org.apache.kafka.common.serialization.StringSerializer
       value-serializer: org.apache.kafka.common.serialization.StringSerializer
+    # 발행/소비 스팬 생성 → Kafka 를 건너도 traceId 가 이어진다
+    template:
+      observation-enabled: true
+    listener:
+      observation-enabled: true
 
 server:
   port: 8084
@@ -67,3 +72,26 @@ management:
     web:
       exposure:
         include: health, info
+  # 관측 — otel-lgtm(k8s/otel-lgtm.yaml) 으로 OTLP 전송. 스택 없이 개발할 땐 OTEL_ENABLED=false.
+  tracing:
+    enabled: ${OTEL_ENABLED:true}
+    sampling:
+      probability: ${OTEL_TRACE_SAMPLING:1.0}      # 데모 규모라 전량 샘플링
+  otlp:
+    tracing:
+      endpoint: ${OTEL_EXPORTER_OTLP_ENDPOINT:http://localhost:4318}/v1/traces
+    metrics:
+      export:
+        enabled: ${OTEL_ENABLED:true}
+        url: ${OTEL_EXPORTER_OTLP_ENDPOINT:http://localhost:4318}/v1/metrics
+        step: 10s                                  # 기본 1m 은 데모에서 그래프가 늦게 뜬다
+        base-time-unit: seconds                    # Prometheus 관례(초 단위) — 대시보드 쿼리가 이 이름에 맞춰져 있다
+  metrics:
+    distribution:
+      # 버킷을 발행해야 Grafana 에서 p50/p95/p99 를 계산할 수 있다. 끄면 +Inf 버킷만 나가 분위수가 NaN 이 된다.
+      percentiles-histogram:
+        http.server.requests: true
+      minimum-expected-value:
+        http.server.requests: 5ms                  # 버킷 개수를 이 범위로 제한 (카디널리티 방어)
+      maximum-expected-value:
+        http.server.requests: 10s

--- a/archiver-service/build.gradle
+++ b/archiver-service/build.gradle
@@ -3,4 +3,5 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'   // RestClient (ClickHouse HTTP)
     implementation 'org.springframework.kafka:spring-kafka'
     implementation 'com.fasterxml.jackson.core:jackson-databind'        // events JSON 역직렬화 + JSONEachRow 직렬화
+    implementation 'io.micrometer:micrometer-registry-otlp'             // 메트릭 OTLP 전송 (ClickHouse 적재 지연/컨슈머 랙 관측 대상)
 }

--- a/archiver-service/src/main/resources/application.yml
+++ b/archiver-service/src/main/resources/application.yml
@@ -11,6 +11,8 @@ spring:
       properties:
         spring.json.value.default.type: com.edrdog.archiverservice.dto.Event
         spring.json.trusted.packages: com.edrdog.archiverservice.dto
+    listener:
+      observation-enabled: true         # 컨슈머 스팬 생성 → 발행 측 traceId 를 이어받아 한 트레이스로 연결
 
 server:
   port: 8083
@@ -30,3 +32,26 @@ management:
     web:
       exposure:
         include: health, info
+  # 관측 — otel-lgtm(k8s/otel-lgtm.yaml) 으로 OTLP 전송. 스택 없이 개발할 땐 OTEL_ENABLED=false.
+  tracing:
+    enabled: ${OTEL_ENABLED:true}
+    sampling:
+      probability: ${OTEL_TRACE_SAMPLING:1.0}      # 데모 규모라 전량 샘플링
+  otlp:
+    tracing:
+      endpoint: ${OTEL_EXPORTER_OTLP_ENDPOINT:http://localhost:4318}/v1/traces
+    metrics:
+      export:
+        enabled: ${OTEL_ENABLED:true}
+        url: ${OTEL_EXPORTER_OTLP_ENDPOINT:http://localhost:4318}/v1/metrics
+        step: 10s                                  # 기본 1m 은 데모에서 그래프가 늦게 뜬다
+        base-time-unit: seconds                    # Prometheus 관례(초 단위) — 대시보드 쿼리가 이 이름에 맞춰져 있다
+  metrics:
+    distribution:
+      # 버킷을 발행해야 Grafana 에서 p50/p95/p99 를 계산할 수 있다. 끄면 +Inf 버킷만 나가 분위수가 NaN 이 된다.
+      percentiles-histogram:
+        http.server.requests: true
+      minimum-expected-value:
+        http.server.requests: 5ms                  # 버킷 개수를 이 범위로 제한 (카디널리티 방어)
+      maximum-expected-value:
+        http.server.requests: 10s

--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,11 @@ subprojects {
 
     dependencies {
         implementation 'org.springframework.boot:spring-boot-starter-actuator'
+        // 분산 트레이싱 — 전 서비스 공통. Kafka 로 흩어진 이벤트 흐름을 traceId 하나로 잇는 게 목적.
+        // Micrometer Observation -> OTel 브리지 -> OTLP 로 otel-lgtm(Tempo) 전송.
+        // 메트릭 익스포터(micrometer-registry-otlp)는 필요한 모듈에만 개별 추가한다.
+        implementation 'io.micrometer:micrometer-tracing-bridge-otel'
+        implementation 'io.opentelemetry:opentelemetry-exporter-otlp'
         testImplementation 'org.springframework.boot:spring-boot-starter-test'
         testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     }

--- a/collector-service/src/main/resources/application.yml
+++ b/collector-service/src/main/resources/application.yml
@@ -11,6 +11,11 @@ spring:
     producer:                           # 정규화 결과(Event JSON 문자열)를 events 로 발행
       key-serializer: org.apache.kafka.common.serialization.StringSerializer
       value-serializer: org.apache.kafka.common.serialization.StringSerializer
+    # 발행/소비 스팬 생성 → Kafka 를 건너도 traceId 가 이어진다
+    template:
+      observation-enabled: true
+    listener:
+      observation-enabled: true
 
 server:
   port: 8082
@@ -25,3 +30,11 @@ management:
     web:
       exposure:
         include: health, info
+  # 관측 — 트레이스만 보낸다(메트릭 익스포터는 api/detector/archiver 에만).
+  tracing:
+    enabled: ${OTEL_ENABLED:true}
+    sampling:
+      probability: ${OTEL_TRACE_SAMPLING:1.0}
+  otlp:
+    tracing:
+      endpoint: ${OTEL_EXPORTER_OTLP_ENDPOINT:http://localhost:4318}/v1/traces

--- a/detector-service/build.gradle
+++ b/detector-service/build.gradle
@@ -3,6 +3,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter'
     implementation 'org.springframework.boot:spring-boot-starter-web'    // 데모용 이벤트 발행/조회 REST + Swagger 호스팅
     implementation 'org.springframework.kafka:spring-kafka'
+    implementation 'io.micrometer:micrometer-registry-otlp'   // 메트릭 OTLP 전송 (판정 처리량/지연 관측 대상)
     implementation 'org.apache.kafka:kafka-streams'
     implementation 'com.fasterxml.jackson.core:jackson-databind'   // 이벤트 JSON serde
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.9'  // Swagger UI (/swagger-ui.html)

--- a/detector-service/src/main/resources/application.yml
+++ b/detector-service/src/main/resources/application.yml
@@ -17,6 +17,11 @@ spring:
       auto-offset-reset: latest
       key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
       value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+    # 발행/소비 스팬 생성 → Kafka 를 건너도 traceId 가 이어진다
+    template:
+      observation-enabled: true
+    listener:
+      observation-enabled: true
 
 server:
   port: 8081
@@ -31,3 +36,26 @@ management:
     web:
       exposure:
         include: health, info
+  # 관측 — otel-lgtm(k8s/otel-lgtm.yaml) 으로 OTLP 전송. 스택 없이 개발할 땐 OTEL_ENABLED=false.
+  tracing:
+    enabled: ${OTEL_ENABLED:true}
+    sampling:
+      probability: ${OTEL_TRACE_SAMPLING:1.0}      # 데모 규모라 전량 샘플링
+  otlp:
+    tracing:
+      endpoint: ${OTEL_EXPORTER_OTLP_ENDPOINT:http://localhost:4318}/v1/traces
+    metrics:
+      export:
+        enabled: ${OTEL_ENABLED:true}
+        url: ${OTEL_EXPORTER_OTLP_ENDPOINT:http://localhost:4318}/v1/metrics
+        step: 10s                                  # 기본 1m 은 데모에서 그래프가 늦게 뜬다
+        base-time-unit: seconds                    # Prometheus 관례(초 단위) — 대시보드 쿼리가 이 이름에 맞춰져 있다
+  metrics:
+    distribution:
+      # 버킷을 발행해야 Grafana 에서 p50/p95/p99 를 계산할 수 있다. 끄면 +Inf 버킷만 나가 분위수가 NaN 이 된다.
+      percentiles-histogram:
+        http.server.requests: true
+      minimum-expected-value:
+        http.server.requests: 5ms                  # 버킷 개수를 이 범위로 제한 (카디널리티 방어)
+      maximum-expected-value:
+        http.server.requests: 10s

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -1,6 +1,6 @@
 # EDRdog 로컬 인프라 (k8s / kind)
 
-모든 모듈의 전제. kind 클러스터에 Kafka(토픽 `events`/`alerts`) + ClickHouse 를 띄운다.
+모든 모듈의 전제. kind 클러스터에 Kafka(토픽 `events`/`alerts`) + ClickHouse + 모니터링 스택을 띄운다.
 호스트에서 도는 Spring 서비스가 NodePort 매핑으로 접근한다.
 
 ## 기동
@@ -8,7 +8,8 @@
 ```bash
 kind create cluster --config k8s/kind-cluster.yaml   # 클러스터 생성 (name: edrdog)
 # kind-cluster.yaml 은 kind 전용이라 apply 대상에서 제외 (아래는 실제 매니페스트만)
-kubectl apply -f k8s/00-namespace.yaml -f k8s/kafka.yaml -f k8s/clickhouse.yaml
+kubectl apply -f k8s/00-namespace.yaml -f k8s/kafka.yaml -f k8s/clickhouse.yaml \
+              -f k8s/otel-lgtm.yaml -f k8s/alloy.yaml
 kubectl -n edrdog get pods                            # Running 확인
 ```
 
@@ -19,8 +20,12 @@ kubectl -n edrdog get pods                            # Running 확인
 | Kafka | `localhost:9092` | detector 등 (EXTERNAL 리스너) |
 | ClickHouse HTTP | `http://localhost:8123` | user/pw/db = `edrdog` |
 | ClickHouse native | `localhost:9000` | JDBC/드라이버용 |
+| Grafana | `http://localhost:3000` | admin / admin. 첫 화면이 EDRdog Overview |
+| OTLP HTTP | `http://localhost:4318` | 서비스가 메트릭·트레이스를 보내는 곳 |
+| OTLP gRPC | `localhost:4317` | 〃 |
 
 클러스터 내부(파드 간) Kafka 주소: `kafka.edrdog.svc.cluster.local:9094`
+클러스터 내부 OTLP 주소: `http://otel-lgtm:4318` (각 서비스 Deployment 의 `OTEL_EXPORTER_OTLP_ENDPOINT`)
 
 ## 확인
 
@@ -31,6 +36,13 @@ kubectl -n edrdog exec deploy/kafka -- \
 
 # ClickHouse ping
 curl http://localhost:8123/ping     # -> Ok.
+
+# Grafana 헬스 + 대시보드 프로비저닝 확인 (EDRdog 폴더에 4개 있어야 함)
+curl http://localhost:3000/api/health
+curl "http://localhost:3000/api/search?type=dash-db"
+
+# 로그 수집 확인 (수집 중인 서비스 목록)
+curl "http://localhost:3000/api/datasources/proxy/uid/loki/loki/api/v1/label/service_name/values"
 ```
 
 ## 종료
@@ -44,3 +56,33 @@ kind delete cluster --name edrdog    # 클러스터째 삭제 (데이터 emptyDi
 - 개발용이라 **영속성 없음**(emptyDir). 파드 재시작 시 데이터 소멸.
 - ClickHouse `edrdog.events` **테이블은 archiver 부팅 시 자동 생성**(`CREATE TABLE IF NOT EXISTS`). 여기선 `edrdog` DB 만 준비.
 - watchdog 클러스터와 호스트 포트(9092/8123/9000)가 겹치므로 **동시 실행 불가**.
+- `extraPortMappings` 는 **클러스터 생성 시에만** 반영된다. 이미 만들어 둔 클러스터에 3000/4317/4318 을 뚫으려면
+  클러스터를 다시 만들거나 `kubectl -n edrdog port-forward svc/otel-lgtm 3000:3000 4318:4318` 로 우회한다.
+
+## 모니터링 (otel-lgtm)
+
+- 구성: Grafana + Prometheus + Tempo + Loki 올인원 이미지(`grafana/otel-lgtm`) + 로그 수집기 Alloy(`k8s/alloy.yaml`).
+- 신호별 경로
+  - **메트릭**: api / detector / archiver 만 OTLP 로 전송 (`micrometer-registry-otlp` 를 그 3개 모듈 `build.gradle` 에만 추가)
+  - **트레이스**: 6개 서비스 전부 OTLP 로 전송
+  - **로그**: 앱은 그냥 stdout 에 찍고, Alloy 가 `*-service` 파드 로그를 읽어 Loki 로 보낸다 (앱 코드 변경 없음)
+- Kafka 발행·소비 구간에도 스팬이 생겨(`spring.kafka.*.observation-enabled`), api → collector → detector → archiver 흐름이
+  트레이스 하나로 이어진다.
+- 로그에는 Spring 기본 패턴의 `[traceId-spanId]` 를 Alloy 가 뽑아 structured metadata 로 붙인다.
+  Grafana 에서 로그 한 줄을 펼치면 trace_id 링크로 Tempo 트레이스까지 바로 넘어간다.
+- 대시보드는 **EDRdog 폴더에 4개**. 첫 화면은 Overview.
+
+  | 대시보드 | 내용 |
+  |---|---|
+  | EDRdog Overview | 요청률·에러율·p95·컨슈머 랙 요약, 서비스별 트래픽, 힙, 로그 볼륨 |
+  | EDRdog HTTP | 상태코드별 요청률, 분위(p50/95/99), 느린·많이 불린 엔드포인트 Top |
+  | EDRdog JVM & Kafka | 힙/GC/스레드/클래스, 컨슈머 랙·소비 처리량·커밋률 |
+  | EDRdog Logs & Traces | 레벨별 로그 볼륨, 로그 스트림, 에러 로그, 최근 트레이스 목록 |
+
+  이미지 기본 대시보드(RED / JVM Overview)도 루트에 그대로 남아 있다.
+  대시보드를 고치려면 `otel-lgtm.yaml` ConfigMap 안의 JSON 을 고치고 apply 한 뒤 파드를 재시작한다
+  (subPath 마운트라 ConfigMap 만 바꿔서는 반영되지 않는다).
+- 스택 없이 서비스만 띄우려면 `OTEL_ENABLED=false`. 샘플링은 `OTEL_TRACE_SAMPLING`(기본 1.0 = 전량).
+- **Grafana 는 비번 없이 들어가진다.** otel-lgtm 이미지가 익명 접속을 Admin 권한으로 열어두기 때문이다
+  (`GF_AUTH_ANONYMOUS_ENABLED=true`, `GF_AUTH_ANONYMOUS_ORG_ROLE=Admin`). 데모용으로 편한 대신,
+  포트에 닿는 사람은 누구나 설정을 바꿀 수 있다. 오래 띄워둘 거면 이 두 env 를 Deployment 에서 꺼야 한다.

--- a/k8s/alert-service.yaml
+++ b/k8s/alert-service.yaml
@@ -27,6 +27,9 @@ spec:
             # tenant Slack webhook 조회용 api-service 내부 엔드포인트 (Service port 80)
             - name: EDRDOG_API_BASE_URL
               value: "http://api-service"
+            # 트레이스 OTLP 수집기 (k8s/otel-lgtm.yaml)
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: "http://otel-lgtm:4318"
           readinessProbe:
             httpGet:
               path: /actuator/health

--- a/k8s/alloy.yaml
+++ b/k8s/alloy.yaml
@@ -1,0 +1,176 @@
+# 로그 수집 (Grafana Alloy) — edrdog 네임스페이스 파드의 stdout 을 읽어 otel-lgtm 안의 Loki 로 보낸다.
+# 앱은 건드리지 않는다. Spring 기본 로그 패턴에 이미 [traceId-spanId] 가 찍히므로
+# 그것만 뽑아 structured metadata 로 붙여 두면 Grafana 에서 로그 -> 트레이스로 바로 넘어갈 수 있다.
+#
+#   기동:  kubectl apply -f k8s/alloy.yaml
+#   확인:  Grafana > Dashboards > EDRdog > Logs & Traces
+#
+# DaemonSet 이 아니라 단일 Deployment 인 이유: loki.source.kubernetes 는 노드 파일이 아니라
+# 쿠버네티스 API 로 로그를 읽는다. DaemonSet 으로 띄우면 노드마다 같은 파드를 중복 수집한다.
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: alloy
+  namespace: edrdog
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: edrdog-alloy-logs
+rules:
+  - apiGroups: [""]
+    resources: ["pods", "pods/log", "namespaces"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: edrdog-alloy-logs
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: edrdog-alloy-logs
+subjects:
+  - kind: ServiceAccount
+    name: alloy
+    namespace: edrdog
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: alloy-config
+  namespace: edrdog
+data:
+  config.alloy: |
+    // 수집 대상: edrdog 네임스페이스 파드만
+    discovery.kubernetes "pods" {
+      role = "pod"
+
+      namespaces {
+        names = ["edrdog"]
+      }
+    }
+
+    // 파드 메타데이터를 Loki 라벨로 (카디널리티가 낮은 것만 라벨로 승격)
+    discovery.relabel "pods" {
+      targets = discovery.kubernetes.pods.targets
+
+      // 앱 서비스만 수집. 모니터링 스택 자신(otel-lgtm, alloy)의 로그까지 담으면
+      // 볼륨 그래프가 스택 노이즈로 뒤덮인다. 스택 로그는 kubectl logs 로 본다.
+      rule {
+        source_labels = ["__meta_kubernetes_pod_label_app"]
+        regex         = ".*-service"
+        action        = "keep"
+      }
+
+      rule {
+        source_labels = ["__meta_kubernetes_pod_label_app"]
+        target_label  = "service_name"
+      }
+      // 파드 라벨은 archiver-service, 메트릭의 job 라벨은 archiver 라 이름이 어긋난다.
+      // -service 접미사를 떼서 양쪽 이름을 맞춘다(로그와 메트릭을 같은 이름으로 필터하려고).
+      rule {
+        source_labels = ["__meta_kubernetes_pod_label_app"]
+        regex         = "(.*)-service"
+        replacement   = "$1"
+        target_label  = "service_name"
+      }
+      rule {
+        source_labels = ["__meta_kubernetes_namespace"]
+        target_label  = "namespace"
+      }
+      rule {
+        source_labels = ["__meta_kubernetes_pod_name"]
+        target_label  = "pod"
+      }
+      rule {
+        source_labels = ["__meta_kubernetes_pod_container_name"]
+        target_label  = "container"
+      }
+    }
+
+    loki.source.kubernetes "pods" {
+      targets    = discovery.relabel.pods.output
+      forward_to = [loki.process.spring.receiver]
+    }
+
+    loki.process "spring" {
+      // 로그 레벨은 값 종류가 적으니 라벨로 (레벨별 필터/집계용)
+      stage.regex {
+        expression = "^\\S+\\s+(?P<level>TRACE|DEBUG|INFO|WARN|ERROR)\\s"
+      }
+      stage.labels {
+        values = {
+          level = "",
+        }
+      }
+
+      // traceId 는 값 종류가 무한하니 라벨이 아니라 structured metadata 로.
+      // Grafana 의 Loki 데이터소스가 trace_id 를 잡아 Tempo 링크를 만들어 준다.
+      stage.regex {
+        expression = "\\[(?P<trace_id>[0-9a-f]{32})-(?P<span_id>[0-9a-f]{16})\\]"
+      }
+      stage.structured_metadata {
+        values = {
+          trace_id = "",
+          span_id  = "",
+        }
+      }
+
+      forward_to = [loki.write.otel_lgtm.receiver]
+    }
+
+    loki.write "otel_lgtm" {
+      endpoint {
+        url = "http://otel-lgtm:3100/loki/api/v1/push"
+      }
+    }
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: alloy
+  namespace: edrdog
+  labels:
+    app: alloy
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: alloy
+  template:
+    metadata:
+      labels:
+        app: alloy
+    spec:
+      serviceAccountName: alloy
+      containers:
+        - name: alloy
+          image: grafana/alloy:v1.18.0
+          args:
+            - run
+            - /etc/alloy/config.alloy
+            - --storage.path=/tmp/alloy
+            - --server.http.listen-addr=0.0.0.0:12345
+          ports:
+            - containerPort: 12345  # Alloy 자체 UI (디버깅용, 노출 안 함)
+          volumeMounts:
+            - name: config
+              mountPath: /etc/alloy
+          readinessProbe:
+            httpGet:
+              path: /-/ready
+              port: 12345
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          resources:
+            requests:
+              cpu: 50m
+              memory: 128Mi
+            limits:
+              memory: 256Mi
+      volumes:
+        - name: config
+          configMap:
+            name: alloy-config

--- a/k8s/api-service.yaml
+++ b/k8s/api-service.yaml
@@ -38,6 +38,9 @@ spec:
             # 발표 환경에서만 true (데모 계정 test/1234 + 과거 7일 시드)
             - name: DEMO_SEED
               value: "false"
+            # 메트릭/트레이스 OTLP 수집기 (k8s/otel-lgtm.yaml)
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: "http://otel-lgtm:4318"
           readinessProbe:
             httpGet:
               path: /actuator/health

--- a/k8s/archiver-service.yaml
+++ b/k8s/archiver-service.yaml
@@ -26,6 +26,9 @@ spec:
               value: "kafka:9094"
             - name: EDRDOG_CLICKHOUSE_URL
               value: "http://clickhouse:8123"
+            # 메트릭/트레이스 OTLP 수집기 (k8s/otel-lgtm.yaml)
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: "http://otel-lgtm:4318"
           readinessProbe:
             httpGet:
               path: /actuator/health

--- a/k8s/detector-service.yaml
+++ b/k8s/detector-service.yaml
@@ -25,6 +25,9 @@ spec:
             # 실제 Kafka 주소로 교체 (ConfigMap 으로 분리해도 됨)
             - name: SPRING_KAFKA_BOOTSTRAP_SERVERS
               value: "kafka:9094"
+            # 메트릭/트레이스 OTLP 수집기 (k8s/otel-lgtm.yaml)
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: "http://otel-lgtm:4318"
           readinessProbe:
             httpGet:
               path: /actuator/health

--- a/k8s/kind-cluster.yaml
+++ b/k8s/kind-cluster.yaml
@@ -22,3 +22,12 @@ nodes:
       - containerPort: 30306   # MySQL               -> host localhost:3306
         hostPort: 3306
         protocol: TCP
+      - containerPort: 30300   # Grafana (otel-lgtm) -> host localhost:3000
+        hostPort: 3000
+        protocol: TCP
+      - containerPort: 30317   # OTLP gRPC           -> host localhost:4317
+        hostPort: 4317
+        protocol: TCP
+      - containerPort: 30318   # OTLP HTTP           -> host localhost:4318
+        hostPort: 4318
+        protocol: TCP

--- a/k8s/otel-lgtm.yaml
+++ b/k8s/otel-lgtm.yaml
@@ -1,0 +1,1920 @@
+# 모니터링 스택 (otel-lgtm) — Grafana + Prometheus + Tempo + Loki 를 담은 올인원 이미지.
+# 서비스들이 OTLP 로 메트릭/트레이스를 밀어넣고(로그는 k8s/alloy.yaml 이 수집), Grafana 에서 본다.
+# 개발용이라 영속성 없음(emptyDir).
+#
+#   기동:  kubectl apply -f k8s/otel-lgtm.yaml -f k8s/alloy.yaml
+#   접속:  http://localhost:3000  (admin / admin)
+#   OTLP:  호스트 실행 서비스 -> http://localhost:4318, 클러스터 내부 -> http://otel-lgtm:4318
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: otel-lgtm-dashboards
+  namespace: edrdog
+data:
+  # 이미지 기본 프로비저닝(RED / JVM 대시보드)을 유지한 채 EDRdog 폴더만 추가한다.
+  edrdog-dashboards.yaml: |
+    apiVersion: 1
+
+    providers:
+      - name: "EDRdog"
+        type: file
+        folder: "EDRdog"
+        options:
+          path: /otel-lgtm/edrdog-dashboards
+          foldersFromFilesStructure: false
+
+  edrdog-overview.json: |
+    {
+      "uid": "edrdog-overview",
+      "title": "EDRdog Overview",
+      "tags": [
+        "edrdog"
+      ],
+      "timezone": "browser",
+      "editable": true,
+      "schemaVersion": 39,
+      "refresh": "10s",
+      "time": {
+        "from": "now-30m",
+        "to": "now"
+      },
+      "links": [
+        {
+          "type": "dashboards",
+          "title": "EDRdog",
+          "tags": [
+            "edrdog"
+          ],
+          "asDropdown": true,
+          "includeVars": true,
+          "keepTime": true,
+          "icon": "external link"
+        }
+      ],
+      "templating": {
+        "list": [
+          {
+            "name": "ds",
+            "type": "datasource",
+            "query": "prometheus",
+            "current": {
+              "text": "Prometheus",
+              "value": "prometheus"
+            },
+            "hide": 0
+          },
+          {
+            "name": "job",
+            "label": "service",
+            "type": "query",
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${ds}"
+            },
+            "query": {
+              "query": "label_values(jvm_threads_live, job)",
+              "refId": "job"
+            },
+            "refresh": 2,
+            "includeAll": true,
+            "allValue": ".*",
+            "multi": true,
+            "current": {
+              "text": "All",
+              "value": "$__all"
+            }
+          }
+        ]
+      },
+      "panels": [
+        {
+          "type": "row",
+          "id": 1,
+          "title": "서비스 요약",
+          "collapsed": false,
+          "panels": [],
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 0
+          }
+        },
+        {
+          "type": "stat",
+          "id": 2,
+          "title": "요청률",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${ds}"
+          },
+          "gridPos": {
+            "h": 5,
+            "w": 6,
+            "x": 0,
+            "y": 1
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "reqps",
+              "decimals": 2,
+              "color": {
+                "mode": "fixed",
+                "fixedColor": "text"
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "graphMode": "area",
+            "colorMode": "value",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            }
+          },
+          "targets": [
+            {
+              "refId": "A",
+              "expr": "sum(rate(http_server_requests_seconds_count{job=~\"$job\"}[$__rate_interval]))"
+            }
+          ]
+        },
+        {
+          "type": "stat",
+          "id": 3,
+          "title": "에러율 (5xx)",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${ds}"
+          },
+          "gridPos": {
+            "h": 5,
+            "w": 6,
+            "x": 6,
+            "y": 1
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "percentunit",
+              "decimals": 2,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "orange",
+                    "value": 0.01
+                  },
+                  {
+                    "color": "red",
+                    "value": 0.05
+                  }
+                ]
+              },
+              "min": 0,
+              "max": 1
+            },
+            "overrides": []
+          },
+          "options": {
+            "graphMode": "area",
+            "colorMode": "value",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            }
+          },
+          "targets": [
+            {
+              "refId": "A",
+              "expr": "(sum(rate(http_server_requests_seconds_count{job=~\"$job\", outcome=\"SERVER_ERROR\"}[$__rate_interval])) or vector(0)) / clamp_min(sum(rate(http_server_requests_seconds_count{job=~\"$job\"}[$__rate_interval])), 0.0001)"
+            }
+          ]
+        },
+        {
+          "type": "stat",
+          "id": 4,
+          "title": "응답시간 p95",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${ds}"
+          },
+          "gridPos": {
+            "h": 5,
+            "w": 6,
+            "x": 12,
+            "y": 1
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "s",
+              "decimals": 3,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "orange",
+                    "value": 0.5
+                  },
+                  {
+                    "color": "red",
+                    "value": 1
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "graphMode": "area",
+            "colorMode": "value",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            }
+          },
+          "targets": [
+            {
+              "refId": "A",
+              "expr": "histogram_quantile(0.95, sum by (le) (rate(http_server_requests_seconds_bucket{job=~\"$job\"}[$__rate_interval])))"
+            }
+          ]
+        },
+        {
+          "type": "stat",
+          "id": 5,
+          "title": "Kafka 컨슈머 최대 랙",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${ds}"
+          },
+          "gridPos": {
+            "h": 5,
+            "w": 6,
+            "x": 18,
+            "y": 1
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "short",
+              "decimals": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "orange",
+                    "value": 1000
+                  },
+                  {
+                    "color": "red",
+                    "value": 10000
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "graphMode": "area",
+            "colorMode": "value",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            }
+          },
+          "targets": [
+            {
+              "refId": "A",
+              "expr": "max(kafka_consumer_fetch_manager_records_lag_max{job=~\"$job\"} >= 0) or vector(0)"
+            }
+          ]
+        },
+        {
+          "type": "row",
+          "id": 6,
+          "title": "트래픽",
+          "collapsed": false,
+          "panels": [],
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 6
+          }
+        },
+        {
+          "type": "timeseries",
+          "id": 7,
+          "title": "서비스별 요청률",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${ds}"
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 0,
+            "y": 7
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "reqps",
+              "custom": {
+                "fillOpacity": 10,
+                "showPoints": "never",
+                "stacking": {
+                  "mode": "normal"
+                }
+              },
+              "min": 0
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            }
+          },
+          "targets": [
+            {
+              "expr": "sum by (job) (rate(http_server_requests_seconds_count{job=~\"$job\"}[$__rate_interval]))",
+              "legendFormat": "{{job}}",
+              "refId": "A"
+            }
+          ]
+        },
+        {
+          "type": "timeseries",
+          "id": 8,
+          "title": "서비스별 에러율",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${ds}"
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 8,
+            "y": 7
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "percentunit",
+              "custom": {
+                "fillOpacity": 10,
+                "showPoints": "never"
+              },
+              "min": 0,
+              "max": 1
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            }
+          },
+          "targets": [
+            {
+              "expr": "(sum by (job) (rate(http_server_requests_seconds_count{job=~\"$job\", outcome=\"SERVER_ERROR\"}[$__rate_interval])) or 0 * sum by (job) (rate(http_server_requests_seconds_count{job=~\"$job\"}[$__rate_interval]))) / clamp_min(sum by (job) (rate(http_server_requests_seconds_count{job=~\"$job\"}[$__rate_interval])), 0.0001)",
+              "legendFormat": "{{job}}",
+              "refId": "A"
+            }
+          ]
+        },
+        {
+          "type": "timeseries",
+          "id": 9,
+          "title": "응답시간 분위 (전체)",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${ds}"
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 16,
+            "y": 7
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "s",
+              "custom": {
+                "fillOpacity": 0,
+                "showPoints": "never"
+              },
+              "min": 0
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            }
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.99, sum by (le) (rate(http_server_requests_seconds_bucket{job=~\"$job\"}[$__rate_interval])))",
+              "legendFormat": "p99",
+              "refId": "A"
+            },
+            {
+              "expr": "histogram_quantile(0.95, sum by (le) (rate(http_server_requests_seconds_bucket{job=~\"$job\"}[$__rate_interval])))",
+              "legendFormat": "p95",
+              "refId": "B"
+            },
+            {
+              "expr": "histogram_quantile(0.50, sum by (le) (rate(http_server_requests_seconds_bucket{job=~\"$job\"}[$__rate_interval])))",
+              "legendFormat": "p50",
+              "refId": "C"
+            }
+          ]
+        },
+        {
+          "type": "row",
+          "id": 10,
+          "title": "리소스 / 로그",
+          "collapsed": false,
+          "panels": [],
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 15
+          }
+        },
+        {
+          "type": "timeseries",
+          "id": 11,
+          "title": "힙 사용률",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${ds}"
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 0,
+            "y": 16
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "percentunit",
+              "custom": {
+                "fillOpacity": 10,
+                "showPoints": "never"
+              },
+              "min": 0,
+              "max": 1
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            }
+          },
+          "targets": [
+            {
+              "expr": "sum by (job) (jvm_memory_used_bytes{job=~\"$job\", area=\"heap\"}) / clamp_min(sum by (job) (jvm_memory_max_bytes{job=~\"$job\", area=\"heap\"}), 1)",
+              "legendFormat": "{{job}}",
+              "refId": "A"
+            }
+          ]
+        },
+        {
+          "type": "timeseries",
+          "id": 12,
+          "title": "Kafka 컨슈머 랙",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${ds}"
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 8,
+            "y": 16
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "short",
+              "custom": {
+                "fillOpacity": 10,
+                "showPoints": "never"
+              },
+              "min": 0
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            }
+          },
+          "targets": [
+            {
+              "expr": "max by (job) (kafka_consumer_fetch_manager_records_lag_max{job=~\"$job\"} >= 0)",
+              "legendFormat": "{{job}}",
+              "refId": "A"
+            }
+          ]
+        },
+        {
+          "type": "timeseries",
+          "id": 13,
+          "title": "로그 볼륨 (레벨별)",
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 16,
+            "y": 16
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "cps",
+              "custom": {
+                "fillOpacity": 10,
+                "showPoints": "never",
+                "stacking": {
+                  "mode": "normal"
+                }
+              },
+              "min": 0
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            }
+          },
+          "targets": [
+            {
+              "expr": "sum by (level) (count_over_time({namespace=\"edrdog\"} [$__auto]))",
+              "legendFormat": "{{level}}",
+              "queryType": "range",
+              "refId": "A"
+            }
+          ]
+        }
+      ]
+    }
+
+  edrdog-http.json: |
+    {
+      "uid": "edrdog-http",
+      "title": "EDRdog HTTP",
+      "tags": [
+        "edrdog"
+      ],
+      "timezone": "browser",
+      "editable": true,
+      "schemaVersion": 39,
+      "refresh": "10s",
+      "time": {
+        "from": "now-30m",
+        "to": "now"
+      },
+      "links": [
+        {
+          "type": "dashboards",
+          "title": "EDRdog",
+          "tags": [
+            "edrdog"
+          ],
+          "asDropdown": true,
+          "includeVars": true,
+          "keepTime": true,
+          "icon": "external link"
+        }
+      ],
+      "templating": {
+        "list": [
+          {
+            "name": "ds",
+            "type": "datasource",
+            "query": "prometheus",
+            "current": {
+              "text": "Prometheus",
+              "value": "prometheus"
+            },
+            "hide": 0
+          },
+          {
+            "name": "job",
+            "label": "service",
+            "type": "query",
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${ds}"
+            },
+            "query": {
+              "query": "label_values(jvm_threads_live, job)",
+              "refId": "job"
+            },
+            "refresh": 2,
+            "includeAll": true,
+            "allValue": ".*",
+            "multi": true,
+            "current": {
+              "text": "All",
+              "value": "$__all"
+            }
+          }
+        ]
+      },
+      "panels": [
+        {
+          "type": "row",
+          "id": 101,
+          "title": "처리량 / 오류",
+          "collapsed": false,
+          "panels": [],
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 0
+          }
+        },
+        {
+          "type": "timeseries",
+          "id": 102,
+          "title": "서비스별 요청률",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${ds}"
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 0,
+            "y": 1
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "reqps",
+              "custom": {
+                "fillOpacity": 10,
+                "showPoints": "never",
+                "stacking": {
+                  "mode": "normal"
+                }
+              },
+              "min": 0
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            }
+          },
+          "targets": [
+            {
+              "expr": "sum by (job) (rate(http_server_requests_seconds_count{job=~\"$job\"}[$__rate_interval]))",
+              "legendFormat": "{{job}}",
+              "refId": "A"
+            }
+          ]
+        },
+        {
+          "type": "timeseries",
+          "id": 103,
+          "title": "상태코드별 요청률",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${ds}"
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 8,
+            "y": 1
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "reqps",
+              "custom": {
+                "fillOpacity": 10,
+                "showPoints": "never",
+                "stacking": {
+                  "mode": "normal"
+                }
+              },
+              "min": 0
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            }
+          },
+          "targets": [
+            {
+              "expr": "sum by (status) (rate(http_server_requests_seconds_count{job=~\"$job\"}[$__rate_interval]))",
+              "legendFormat": "{{status}}",
+              "refId": "A"
+            }
+          ]
+        },
+        {
+          "type": "timeseries",
+          "id": 104,
+          "title": "서비스별 에러율",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${ds}"
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 16,
+            "y": 1
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "percentunit",
+              "custom": {
+                "fillOpacity": 10,
+                "showPoints": "never"
+              },
+              "min": 0,
+              "max": 1
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            }
+          },
+          "targets": [
+            {
+              "expr": "(sum by (job) (rate(http_server_requests_seconds_count{job=~\"$job\", outcome=\"SERVER_ERROR\"}[$__rate_interval])) or 0 * sum by (job) (rate(http_server_requests_seconds_count{job=~\"$job\"}[$__rate_interval]))) / clamp_min(sum by (job) (rate(http_server_requests_seconds_count{job=~\"$job\"}[$__rate_interval])), 0.0001)",
+              "legendFormat": "{{job}}",
+              "refId": "A"
+            }
+          ]
+        },
+        {
+          "type": "row",
+          "id": 105,
+          "title": "응답시간",
+          "collapsed": false,
+          "panels": [],
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 9
+          }
+        },
+        {
+          "type": "timeseries",
+          "id": 106,
+          "title": "분위 (전체)",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${ds}"
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 10
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "s",
+              "custom": {
+                "fillOpacity": 0,
+                "showPoints": "never"
+              },
+              "min": 0
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            }
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.99, sum by (le) (rate(http_server_requests_seconds_bucket{job=~\"$job\"}[$__rate_interval])))",
+              "legendFormat": "p99",
+              "refId": "A"
+            },
+            {
+              "expr": "histogram_quantile(0.95, sum by (le) (rate(http_server_requests_seconds_bucket{job=~\"$job\"}[$__rate_interval])))",
+              "legendFormat": "p95",
+              "refId": "B"
+            },
+            {
+              "expr": "histogram_quantile(0.50, sum by (le) (rate(http_server_requests_seconds_bucket{job=~\"$job\"}[$__rate_interval])))",
+              "legendFormat": "p50",
+              "refId": "C"
+            }
+          ]
+        },
+        {
+          "type": "timeseries",
+          "id": 107,
+          "title": "서비스별 p95",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${ds}"
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 10
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "s",
+              "custom": {
+                "fillOpacity": 0,
+                "showPoints": "never"
+              },
+              "min": 0
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            }
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.95, sum by (le, job) (rate(http_server_requests_seconds_bucket{job=~\"$job\"}[$__rate_interval])))",
+              "legendFormat": "{{job}}",
+              "refId": "A"
+            }
+          ]
+        },
+        {
+          "type": "row",
+          "id": 108,
+          "title": "엔드포인트",
+          "collapsed": false,
+          "panels": [],
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 18
+          }
+        },
+        {
+          "type": "table",
+          "id": 109,
+          "title": "느린 엔드포인트 Top (p95)",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${ds}"
+          },
+          "gridPos": {
+            "h": 9,
+            "w": 12,
+            "x": 0,
+            "y": 19
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "s",
+              "decimals": 3
+            },
+            "overrides": []
+          },
+          "options": {
+            "showHeader": true,
+            "sortBy": [
+              {
+                "displayName": "p95",
+                "desc": true
+              }
+            ]
+          },
+          "targets": [
+            {
+              "refId": "A",
+              "format": "table",
+              "instant": true,
+              "expr": "topk(10, histogram_quantile(0.95, sum by (le, job, uri, method) (rate(http_server_requests_seconds_bucket{job=~\"$job\"}[$__rate_interval]))))"
+            }
+          ],
+          "transformations": [
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true
+                },
+                "renameByName": {
+                  "Value": "p95"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "type": "table",
+          "id": 110,
+          "title": "호출 많은 엔드포인트 Top",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${ds}"
+          },
+          "gridPos": {
+            "h": 9,
+            "w": 12,
+            "x": 12,
+            "y": 19
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "reqps",
+              "decimals": 2
+            },
+            "overrides": []
+          },
+          "options": {
+            "showHeader": true,
+            "sortBy": [
+              {
+                "displayName": "req/s",
+                "desc": true
+              }
+            ]
+          },
+          "targets": [
+            {
+              "refId": "A",
+              "format": "table",
+              "instant": true,
+              "expr": "topk(10, sum by (job, uri, method) (rate(http_server_requests_seconds_count{job=~\"$job\"}[$__rate_interval])))"
+            }
+          ],
+          "transformations": [
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true
+                },
+                "renameByName": {
+                  "Value": "req/s"
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+
+  edrdog-jvm-kafka.json: |
+    {
+      "uid": "edrdog-jvm-kafka",
+      "title": "EDRdog JVM & Kafka",
+      "tags": [
+        "edrdog"
+      ],
+      "timezone": "browser",
+      "editable": true,
+      "schemaVersion": 39,
+      "refresh": "10s",
+      "time": {
+        "from": "now-30m",
+        "to": "now"
+      },
+      "links": [
+        {
+          "type": "dashboards",
+          "title": "EDRdog",
+          "tags": [
+            "edrdog"
+          ],
+          "asDropdown": true,
+          "includeVars": true,
+          "keepTime": true,
+          "icon": "external link"
+        }
+      ],
+      "templating": {
+        "list": [
+          {
+            "name": "ds",
+            "type": "datasource",
+            "query": "prometheus",
+            "current": {
+              "text": "Prometheus",
+              "value": "prometheus"
+            },
+            "hide": 0
+          },
+          {
+            "name": "job",
+            "label": "service",
+            "type": "query",
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${ds}"
+            },
+            "query": {
+              "query": "label_values(jvm_threads_live, job)",
+              "refId": "job"
+            },
+            "refresh": 2,
+            "includeAll": true,
+            "allValue": ".*",
+            "multi": true,
+            "current": {
+              "text": "All",
+              "value": "$__all"
+            }
+          }
+        ]
+      },
+      "panels": [
+        {
+          "type": "row",
+          "id": 201,
+          "title": "JVM 메모리",
+          "collapsed": false,
+          "panels": [],
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 0
+          }
+        },
+        {
+          "type": "timeseries",
+          "id": 202,
+          "title": "힙 사용률",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${ds}"
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 0,
+            "y": 1
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "percentunit",
+              "custom": {
+                "fillOpacity": 10,
+                "showPoints": "never"
+              },
+              "min": 0,
+              "max": 1
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            }
+          },
+          "targets": [
+            {
+              "expr": "sum by (job) (jvm_memory_used_bytes{job=~\"$job\", area=\"heap\"}) / clamp_min(sum by (job) (jvm_memory_max_bytes{job=~\"$job\", area=\"heap\"}), 1)",
+              "legendFormat": "{{job}}",
+              "refId": "A"
+            }
+          ]
+        },
+        {
+          "type": "timeseries",
+          "id": 203,
+          "title": "힙 사용량",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${ds}"
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 8,
+            "y": 1
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "bytes",
+              "custom": {
+                "fillOpacity": 10,
+                "showPoints": "never"
+              },
+              "min": 0
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            }
+          },
+          "targets": [
+            {
+              "expr": "sum by (job) (jvm_memory_used_bytes{job=~\"$job\", area=\"heap\"})",
+              "legendFormat": "{{job}} used",
+              "refId": "A"
+            }
+          ]
+        },
+        {
+          "type": "timeseries",
+          "id": 204,
+          "title": "GC 정지 시간",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${ds}"
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 16,
+            "y": 1
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "s",
+              "custom": {
+                "fillOpacity": 10,
+                "showPoints": "never"
+              },
+              "min": 0
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            }
+          },
+          "targets": [
+            {
+              "expr": "sum by (job) (rate(jvm_gc_pause_seconds_sum{job=~\"$job\"}[$__rate_interval]))",
+              "legendFormat": "{{job}}",
+              "refId": "A"
+            }
+          ]
+        },
+        {
+          "type": "row",
+          "id": 205,
+          "title": "JVM 런타임",
+          "collapsed": false,
+          "panels": [],
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 9
+          }
+        },
+        {
+          "type": "timeseries",
+          "id": 206,
+          "title": "스레드",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${ds}"
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 0,
+            "y": 10
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "short",
+              "custom": {
+                "fillOpacity": 0,
+                "showPoints": "never"
+              },
+              "min": 0
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            }
+          },
+          "targets": [
+            {
+              "expr": "sum by (job) (jvm_threads_live{job=~\"$job\"})",
+              "legendFormat": "{{job}}",
+              "refId": "A"
+            }
+          ]
+        },
+        {
+          "type": "timeseries",
+          "id": 207,
+          "title": "로드된 클래스",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${ds}"
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 8,
+            "y": 10
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "short",
+              "custom": {
+                "fillOpacity": 0,
+                "showPoints": "never"
+              },
+              "min": 0
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            }
+          },
+          "targets": [
+            {
+              "expr": "sum by (job) (jvm_classes_loaded{job=~\"$job\"})",
+              "legendFormat": "{{job}}",
+              "refId": "A"
+            }
+          ]
+        },
+        {
+          "type": "timeseries",
+          "id": 208,
+          "title": "GC 할당률",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${ds}"
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 16,
+            "y": 10
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "Bps",
+              "custom": {
+                "fillOpacity": 10,
+                "showPoints": "never"
+              },
+              "min": 0
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            }
+          },
+          "targets": [
+            {
+              "expr": "sum by (job) (rate(jvm_gc_memory_allocated_bytes_total{job=~\"$job\"}[$__rate_interval]))",
+              "legendFormat": "{{job}}",
+              "refId": "A"
+            }
+          ]
+        },
+        {
+          "type": "row",
+          "id": 209,
+          "title": "Kafka 컨슈머",
+          "collapsed": false,
+          "panels": [],
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 18
+          }
+        },
+        {
+          "type": "timeseries",
+          "id": 210,
+          "title": "컨슈머 랙",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${ds}"
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 0,
+            "y": 19
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "short",
+              "custom": {
+                "fillOpacity": 10,
+                "showPoints": "never"
+              },
+              "min": 0
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            }
+          },
+          "targets": [
+            {
+              "expr": "max by (job) (kafka_consumer_fetch_manager_records_lag_max{job=~\"$job\"} >= 0)",
+              "legendFormat": "{{job}}",
+              "refId": "A"
+            }
+          ]
+        },
+        {
+          "type": "timeseries",
+          "id": 211,
+          "title": "소비 처리량",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${ds}"
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 8,
+            "y": 19
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "cps",
+              "custom": {
+                "fillOpacity": 10,
+                "showPoints": "never"
+              },
+              "min": 0
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            }
+          },
+          "targets": [
+            {
+              "expr": "sum by (job) (rate(kafka_consumer_fetch_manager_records_consumed_total{job=~\"$job\"}[$__rate_interval]))",
+              "legendFormat": "{{job}}",
+              "refId": "A"
+            }
+          ]
+        },
+        {
+          "type": "timeseries",
+          "id": 212,
+          "title": "커밋률",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${ds}"
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 16,
+            "y": 19
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "cps",
+              "custom": {
+                "fillOpacity": 10,
+                "showPoints": "never"
+              },
+              "min": 0
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            }
+          },
+          "targets": [
+            {
+              "expr": "sum by (job) (rate(kafka_consumer_coordinator_commit_total{job=~\"$job\"}[$__rate_interval]))",
+              "legendFormat": "{{job}}",
+              "refId": "A"
+            }
+          ]
+        }
+      ]
+    }
+
+  edrdog-logs-traces.json: |
+    {
+      "uid": "edrdog-logs-traces",
+      "title": "EDRdog Logs & Traces",
+      "tags": [
+        "edrdog"
+      ],
+      "timezone": "browser",
+      "editable": true,
+      "schemaVersion": 39,
+      "refresh": "10s",
+      "time": {
+        "from": "now-30m",
+        "to": "now"
+      },
+      "links": [
+        {
+          "type": "dashboards",
+          "title": "EDRdog",
+          "tags": [
+            "edrdog"
+          ],
+          "asDropdown": true,
+          "includeVars": true,
+          "keepTime": true,
+          "icon": "external link"
+        }
+      ],
+      "templating": {
+        "list": [
+          {
+            "name": "service",
+            "label": "service",
+            "type": "query",
+            "datasource": {
+              "type": "loki",
+              "uid": "loki"
+            },
+            "query": {
+              "label": "service_name",
+              "stream": "{namespace=\"edrdog\"}",
+              "type": 1,
+              "refId": "service"
+            },
+            "refresh": 2,
+            "includeAll": true,
+            "allValue": ".+",
+            "multi": true,
+            "current": {
+              "text": "All",
+              "value": "$__all"
+            }
+          }
+        ]
+      },
+      "panels": [
+        {
+          "type": "row",
+          "id": 301,
+          "title": "로그",
+          "collapsed": false,
+          "panels": [],
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 0
+          }
+        },
+        {
+          "type": "stat",
+          "id": 302,
+          "title": "ERROR (구간 합계)",
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "gridPos": {
+            "h": 5,
+            "w": 6,
+            "x": 0,
+            "y": 1
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "short",
+              "decimals": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 1
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "graphMode": "area",
+            "colorMode": "value",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            }
+          },
+          "targets": [
+            {
+              "refId": "A",
+              "expr": "sum(count_over_time({namespace=\"edrdog\", service_name=~\"$service\", level=\"ERROR\"} [$__range])) or vector(0)"
+            }
+          ]
+        },
+        {
+          "type": "stat",
+          "id": 303,
+          "title": "WARN (구간 합계)",
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "gridPos": {
+            "h": 5,
+            "w": 6,
+            "x": 6,
+            "y": 1
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "short",
+              "decimals": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "orange",
+                    "value": 1
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "graphMode": "area",
+            "colorMode": "value",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            }
+          },
+          "targets": [
+            {
+              "refId": "A",
+              "expr": "sum(count_over_time({namespace=\"edrdog\", service_name=~\"$service\", level=\"WARN\"} [$__range])) or vector(0)"
+            }
+          ]
+        },
+        {
+          "type": "timeseries",
+          "id": 304,
+          "title": "로그 볼륨 (레벨별)",
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "gridPos": {
+            "h": 5,
+            "w": 12,
+            "x": 12,
+            "y": 1
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "cps",
+              "custom": {
+                "fillOpacity": 10,
+                "showPoints": "never",
+                "stacking": {
+                  "mode": "normal"
+                }
+              },
+              "min": 0
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            }
+          },
+          "targets": [
+            {
+              "expr": "sum by (level) (count_over_time({namespace=\"edrdog\", service_name=~\"$service\"} [$__auto]))",
+              "legendFormat": "{{level}}",
+              "refId": "A"
+            }
+          ]
+        },
+        {
+          "type": "logs",
+          "id": 305,
+          "title": "로그 스트림",
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "gridPos": {
+            "h": 11,
+            "w": 24,
+            "x": 0,
+            "y": 6
+          },
+          "options": {
+            "showTime": true,
+            "wrapLogMessage": true,
+            "sortOrder": "Descending",
+            "enableLogDetails": true,
+            "dedupStrategy": "none",
+            "prettifyLogMessage": false,
+            "showLabels": false,
+            "showCommonLabels": false,
+            "enableInfiniteScrolling": false,
+            "syntaxHighlighting": true
+          },
+          "targets": [
+            {
+              "refId": "A",
+              "expr": "{namespace=\"edrdog\", service_name=~\"$service\"}",
+              "queryType": "range"
+            }
+          ]
+        },
+        {
+          "type": "logs",
+          "id": 306,
+          "title": "에러 로그만",
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "gridPos": {
+            "h": 9,
+            "w": 24,
+            "x": 0,
+            "y": 17
+          },
+          "options": {
+            "showTime": true,
+            "wrapLogMessage": true,
+            "sortOrder": "Descending",
+            "enableLogDetails": true,
+            "dedupStrategy": "none",
+            "prettifyLogMessage": false,
+            "showLabels": false,
+            "showCommonLabels": false,
+            "enableInfiniteScrolling": false,
+            "syntaxHighlighting": true
+          },
+          "targets": [
+            {
+              "refId": "A",
+              "queryType": "range",
+              "expr": "{namespace=\"edrdog\", service_name=~\"$service\", level=~\"ERROR|WARN\"}"
+            }
+          ]
+        },
+        {
+          "type": "row",
+          "id": 307,
+          "title": "트레이스",
+          "collapsed": false,
+          "panels": [],
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 26
+          }
+        },
+        {
+          "type": "table",
+          "id": 308,
+          "title": "최근 트레이스 (Tempo)",
+          "datasource": {
+            "type": "tempo",
+            "uid": "tempo"
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 24,
+            "x": 0,
+            "y": 27
+          },
+          "options": {
+            "showHeader": true
+          },
+          "targets": [
+            {
+              "refId": "A",
+              "queryType": "traceqlSearch",
+              "filters": [],
+              "limit": 20,
+              "tableType": "traces"
+            }
+          ]
+        }
+      ]
+    }
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: otel-lgtm
+  namespace: edrdog
+  labels:
+    app: otel-lgtm
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: otel-lgtm
+  template:
+    metadata:
+      labels:
+        app: otel-lgtm
+    spec:
+      containers:
+        - name: otel-lgtm
+          image: grafana/otel-lgtm:0.29.2
+          ports:
+            - containerPort: 3000  # Grafana
+            - containerPort: 3100  # Loki (Alloy 가 로그를 밀어넣는 곳)
+            - containerPort: 4317  # OTLP gRPC
+            - containerPort: 4318  # OTLP HTTP
+          env:
+            # 첫 화면을 EDRdog 대시보드로 (기본 Grafana 홈 대신)
+            - name: GF_DASHBOARDS_DEFAULT_HOME_DASHBOARD_PATH
+              value: /otel-lgtm/edrdog-dashboards/edrdog-overview.json
+          volumeMounts:
+            # 프로비저닝 디렉터리는 통째로 덮으면 기본 대시보드가 사라지므로 파일 하나만 subPath 로 얹는다.
+            - name: dashboards
+              mountPath: /otel-lgtm/grafana/conf/provisioning/dashboards/edrdog-dashboards.yaml
+              subPath: edrdog-dashboards.yaml
+            - name: dashboards
+              mountPath: /otel-lgtm/edrdog-dashboards/edrdog-overview.json
+              subPath: edrdog-overview.json
+            - name: dashboards
+              mountPath: /otel-lgtm/edrdog-dashboards/edrdog-http.json
+              subPath: edrdog-http.json
+            - name: dashboards
+              mountPath: /otel-lgtm/edrdog-dashboards/edrdog-jvm-kafka.json
+              subPath: edrdog-jvm-kafka.json
+            - name: dashboards
+              mountPath: /otel-lgtm/edrdog-dashboards/edrdog-logs-traces.json
+              subPath: edrdog-logs-traces.json
+            - name: data
+              mountPath: /data
+          readinessProbe:
+            httpGet:
+              path: /api/health
+              port: 3000
+            initialDelaySeconds: 15
+            periodSeconds: 10
+          resources:
+            requests:
+              cpu: 250m
+              memory: 768Mi   # 실측 유휴 ~670Mi (Grafana/Prometheus/Tempo/Loki 동시 구동)
+            limits:
+              memory: 2Gi
+      volumes:
+        - name: dashboards
+          configMap:
+            name: otel-lgtm-dashboards
+        - name: data
+          emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: otel-lgtm
+  namespace: edrdog
+  labels:
+    app: otel-lgtm
+spec:
+  type: NodePort
+  selector:
+    app: otel-lgtm
+  ports:
+    - name: grafana
+      port: 3000
+      targetPort: 3000
+      nodePort: 30300
+    - name: loki
+      port: 3100
+      targetPort: 3100
+      nodePort: 30310
+    - name: otlp-grpc
+      port: 4317
+      targetPort: 4317
+      nodePort: 30317
+    - name: otlp-http
+      port: 4318
+      targetPort: 4318
+      nodePort: 30318

--- a/k8s/responder-service.yaml
+++ b/k8s/responder-service.yaml
@@ -24,6 +24,9 @@ spec:
           env:
             - name: SPRING_KAFKA_BOOTSTRAP_SERVERS
               value: "kafka:9094"
+            # 트레이스 OTLP 수집기 (k8s/otel-lgtm.yaml)
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: "http://otel-lgtm:4318"
             # 실제 조치(kill) 실행은 기본 OFF(dry-run). 신뢰가 쌓인 뒤 아래를 채워 켠다.
             # 켤 때 FLEET_BASE_URL 은 https 여야 하며(FleetTls), 자가서명 인증서면 FLEET_TLS_TRUSTSTORE 를 지정한다.
             # - name: RESPONDER_EXECUTE_ENABLED

--- a/responder-service/src/main/resources/application.yml
+++ b/responder-service/src/main/resources/application.yml
@@ -11,6 +11,8 @@ spring:
       properties:
         spring.json.value.default.type: com.edrdog.responderservice.dto.Alert
         spring.json.trusted.packages: com.edrdog.responderservice.dto
+    listener:
+      observation-enabled: true         # 컨슈머 스팬 생성 → 발행 측 traceId 를 이어받아 한 트레이스로 연결
 
 server:
   port: 8082
@@ -37,3 +39,11 @@ management:
     web:
       exposure:
         include: health, info
+  # 관측 — 트레이스만 보낸다(메트릭 익스포터는 api/detector/archiver 에만).
+  tracing:
+    enabled: ${OTEL_ENABLED:true}
+    sampling:
+      probability: ${OTEL_TRACE_SAMPLING:1.0}
+  otlp:
+    tracing:
+      endpoint: ${OTEL_EXPORTER_OTLP_ENDPOINT:http://localhost:4318}/v1/traces


### PR DESCRIPTION
## 무엇을

서비스 상태를 밖에서 볼 수단이 없어서 메트릭·트레이스·로그를 한곳에 모으고 Grafana 대시보드를 붙였다.
개인/데모 규모라 컴포넌트를 따로 띄우지 않고 `grafana/otel-lgtm` 올인원 이미지 하나로 끝냈다. 영속성은 없다(emptyDir).

## 신호별 경로

| 신호 | 대상 | 방식 |
|---|---|---|
| 트레이스 | 6개 서비스 전부 | micrometer-tracing-bridge-otel → OTLP → Tempo |
| 메트릭 | api / detector / archiver | micrometer-registry-otlp → OTLP → Prometheus |
| 로그 | `*-service` 파드 | Alloy 가 stdout 수집 → Loki (앱 코드 변경 없음) |

Kafka 발행·소비 구간에도 스팬을 만들어(`spring.kafka.*.observation-enabled`) api → collector → detector → archiver 흐름이 트레이스 하나로 이어진다.
로그에는 Spring 기본 패턴의 `[traceId-spanId]` 를 Alloy 가 뽑아 structured metadata 로 붙이므로, 로그 한 줄에서 트레이스로 바로 넘어갈 수 있다.

## 대시보드

EDRdog 폴더에 4개. 첫 화면은 Overview.

| 대시보드 | 내용 |
|---|---|
| Overview | 요청률·에러율·p95·컨슈머 랙 요약, 서비스별 트래픽, 힙, 로그 볼륨 |
| HTTP | 상태코드별 요청률, 분위(p50/95/99), 느린·많이 불린 엔드포인트 Top |
| JVM & Kafka | 힙/GC/스레드/클래스, 컨슈머 랙·소비 처리량·커밋률 |
| Logs & Traces | 레벨별 로그 볼륨, 로그 스트림, 에러 로그, 최근 트레이스 목록 |

이미지 기본 대시보드(RED / JVM Overview)도 루트에 그대로 남는다.

## 기동

```bash
kubectl apply -f k8s/00-namespace.yaml -f k8s/kafka.yaml -f k8s/clickhouse.yaml \
              -f k8s/otel-lgtm.yaml -f k8s/alloy.yaml
# http://localhost:3000
```

`extraPortMappings` 는 클러스터 생성 시에만 반영된다. 이미 만들어 둔 kind 클러스터에서는
`kubectl -n edrdog port-forward svc/otel-lgtm 3000:3000 4318:4318` 로 우회한다.

## 확인한 것

별도 kind 클러스터를 만들어 검증하고 지웠다(기존 개발 클러스터는 건드리지 않음).

- Prometheus 에 메트릭, Tempo 에 트레이스 도착 (실제 archiver-service 기동)
- Loki 라벨 `service_name`(archiver-service → archiver 정규화), `level`(INFO/WARN/ERROR) 확인
- `trace_id` 가 인덱스 라벨이 아니라 structured metadata 로 들어가는 것 확인 (카디널리티 방어)
- Alloy 필터 적용 후 수집 대상이 앱 서비스만 남는 것 확인
- 대시보드 4개 프로비저닝 및 전 패널 쿼리 데이터 반환 확인
- `./gradlew build` 통과, 매니페스트 전부 `kubectl apply --dry-run=server` 통과

검증 중 고친 것: `logs` 패널 옵션을 일부만 주면 대시보드 레이아웃이 무너지는 문제,
Tempo 패널 `queryType` 이 `traceql` 이면 대시보드가 Explore 로 튕기는 문제,
히스토그램 버킷 미발행으로 p95 가 NaN 이던 문제.

## 남은 것 / 주의

- api → collector → detector → archiver 전 구간 트레이스 연결은 6개를 모두 띄워야 확인된다. 이번엔 archiver 단독으로만 확인했다.
- Grafana 는 otel-lgtm 이미지 기본값대로 **익명 Admin 접속이 열려 있다**. 데모 편의를 위해 그대로 뒀고 README 에 명시했다.
  오래 띄울 거면 Deployment 에서 `GF_AUTH_ANONYMOUS_ENABLED` 를 꺼야 한다.
- 대시보드를 고치려면 `otel-lgtm.yaml` ConfigMap 의 JSON 을 고치고 apply 한 뒤 파드를 재시작해야 한다(subPath 마운트).