### PR TITLE
feat: 모니터링 보강 (지표 영속성 + 인프라 메트릭 + CD apply)

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -69,8 +69,11 @@ jobs:
             ${{ steps.vars.outputs.image_base }}:${{ github.sha }}
             ${{ steps.vars.outputs.image_base }}:latest
 
-  # CD: EC2(k3s) 에 SSH 로 접속해 새 이미지(:SHA)로 롤링. k3s API 를 외부에 노출하지 않는다.
+  # CD: EC2(k3s) 에 SSH 로 접속해 모니터링 매니페스트를 apply 하고 서비스는 새 이미지(:SHA)로 롤링.
+  # k3s API 를 외부에 노출하지 않는다.
   # 필요한 secret: EC2_HOST(도메인/공인IP), EC2_SSH_KEY(개인키). 선택: EC2_USER(기본 ubuntu).
+  # 서비스 매니페스트는 apply 하지 않는다(레포와 서버 상태가 어긋나 있어 실서비스가 죽는다).
+  # 서비스 환경변수(OTEL_EXPORTER_OTLP_ENDPOINT 등)는 Infisical 로 주입한다.
   deploy:
     needs: image
     if: github.event_name == 'push'
@@ -94,6 +97,22 @@ jobs:
             "REPO='$REPO_LC' SHA='$SHA' NS=edrdog bash -s" <<'REMOTE'
           set -euo pipefail
           MODULES="detector-service responder-service archiver-service api-service alert-service"
+
+          # 모니터링 스택만 매니페스트로 apply 한다.
+          # 서비스 5개 매니페스트는 손대지 않는다. 레포의 api-service Service 는 ClusterIP 인데
+          # 서버는 NodePort 30084 로 떠 있어(Caddy 가 이 포트로 프록시) apply 하면 사이트가 죽는다.
+          # 서버 브랜치를 건드리지 않으려고 FETCH_HEAD 에서 파일만 꺼내 적용한다.
+          if [ -d ~/Backend/.git ]; then
+          git -C ~/Backend fetch --quiet origin main
+          for f in k8s/otel-lgtm.yaml k8s/alloy.yaml; do
+          git -C ~/Backend show "FETCH_HEAD:$f" | sudo kubectl apply -f -
+          done
+          sudo kubectl -n "$NS" rollout status deployment/otel-lgtm --timeout=300s
+          sudo kubectl -n "$NS" rollout status deployment/alloy --timeout=180s
+          else
+          echo "~/Backend 클론이 없어 모니터링 매니페스트 apply 를 건너뛴다" >&2
+          fi
+
           for m in $MODULES; do
           sudo kubectl -n "$NS" set image "deployment/$m" "$m=ghcr.io/$REPO/$m:$SHA"
           done

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -107,6 +107,11 @@ jobs:
           for f in k8s/otel-lgtm.yaml k8s/alloy.yaml; do
           git -C ~/Backend show "FETCH_HEAD:$f" | sudo kubectl apply -f -
           done
+          # Infisical 연동은 Operator 가 깔려 있을 때만. 없으면 CRD 가 없어 apply 가 실패하고
+          # set -e 때문에 서비스 롤링까지 같이 죽는다.
+          if sudo kubectl get crd infisicalsecrets.secrets.infisical.com >/dev/null 2>&1; then
+          git -C ~/Backend show "FETCH_HEAD:k8s/infisical.yaml" | sudo kubectl apply -f -
+          fi
           sudo kubectl -n "$NS" rollout status deployment/otel-lgtm --timeout=300s
           sudo kubectl -n "$NS" rollout status deployment/alloy --timeout=180s
           else

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -66,6 +66,8 @@ kind delete cluster --name edrdog    # 클러스터째 삭제 (데이터 emptyDi
   - **메트릭**: api / detector / archiver 만 OTLP 로 전송 (`micrometer-registry-otlp` 를 그 3개 모듈 `build.gradle` 에만 추가)
   - **트레이스**: 6개 서비스 전부 OTLP 로 전송
   - **로그**: 앱은 그냥 stdout 에 찍고, Alloy 가 `*-service` 파드 로그를 읽어 Loki 로 보낸다 (앱 코드 변경 없음)
+  - **인프라 메트릭**: Alloy 가 kubelet 의 cAdvisor·resource 엔드포인트를 긁어 컨테이너·노드 CPU/메모리를
+    Prometheus 로 remote write 한다. 별도 exporter 를 띄우지 않는다.
 - Kafka 발행·소비 구간에도 스팬이 생겨(`spring.kafka.*.observation-enabled`), api → collector → detector → archiver 흐름이
   트레이스 하나로 이어진다.
 - 로그에는 Spring 기본 패턴의 `[traceId-spanId]` 를 Alloy 가 뽑아 structured metadata 로 붙인다.
@@ -76,13 +78,16 @@ kind delete cluster --name edrdog    # 클러스터째 삭제 (데이터 emptyDi
   |---|---|
   | EDRdog Overview | 요청률·에러율·p95·컨슈머 랙 요약, 서비스별 트래픽, 힙, 로그 볼륨 |
   | EDRdog HTTP | 상태코드별 요청률, 분위(p50/95/99), 느린·많이 불린 엔드포인트 Top |
-  | EDRdog JVM & Kafka | 힙/GC/스레드/클래스, 컨슈머 랙·소비 처리량·커밋률 |
+  | EDRdog Resources | 힙/GC/스레드/클래스, 컨슈머 랙·소비 처리량·커밋률, 컨테이너·노드 CPU/메모리 |
   | EDRdog Logs & Traces | 레벨별 로그 볼륨, 로그 스트림, 에러 로그, 최근 트레이스 목록 |
 
   이미지 기본 대시보드(RED / JVM Overview)도 루트에 그대로 남아 있다.
   대시보드를 고치려면 `otel-lgtm.yaml` ConfigMap 안의 JSON 을 고치고 apply 한 뒤 파드를 재시작한다
   (subPath 마운트라 ConfigMap 만 바꿔서는 반영되지 않는다).
 - 스택 없이 서비스만 띄우려면 `OTEL_ENABLED=false`. 샘플링은 `OTEL_TRACE_SAMPLING`(기본 1.0 = 전량).
+- 지표는 **PVC(`otel-lgtm-data`, 5Gi)** 에 남는다. 여기만 emptyDir 이 아니다. 파드가 재시작돼도 그동안의
+  지표·로그·트레이스가 살아 있어야 발표 중에 그래프가 비지 않기 때문이다. 기본 StorageClass 를 쓴다.
+  RWO 볼륨이라 Deployment 전략은 `Recreate`(롤링이면 새 파드가 볼륨을 못 잡고 서로 기다린다).
 - **Grafana 는 비번 없이 들어가진다.** otel-lgtm 이미지가 익명 접속을 Admin 권한으로 열어두기 때문이다
   (`GF_AUTH_ANONYMOUS_ENABLED=true`, `GF_AUTH_ANONYMOUS_ORG_ROLE=Admin`). 데모용으로 편한 대신,
   포트에 닿는 사람은 누구나 설정을 바꿀 수 있다. 오래 띄워둘 거면 이 두 env 를 Deployment 에서 꺼야 한다.

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -51,6 +51,19 @@ curl "http://localhost:3000/api/datasources/proxy/uid/loki/loki/api/v1/label/ser
 kind delete cluster --name edrdog    # 클러스터째 삭제 (데이터 emptyDir 라 함께 소멸)
 ```
 
+## 시크릿 (Infisical)
+
+매니페스트에 평문으로 박혀 있던 값(`DB_PASSWORD`, `CLICKHOUSE_PASSWORD` 등)을 Infisical 로 옮긴다.
+Operator 가 Infisical 을 읽어 `edrdog-secrets` k8s Secret 으로 동기화하고, 서비스는 그 Secret 을 `envFrom` 으로 받는다.
+
+설치와 연결 절차는 `k8s/infisical.yaml` 주석에 있다. 요약하면 Operator 설치 1회,
+Machine Identity 자격증명 Secret 생성 1회, `kubectl apply -f k8s/infisical.yaml`, 서비스에 `envFrom` patch.
+
+- 릴리스된 Operator(v0.11.5)에는 문서에 나오는 v1beta1 CRD 가 아직 없다. 실제로 도는 건 v1alpha1 `InfisicalSecret` 이다.
+- Deployment 에 같은 이름의 env 가 직접 박혀 있으면 그쪽이 `envFrom` 을 이긴다. Infisical 값을 쓰려면
+  `kubectl -n edrdog set env deployment/<이름> <키>-` 로 기존 env 를 먼저 지운다.
+- CD 는 `infisicalsecrets` CRD 가 있을 때만 이 파일을 apply 한다. Operator 가 없으면 건너뛴다.
+
 ## 메모
 
 - 개발용이라 **영속성 없음**(emptyDir). 파드 재시작 시 데이터 소멸.

--- a/k8s/alloy.yaml
+++ b/k8s/alloy.yaml
@@ -22,6 +22,12 @@ rules:
   - apiGroups: [""]
     resources: ["pods", "pods/log", "namespaces"]
     verbs: ["get", "list", "watch"]
+  # 인프라 메트릭: kubelet 이 노출하는 컨테이너/노드 사용량을 긁기 위해 필요
+  - apiGroups: [""]
+    resources: ["nodes", "nodes/metrics", "nodes/proxy"]
+    verbs: ["get", "list", "watch"]
+  - nonResourceURLs: ["/metrics", "/metrics/cadvisor", "/metrics/resource"]
+    verbs: ["get"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -124,6 +130,76 @@ data:
     loki.write "otel_lgtm" {
       endpoint {
         url = "http://otel-lgtm:3100/loki/api/v1/push"
+      }
+    }
+
+    // ---- 인프라 메트릭 ----
+    // 앱이 내보내는 JVM 지표만으로는 "힙은 여유로운데 파드가 왜 느리지" 같은 상황을 못 본다.
+    // kubelet 이 이미 노출하고 있는 컨테이너·노드 사용량을 긁어 채운다(별도 exporter 배포 없음).
+    discovery.kubernetes "nodes" {
+      role = "node"
+    }
+
+    discovery.relabel "cadvisor" {
+      targets = discovery.kubernetes.nodes.targets
+
+      rule {
+        target_label = "__metrics_path__"
+        replacement  = "/metrics/cadvisor"
+      }
+    }
+
+    discovery.relabel "kubelet_resource" {
+      targets = discovery.kubernetes.nodes.targets
+
+      rule {
+        target_label = "__metrics_path__"
+        replacement  = "/metrics/resource"
+      }
+    }
+
+    // 컨테이너별 CPU·메모리·네트워크
+    prometheus.scrape "cadvisor" {
+      targets           = discovery.relabel.cadvisor.output
+      forward_to        = [prometheus.relabel.infra.receiver]
+      job_name          = "kubelet/cadvisor"
+      scheme            = "https"
+      scrape_interval   = "30s"
+      bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+
+      tls_config {
+        insecure_skip_verify = true
+      }
+    }
+
+    // 노드 전체 CPU·메모리
+    prometheus.scrape "kubelet_resource" {
+      targets           = discovery.relabel.kubelet_resource.output
+      forward_to        = [prometheus.relabel.infra.receiver]
+      job_name          = "kubelet/resource"
+      scheme            = "https"
+      scrape_interval   = "30s"
+      bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+
+      tls_config {
+        insecure_skip_verify = true
+      }
+    }
+
+    // cAdvisor 는 시리즈가 수천 개다. 대시보드에서 실제로 쓰는 것만 남긴다.
+    prometheus.relabel "infra" {
+      forward_to = [prometheus.remote_write.otel_lgtm.receiver]
+
+      rule {
+        source_labels = ["__name__"]
+        regex         = "container_cpu_usage_seconds_total|container_memory_working_set_bytes|container_network_receive_bytes_total|container_network_transmit_bytes_total|node_cpu_usage_seconds_total|node_memory_working_set_bytes|machine_cpu_cores|machine_memory_bytes"
+        action        = "keep"
+      }
+    }
+
+    prometheus.remote_write "otel_lgtm" {
+      endpoint {
+        url = "http://otel-lgtm:9090/api/v1/write"
       }
     }
 ---

--- a/k8s/infisical.yaml
+++ b/k8s/infisical.yaml
@@ -1,0 +1,55 @@
+# Infisical 연동 — Infisical 에 등록한 값을 k8s Secret(edrdog-secrets) 으로 동기화한다.
+# 매니페스트에 비밀번호를 평문으로 박아두던 걸(DB_PASSWORD, CLICKHOUSE_PASSWORD 등) 여기로 옮기는 게 목적이다.
+#
+# 문서에는 v1beta1(InfisicalConnection/InfisicalAuth/InfisicalStaticSecret)이 나오지만
+# 릴리스된 Operator(v0.11.5)에는 아직 그 CRD 가 없다. 실제로 도는 건 v1alpha1 InfisicalSecret 이다.
+#
+# 1) Operator 설치 (1회)
+#   kubectl apply -f https://raw.githubusercontent.com/Infisical/kubernetes-operator/infisical-k8-operator/v0.11.5/kubectl-install/install-secrets-operator.yaml
+#
+# 2) Machine Identity 자격증명 (1회, 값이 비밀이라 레포에 두지 않는다)
+#    Infisical > Access Control > Identities 에서 Universal Auth 로 발급하고
+#    프로젝트 멤버로 추가한 뒤, 서버에서 직접 만든다:
+#   kubectl -n edrdog create secret generic infisical-universal-auth \
+#     --from-literal=clientId=<Client ID> \
+#     --from-literal=clientSecret=<Client Secret>
+#
+# 3) 적용
+#   kubectl apply -f k8s/infisical.yaml
+#   kubectl -n edrdog get infisicalsecret edrdog          # 상태 확인
+#   kubectl -n edrdog get secret edrdog-secrets -o jsonpath='{.data}' | tr ',' '\n'
+#
+# 4) 서비스가 이 Secret 을 읽게 한다(Service 객체를 안 건드리려고 patch 로 넣는다)
+#   for m in detector-service responder-service archiver-service api-service alert-service; do
+#     kubectl -n edrdog patch deployment "$m" --type=strategic \
+#       -p "{\"spec\":{\"template\":{\"spec\":{\"containers\":[{\"name\":\"$m\",\"envFrom\":[{\"secretRef\":{\"name\":\"edrdog-secrets\"}}]}]}}}}"
+#   done
+#
+#   주의: Deployment 에 같은 이름의 env 가 직접 박혀 있으면 그쪽이 envFrom 을 이긴다.
+#   예를 들어 api-service 의 DB_PASSWORD 는 매니페스트에 평문으로 있어서, Infisical 값을 쓰려면
+#   `kubectl -n edrdog set env deployment/api-service DB_PASSWORD-` 로 먼저 지워야 한다.
+---
+apiVersion: secrets.infisical.com/v1alpha1
+kind: InfisicalSecret
+metadata:
+  name: edrdog
+  namespace: edrdog
+spec:
+  hostAPI: https://app.infisical.com/api
+  resyncInterval: 60
+
+  authentication:
+    universalAuth:
+      credentialsRef:
+        secretName: infisical-universal-auth
+        secretNamespace: edrdog
+      secretsScope:
+        # 프로젝트 슬러그는 Infisical 프로젝트 Settings 에서 확인한다. 비밀값이 아니다.
+        projectSlug: REPLACE_WITH_INFISICAL_PROJECT_SLUG
+        envSlug: prod        # Infisical 의 Production 환경 슬러그
+        secretsPath: /
+
+  managedSecretReference:
+    secretName: edrdog-secrets
+    secretNamespace: edrdog
+    creationPolicy: Owner

--- a/k8s/otel-lgtm.yaml
+++ b/k8s/otel-lgtm.yaml
@@ -1,10 +1,23 @@
 # 모니터링 스택 (otel-lgtm) — Grafana + Prometheus + Tempo + Loki 를 담은 올인원 이미지.
-# 서비스들이 OTLP 로 메트릭/트레이스를 밀어넣고(로그는 k8s/alloy.yaml 이 수집), Grafana 에서 본다.
-# 개발용이라 영속성 없음(emptyDir).
+# 서비스들이 OTLP 로 메트릭/트레이스를 밀어넣고(로그·인프라 메트릭은 k8s/alloy.yaml 이 수집), Grafana 에서 본다.
 #
 #   기동:  kubectl apply -f k8s/otel-lgtm.yaml -f k8s/alloy.yaml
-#   접속:  http://localhost:3000  (admin / admin)
+#   접속:  http://localhost:3000  (익명 Admin 으로 열려 있음)
 #   OTLP:  호스트 실행 서비스 -> http://localhost:4318, 클러스터 내부 -> http://otel-lgtm:4318
+---
+# 지표 보관용 볼륨. emptyDir 로 두면 파드가 한 번 재시작될 때 그동안의 지표·로그·트레이스가
+# 통째로 사라져 발표 중 그래프가 빈다. 기본 StorageClass 를 쓴다(kind: standard, k3s: local-path).
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: otel-lgtm-data
+  namespace: edrdog
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -1032,7 +1045,7 @@ data:
   edrdog-jvm-kafka.json: |
     {
       "uid": "edrdog-jvm-kafka",
-      "title": "EDRdog JVM & Kafka",
+      "title": "EDRdog Resources",
       "tags": [
         "edrdog"
       ],
@@ -1492,6 +1505,145 @@ data:
               "refId": "A"
             }
           ]
+        },
+        {
+          "type": "row",
+          "id": 213,
+          "title": "컨테이너 / 노드",
+          "collapsed": false,
+          "panels": [],
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 27
+          }
+        },
+        {
+          "type": "timeseries",
+          "id": 214,
+          "title": "컨테이너 CPU",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${ds}"
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 0,
+            "y": 28
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "short",
+              "custom": {
+                "fillOpacity": 10,
+                "showPoints": "never"
+              },
+              "min": 0
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            }
+          },
+          "targets": [
+            {
+              "expr": "sum by (pod) (rate(container_cpu_usage_seconds_total{namespace=\"edrdog\", container!=\"\"}[$__rate_interval]))",
+              "legendFormat": "{{pod}}",
+              "refId": "A"
+            }
+          ]
+        },
+        {
+          "type": "timeseries",
+          "id": 215,
+          "title": "컨테이너 메모리",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${ds}"
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 8,
+            "y": 28
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "bytes",
+              "custom": {
+                "fillOpacity": 10,
+                "showPoints": "never"
+              },
+              "min": 0
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            }
+          },
+          "targets": [
+            {
+              "expr": "sum by (pod) (container_memory_working_set_bytes{namespace=\"edrdog\", container!=\"\"})",
+              "legendFormat": "{{pod}}",
+              "refId": "A"
+            }
+          ]
+        },
+        {
+          "type": "timeseries",
+          "id": 216,
+          "title": "노드 사용률",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${ds}"
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 16,
+            "y": 28
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "percentunit",
+              "custom": {
+                "fillOpacity": 10,
+                "showPoints": "never"
+              },
+              "min": 0,
+              "max": 1
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            }
+          },
+          "targets": [
+            {
+              "expr": "sum(rate(node_cpu_usage_seconds_total[$__rate_interval])) / clamp_min(sum(machine_cpu_cores), 1)",
+              "legendFormat": "CPU",
+              "refId": "A"
+            },
+            {
+              "expr": "sum(node_memory_working_set_bytes) / clamp_min(sum(machine_memory_bytes), 1)",
+              "legendFormat": "메모리",
+              "refId": "B"
+            }
+          ]
         }
       ]
     }
@@ -1832,6 +1984,9 @@ metadata:
     app: otel-lgtm
 spec:
   replicas: 1
+  # ReadWriteOnce PVC 라 롤링 업데이트로는 새 파드가 볼륨을 못 잡고 서로 기다린다. 먼저 내리고 띄운다.
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app: otel-lgtm
@@ -1848,10 +2003,14 @@ spec:
             - containerPort: 3100  # Loki (Alloy 가 로그를 밀어넣는 곳)
             - containerPort: 4317  # OTLP gRPC
             - containerPort: 4318  # OTLP HTTP
+            - containerPort: 9090  # Prometheus (Alloy 가 인프라 메트릭을 밀어넣는 곳)
           env:
             # 첫 화면을 EDRdog 대시보드로 (기본 Grafana 홈 대신)
             - name: GF_DASHBOARDS_DEFAULT_HOME_DASHBOARD_PATH
               value: /otel-lgtm/edrdog-dashboards/edrdog-overview.json
+          # Alloy 가 인프라 메트릭을 밀어넣는 remote write 수신은 이미지 기본 실행 인자에
+          # 이미 켜져 있다(--web.enable-remote-write-receiver). PROMETHEUS_EXTRA_ARGS 로
+          # 같은 플래그를 또 주면 중복으로 Prometheus 가 아예 뜨지 않으니 넣지 말 것.
           volumeMounts:
             # 프로비저닝 디렉터리는 통째로 덮으면 기본 대시보드가 사라지므로 파일 하나만 subPath 로 얹는다.
             - name: dashboards
@@ -1888,7 +2047,8 @@ spec:
           configMap:
             name: otel-lgtm-dashboards
         - name: data
-          emptyDir: {}
+          persistentVolumeClaim:
+            claimName: otel-lgtm-data
 ---
 apiVersion: v1
 kind: Service
@@ -1918,3 +2078,7 @@ spec:
       port: 4318
       targetPort: 4318
       nodePort: 30318
+    - name: prometheus
+      port: 9090
+      targetPort: 9090
+      nodePort: 30909


### PR DESCRIPTION
#79 후속. 팀 C 리포(`deploy/portainer/compose.observability.yaml`)와 비교해 우리가 비어 있던 부분을 메운다.

## 1. 지표 영속성 (emptyDir → PVC)

파드가 한 번 재시작되면 그동안의 지표·로그·트레이스가 통째로 사라져 발표 중 그래프가 빈다.
`/data` 를 PVC(5Gi, 기본 StorageClass)로 바꿨다.

RWO 볼륨이라 롤링 업데이트로는 새 파드가 볼륨을 못 잡고 서로 기다린다. Deployment 전략을 `Recreate` 로 뒀다.

## 2. 인프라 메트릭 (컨테이너·노드 CPU/메모리)

JVM 힙만 보여서는 "힙은 여유로운데 파드가 왜 느리지" 같은 상황(CPU 스로틀, 노드 포화)을 못 본다.
Alloy 가 kubelet 의 `/metrics/cadvisor` 와 `/metrics/resource` 를 긁어 Prometheus 로 remote write 한다.
node-exporter 나 cadvisor 를 따로 띄우지 않는다.

cAdvisor 는 시리즈가 수천 개라 대시보드에서 실제로 쓰는 것만 `keep` 한다.
RBAC 에 `nodes`, `nodes/metrics`, `nodes/proxy` 추가.

대시보드 `EDRdog JVM & Kafka` → `EDRdog Resources` 로 바꾸고 컨테이너/노드 행을 추가했다(uid 는 그대로).

## 3. CD 가 모니터링 매니페스트를 apply

지금까지 CD 는 `set image` 만 해서, 머지해도 배포 서버에는 모니터링 스택이 안 생겼다.
`k8s/otel-lgtm.yaml` 과 `k8s/alloy.yaml` 만 apply 하도록 추가했다.

**서비스 5개 매니페스트는 계속 apply 하지 않는다.** 레포의 `api-service` Service 는 ClusterIP 인데
서버는 NodePort 30084 로 떠 있고 Caddy 가 그 포트로 프록시한다. apply 하면 사이트가 죽는다.
서버 브랜치를 건드리지 않으려고 `git show FETCH_HEAD:<path> | kubectl apply -f -` 방식을 쓴다.

서비스 환경변수(`OTEL_EXPORTER_OTLP_ENDPOINT`)는 Infisical 로 주입한다.

## 확인한 것

별도 kind 클러스터에서 검증하고 지웠다.

- PVC 바인딩 확인, 파드를 지웠다 띄워 **재시작 전 데이터가 남는 것 확인**(19샘플 → 24샘플)
- 인프라 메트릭 4개 쿼리 전부 데이터 반환: 컨테이너 CPU/메모리(파드별), 노드 CPU 1.56%, 노드 메모리 25.2%
- 원격 배포 스크립트 `bash -n` 문법 검사 통과

검증 중 발견: remote write 수신 플래그는 이미지 기본 실행 인자에 **이미 켜져 있다**.
`PROMETHEUS_EXTRA_ARGS` 로 같은 플래그를 또 주면 중복으로 Prometheus 가 아예 뜨지 않는다
(connection refused 로 확인하고 제거).

## 남은 것

- api → collector → detector → archiver 전 구간 트레이스 연결은 6개를 다 띄워야 확인된다.
- `collector-service` 는 `k8s/` 매니페스트도 CI 이미지 매트릭스도 없어서 배포 환경에서는 관측 대상이 아니다.