### PR TITLE
release: dev → main (모니터링 스택 + 발표용 시연 API + Kafdrop)

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -69,8 +69,11 @@ jobs:
             ${{ steps.vars.outputs.image_base }}:${{ github.sha }}
             ${{ steps.vars.outputs.image_base }}:latest
 
-  # CD: EC2(k3s) 에 SSH 로 접속해 새 이미지(:SHA)로 롤링. k3s API 를 외부에 노출하지 않는다.
+  # CD: EC2(k3s) 에 SSH 로 접속해 모니터링 매니페스트를 apply 하고 서비스는 새 이미지(:SHA)로 롤링.
+  # k3s API 를 외부에 노출하지 않는다.
   # 필요한 secret: EC2_HOST(도메인/공인IP), EC2_SSH_KEY(개인키). 선택: EC2_USER(기본 ubuntu).
+  # 서비스 매니페스트는 apply 하지 않는다(레포와 서버 상태가 어긋나 있어 실서비스가 죽는다).
+  # 서비스 환경변수(OTEL_EXPORTER_OTLP_ENDPOINT 등)는 Infisical 로 주입한다.
   deploy:
     needs: image
     if: github.event_name == 'push'
@@ -94,6 +97,22 @@ jobs:
             "REPO='$REPO_LC' SHA='$SHA' NS=edrdog bash -s" <<'REMOTE'
           set -euo pipefail
           MODULES="detector-service responder-service archiver-service api-service alert-service"
+
+          # 모니터링 스택만 매니페스트로 apply 한다.
+          # 서비스 5개 매니페스트는 손대지 않는다. 레포의 api-service Service 는 ClusterIP 인데
+          # 서버는 NodePort 30084 로 떠 있어(Caddy 가 이 포트로 프록시) apply 하면 사이트가 죽는다.
+          # 서버 브랜치를 건드리지 않으려고 FETCH_HEAD 에서 파일만 꺼내 적용한다.
+          if [ -d ~/Backend/.git ]; then
+          git -C ~/Backend fetch --quiet origin main
+          for f in k8s/otel-lgtm.yaml k8s/alloy.yaml; do
+          git -C ~/Backend show "FETCH_HEAD:$f" | sudo kubectl apply -f -
+          done
+          sudo kubectl -n "$NS" rollout status deployment/otel-lgtm --timeout=300s
+          sudo kubectl -n "$NS" rollout status deployment/alloy --timeout=180s
+          else
+          echo "~/Backend 클론이 없어 모니터링 매니페스트 apply 를 건너뛴다" >&2
+          fi
+
           for m in $MODULES; do
           sudo kubectl -n "$NS" set image "deployment/$m" "$m=ghcr.io/$REPO/$m:$SHA"
           done

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -107,6 +107,11 @@ jobs:
           for f in k8s/otel-lgtm.yaml k8s/alloy.yaml; do
           git -C ~/Backend show "FETCH_HEAD:$f" | sudo kubectl apply -f -
           done
+          # Infisical 연동은 Operator 가 깔려 있을 때만. 없으면 CRD 가 없어 apply 가 실패하고
+          # set -e 때문에 서비스 롤링까지 같이 죽는다.
+          if sudo kubectl get crd infisicalsecrets.secrets.infisical.com >/dev/null 2>&1; then
+          git -C ~/Backend show "FETCH_HEAD:k8s/infisical.yaml" | sudo kubectl apply -f -
+          fi
           sudo kubectl -n "$NS" rollout status deployment/otel-lgtm --timeout=300s
           sudo kubectl -n "$NS" rollout status deployment/alloy --timeout=180s
           else

--- a/alert-service/src/main/resources/application.yml
+++ b/alert-service/src/main/resources/application.yml
@@ -11,6 +11,8 @@ spring:
       properties:
         spring.json.value.default.type: com.edrdog.alertservice.dto.Alert
         spring.json.trusted.packages: com.edrdog.alertservice.dto
+    listener:
+      observation-enabled: true         # 컨슈머 스팬 생성 → 발행 측 traceId 를 이어받아 한 트레이스로 연결
 
 server:
   port: 8083
@@ -31,3 +33,11 @@ management:
     web:
       exposure:
         include: health, info
+  # 관측 — 트레이스만 보낸다(메트릭 익스포터는 api/detector/archiver 에만).
+  tracing:
+    enabled: ${OTEL_ENABLED:true}
+    sampling:
+      probability: ${OTEL_TRACE_SAMPLING:1.0}
+  otlp:
+    tracing:
+      endpoint: ${OTEL_EXPORTER_OTLP_ENDPOINT:http://localhost:4318}/v1/traces

--- a/api-service/build.gradle
+++ b/api-service/build.gradle
@@ -9,6 +9,7 @@ dependencies {
     implementation 'org.springframework.security:spring-security-crypto'      // auth: BCrypt 비밀번호 해시(필터체인 없이)
     implementation 'com.maxmind.geoip2:geoip2:4.2.1'                   // GeoLite2-Country mmdb 로 dest_ip -> 국가 코드 (world map)
     testImplementation 'com.h2database:h2'                             // auth: 테스트용 임베디드 DB
+    implementation 'io.micrometer:micrometer-registry-otlp'            // 메트릭 OTLP 전송 (프론트 진입점이라 RED 지표 필요)
 }
 
 // --- GeoLite2-Country mmdb: 빌드 시 MaxMind 에서 다운로드해 jar 리소스로 번들 ---

--- a/api-service/src/main/java/com/edrdog/apiservice/demo/AlertArrivals.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/demo/AlertArrivals.java
@@ -1,0 +1,50 @@
+package com.edrdog.apiservice.demo;
+
+import com.edrdog.apiservice.alert.AlertId;
+import com.edrdog.apiservice.alert.dto.Alert;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * alerts 토픽에 판정 결과가 <b>도착한 시각</b>을 alert id 별로 기록한다 (데모 타임라인 계측용).
+ *
+ * <p>적재용 리스너(AlertIngestListener)와 별도 컨슈머 그룹이라 서로 간섭하지 않는다. 굳이 분리한 이유는
+ * 발표에서 보여줄 구간이 "Kafka → Streams → Kafka" 이기 때문이다. detector 가 판정을 alerts 토픽에
+ * 되돌려준 시점과, 그게 ClickHouse 에 적재돼 조회 가능해진 시점을 따로 찍어야 두 단계를 구분해 보여줄 수 있다.
+ *
+ * <p>id 계산은 적재 경로와 같은 {@link AlertId} 를 쓴다. 그래서 호출자는 발행 전에 기대 id 를 미리 계산해
+ * 이번 회차 alert 만 정확히 기다릴 수 있다(과거 회차의 같은 룰 alert 에 속지 않는다).
+ */
+@Component
+public class AlertArrivals {
+
+    /** 보관 상한. 발표용 계측이라 최근 것만 있으면 된다. */
+    private static final int MAX = 200;
+
+    private final Map<String, Long> arrivedAt = Collections.synchronizedMap(
+            new LinkedHashMap<>(16, 0.75f, false) {
+                @Override
+                protected boolean removeEldestEntry(Map.Entry<String, Long> eldest) {
+                    return size() > MAX;
+                }
+            });
+
+    @KafkaListener(topics = "${edrdog.kafka.alerts-topic}", groupId = "api-demo-arrivals")
+    public void onAlert(Alert alert) {
+        if (alert == null || alert.tenantId() == null || alert.host() == null || alert.ruleId() == null) {
+            return;
+        }
+        String id = AlertId.of(alert.tenantId(), alert.host(), alert.ruleId(), alert.ts());
+        arrivedAt.putIfAbsent(id, System.currentTimeMillis());
+    }
+
+    /** 그 alert 가 alerts 토픽에서 관측된 시각(epoch millis). 아직 안 왔으면 empty. */
+    public Optional<Long> arrivedAt(String alertId) {
+        return Optional.ofNullable(arrivedAt.get(alertId));
+    }
+}

--- a/api-service/src/main/java/com/edrdog/apiservice/demo/CollectedEvent.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/demo/CollectedEvent.java
@@ -1,0 +1,59 @@
+package com.edrdog.apiservice.demo;
+
+/**
+ * events 토픽 발행 스키마 사본 (detector 의 Event 와 동일 필드).
+ * 데모 수집 API 가 이 형태로 발행하면 detector Kafka Streams 가 그대로 상관분석한다.
+ *
+ * <p>detector/archiver 모듈이 각자 사본을 두는 것과 같은 이유로 여기에도 사본을 둔다(모듈 간 의존 없음).
+ * 필드명이 detector 의 Event 와 어긋나면 판정 입력이 null 로 들어가므로 바꿀 때 함께 맞춰야 한다.
+ *
+ * @param host      엔드포인트 식별자 (상관분석 키 = Kafka 파티션 키)
+ * @param type      process | network | file | script
+ * @param ts        발생 시각 (epoch millis) — detector 의 event-time 윈도우 기준
+ * @param process   프로세스명/파일명 (basename)
+ * @param parent    부모 프로세스명
+ * @param cmdline   명령행. file/script 는 판정에 쓰는 전체 경로를 여기 담는다.
+ * @param destIp    목적지 IP (network)
+ * @param destPort  목적지 포트 (network)
+ * @param tenantId  조직(tenant) 식별자 — api-service 의 tenant PK 문자열이어야 조회에서 보인다
+ */
+public record CollectedEvent(
+        String host,
+        String type,
+        long ts,
+        String process,
+        String parent,
+        String cmdline,
+        String destIp,
+        int destPort,
+        String tenantId
+) {
+
+    public static final String TYPE_PROCESS = "process";
+    public static final String TYPE_NETWORK = "network";
+    public static final String TYPE_FILE = "file";
+    public static final String TYPE_SCRIPT = "script";
+
+    /** process 이벤트. */
+    public static CollectedEvent process(String host, long ts, String process, String parent,
+                                         String cmdline, String tenantId) {
+        return new CollectedEvent(host, TYPE_PROCESS, ts, process, parent, cmdline, null, 0, tenantId);
+    }
+
+    /** network 이벤트. 소유 프로세스를 같이 담아야 lineage 가 process -> network 로 이어진다. */
+    public static CollectedEvent network(String host, long ts, String process, String destIp,
+                                         int destPort, String tenantId) {
+        return new CollectedEvent(host, TYPE_NETWORK, ts, process, null, null, destIp, destPort, tenantId);
+    }
+
+    /** script 이벤트. process 는 인터프리터 basename, cmdline 은 판정용 전체 경로. */
+    public static CollectedEvent script(String host, long ts, String process, String parent,
+                                        String cmdline, String tenantId) {
+        return new CollectedEvent(host, TYPE_SCRIPT, ts, process, parent, cmdline, null, 0, tenantId);
+    }
+
+    /** file 이벤트. process 는 파일명 basename, cmdline 은 판정용 전체 경로. */
+    public static CollectedEvent file(String host, long ts, String name, String fullPath, String tenantId) {
+        return new CollectedEvent(host, TYPE_FILE, ts, name, null, fullPath, null, 0, tenantId);
+    }
+}

--- a/api-service/src/main/java/com/edrdog/apiservice/demo/DemoAccountSeeder.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/demo/DemoAccountSeeder.java
@@ -38,7 +38,8 @@ public class DemoAccountSeeder {
      */
     public static final long TENANT_ID = 99L;
 
-    static final String EMAIL = "test@edrdog.local";
+    /** 데모 계정 이메일. 데모 API 가 이 계정으로 쓸 tenant 를 찾는다(DemoTenant). */
+    public static final String EMAIL = "test@edrdog.local";
 
     /** 이메일 형식이 아니던 옛 데모 계정. 남아 있으면 정리한다. */
     static final String LEGACY_EMAIL = "test";

--- a/api-service/src/main/java/com/edrdog/apiservice/demo/DemoFlowService.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/demo/DemoFlowService.java
@@ -1,0 +1,171 @@
+package com.edrdog.apiservice.demo;
+
+import com.edrdog.apiservice.alert.AlertId;
+import com.edrdog.apiservice.alert.AlertService;
+import com.edrdog.apiservice.alert.web.AlertResponse;
+import com.edrdog.apiservice.auth.exception.AuthException;
+import com.edrdog.apiservice.demo.web.DemoFlowResponse;
+import com.edrdog.apiservice.demo.web.DemoFlowStep;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * 발표용 전체 플로우 실행. 엔드포인트가 로그를 보낸 것처럼 events 토픽에 발행하고,
+ * detector 가 alerts 토픽으로 되돌려준 판정이 저장돼 조회 가능해질 때까지 기다린 뒤 단계별 결과를 만든다.
+ *
+ * <p>세 단계를 각각 실측한다. 발표에서 보여줄 구간이 "Kafka → Streams → Kafka" 라, 판정이 토픽에 돌아온
+ * 시점(2단계)과 그게 저장돼 조회되는 시점(3단계)을 분리해야 스트림즈가 한 일이 눈에 보인다.
+ *
+ * <ol>
+ *   <li>수집 — api-service → Kafka(events). 발행에 걸린 시간</li>
+ *   <li>탐지 — detector Kafka Streams → Kafka(alerts). {@link AlertArrivals} 가 관측한 도착 시각</li>
+ *   <li>저장 — api-service → ClickHouse(판정기록) + MySQL(status). 조회 API 로 읽히는 시점</li>
+ * </ol>
+ *
+ * <p>alert id 는 발행 <b>전에</b> 계산한다({@link AlertId} 가 tenant|host|rule|ts 로 결정적이고, 판정 ts 는
+ * 마지막 이벤트의 ts 와 같다). 그래서 과거 회차의 같은 룰 alert 를 이번 결과로 착각하지 않는다.
+ */
+@Service
+public class DemoFlowService {
+
+    private static final Logger log = LoggerFactory.getLogger(DemoFlowService.class);
+
+    private static final long POLL_MS = 250;
+
+    private static final String PIPELINE =
+            "api-service → Kafka(events) → detector Kafka Streams → Kafka(alerts) → api-service(ClickHouse+MySQL)";
+
+    private final EventsProducer producer;
+    private final AlertArrivals arrivals;
+    private final AlertService alerts;
+    private final long detectTimeoutMs;
+    private final long storeTimeoutMs;
+
+    public DemoFlowService(EventsProducer producer, AlertArrivals arrivals, AlertService alerts,
+                           @Value("${edrdog.demo.detect-timeout-ms}") long detectTimeoutMs,
+                           @Value("${edrdog.demo.store-timeout-ms}") long storeTimeoutMs) {
+        this.producer = producer;
+        this.arrivals = arrivals;
+        this.alerts = alerts;
+        this.detectTimeoutMs = detectTimeoutMs;
+        this.storeTimeoutMs = storeTimeoutMs;
+    }
+
+    /**
+     * 시나리오 로그를 발행하고 판정이 조회 가능해질 때까지 기다린다.
+     *
+     * @param scenario 시나리오 이름 (미지원이면 IllegalArgumentException)
+     * @param host     엔드포인트 식별자. null/빈값이면 시나리오 기본 host
+     * @param tenantId 로그인 유저의 tenant PK 문자열
+     */
+    public DemoFlowResponse run(String scenario, String host, String tenantId) {
+        String target = (host == null || host.isBlank()) ? DemoScenario.defaultHost(scenario) : host.trim();
+        long start = System.currentTimeMillis();
+        List<CollectedEvent> logs = DemoScenario.build(scenario, target, start, tenantId);
+
+        logs.forEach(producer::publish);
+        long publishedAt = System.currentTimeMillis();
+
+        String ruleId = DemoScenario.expectedRuleId(scenario);
+        long triggerTs = logs.get(logs.size() - 1).ts();
+        String alertId = AlertId.of(tenantId, target, ruleId, triggerTs);
+
+        Optional<Long> detectedAt = awaitArrival(alertId, publishedAt + detectTimeoutMs);
+        Optional<AlertResponse> stored = detectedAt.isEmpty()
+                ? Optional.empty()
+                : awaitStored(tenantId, alertId, System.currentTimeMillis() + storeTimeoutMs);
+        long finishedAt = System.currentTimeMillis();
+
+        List<DemoFlowStep> steps = steps(logs, ruleId, start, publishedAt, detectedAt, stored, finishedAt);
+        if (stored.isEmpty()) {
+            log.warn("데모 플로우 미완료: scenario={} host={} alertId={} 탐지도착={} (detector/Kafka 상태 확인)",
+                    scenario, target, alertId, detectedAt.isPresent());
+        }
+        return new DemoFlowResponse(scenario, target, tenantId, PIPELINE, alertId,
+                finishedAt - start, steps, logs, stored.orElse(null), nextSteps(alertId));
+    }
+
+    private List<DemoFlowStep> steps(List<CollectedEvent> logs, String ruleId, long start, long publishedAt,
+                                     Optional<Long> detectedAt, Optional<AlertResponse> stored, long finishedAt) {
+        List<DemoFlowStep> steps = new ArrayList<>();
+        long normal = logs.stream().filter(e -> e.ts() < start).count();
+        steps.add(DemoFlowStep.ok(1, "수집", "api-service → Kafka(events)", publishedAt - start,
+                "엔드포인트 로그 " + logs.size() + "건 발행 (평소 배경 " + normal + "건 + 공격 "
+                        + (logs.size() - normal) + "건). 파티션 키 = host 라 순서가 보존된다"));
+
+        String detectPath = "Kafka(events) → detector Kafka Streams → Kafka(alerts)";
+        if (detectedAt.isEmpty()) {
+            steps.add(DemoFlowStep.timeout(2, "탐지", detectPath, finishedAt - publishedAt,
+                    detectTimeoutMs + "ms 안에 판정이 alerts 토픽으로 돌아오지 않았다. "
+                            + "detector-service 파드와 Kafka 연결을 확인하세요"));
+            return List.copyOf(steps);
+        }
+        steps.add(DemoFlowStep.ok(2, "탐지", detectPath, detectedAt.get() - publishedAt,
+                "상관분석이 " + ruleId + " 를 매칭해 alerts 토픽으로 발행, api-service 가 되받았다"));
+
+        String storePath = "api-service → ClickHouse(판정기록) + MySQL(트리아지 status)";
+        if (stored.isEmpty()) {
+            steps.add(DemoFlowStep.timeout(3, "저장", storePath, finishedAt - detectedAt.get(),
+                    storeTimeoutMs + "ms 안에 조회되지 않았다. ClickHouse 상태를 확인하세요"));
+            return List.copyOf(steps);
+        }
+        AlertResponse alert = stored.get();
+        steps.add(DemoFlowStep.ok(3, "저장", storePath, finishedAt - detectedAt.get(),
+                alert.threatName() + " / " + alert.mitre() + " / " + alert.severity()
+                        + " → 권고조치 " + alert.action() + ". GET /api/alerts 로 조회된다"));
+        return List.copyOf(steps);
+    }
+
+    /** 그 alert 가 alerts 토픽에 도착할 때까지 폴링. 제한시간을 넘기면 empty. */
+    private Optional<Long> awaitArrival(String alertId, long deadline) {
+        while (true) {
+            Optional<Long> at = arrivals.arrivedAt(alertId);
+            if (at.isPresent() || !sleepUntil(deadline)) {
+                return at;
+            }
+        }
+    }
+
+    /** 그 alert 가 조회 가능해질 때까지 폴링. 제한시간을 넘기면 empty. */
+    private Optional<AlertResponse> awaitStored(String tenantId, String alertId, long deadline) {
+        while (true) {
+            try {
+                return Optional.of(alerts.get(tenantId, alertId));
+            } catch (AuthException e) {
+                if (e.getKind() != AuthException.Kind.NOT_FOUND || !sleepUntil(deadline)) {
+                    return Optional.empty();   // 아직 적재 전(404) 이 아니면 재시도할 이유가 없다
+                }
+            }
+        }
+    }
+
+    /**
+     * 다음 폴링까지 대기. 제한시간이 남아 있으면 true(계속), 넘겼거나 인터럽트되면 false(중단).
+     */
+    private boolean sleepUntil(long deadline) {
+        if (System.currentTimeMillis() >= deadline) {
+            return false;
+        }
+        try {
+            Thread.sleep(POLL_MS);
+            return true;
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return false;
+        }
+    }
+
+    private static List<String> nextSteps(String alertId) {
+        return List.of(
+                "GET /api/alerts — 방금 만들어진 알림이 목록 맨 위에 있다",
+                "GET /api/alerts/" + alertId + "/lineage — 이 알림의 공격 경로 그래프",
+                "GET /api/alerts/summary — 대시보드 집계에 반영된 모습",
+                "POST /api/alerts/" + alertId + "/respond — responder 로 프로세스 종료 조치");
+    }
+}

--- a/api-service/src/main/java/com/edrdog/apiservice/demo/DemoScenario.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/demo/DemoScenario.java
@@ -1,0 +1,160 @@
+package com.edrdog.apiservice.demo;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * 발표용 공격 시나리오 생성 (순수 함수). baseTs 를 인자로 받아 결정적 — 테스트로 재현 가능.
+ *
+ * <p>실제 엔드포인트가 로그를 보내는 것처럼 보이게 하려고 공격 이벤트 앞에 <b>정상 배경 로그</b>를 붙인다.
+ * 대시보드에서 "이 호스트는 평소 이런 걸 돌리고 있었고, 그 중 이것만 탐지됐다" 로 보인다.
+ *
+ * <p>배경 로그에 network 이벤트를 넣지 않는 것이 이 클래스의 핵심 제약이다. detector 의 R2 는
+ * "선행 network(80/443/8080) + 이후 아무 process" 만으로 CRITICAL 을 내므로, 배경에 network 를 섞으면
+ * 뒤따르는 정상 프로세스가 전부 오탐으로 잡힌다. network 는 download-exec 시나리오에서만 의도적으로 쓴다.
+ *
+ * <p>판정을 트리거하는 이벤트는 항상 <b>마지막</b> 이벤트다. detector 가 만들 alert 의 ts 가 그 이벤트의 ts 와
+ * 같아지므로, 호출자는 alert id 를 미리 계산해 도착을 기다릴 수 있다.
+ */
+public final class DemoScenario {
+
+    private DemoScenario() {
+    }
+
+    /** R1 T1059 (HIGH): office 앱이 shell 을 자식으로 띄우는 매크로 침투. */
+    public static final String PROCESS_CHAIN = "process-chain";
+    /** R2 T1105+T1204 (CRITICAL): 다운로드 아웃바운드 후 그 파일 실행. */
+    public static final String DOWNLOAD_EXEC = "download-exec";
+    /** R3 T1059 (MEDIUM): 다운로드 경로의 스크립트 실행. */
+    public static final String SCRIPT_EXEC = "script-exec";
+    /** R4 T1547 (MEDIUM): 시작프로그램 경로에 파일 생성(지속성 확보). */
+    public static final String FILE_AUTORUN = "file-autorun";
+
+    private static final List<String> NAMES =
+            List.of(PROCESS_CHAIN, DOWNLOAD_EXEC, SCRIPT_EXEC, FILE_AUTORUN);
+
+    /**
+     * 시나리오별 기본 host. 서로 다르게 두는 이유가 있다. detector 의 상관 버퍼는 host 별 5분이라
+     * 같은 host 로 다른 시나리오를 연달아 돌리면 앞 시나리오의 선행 이벤트가 남아 의도한 룰이 아닌
+     * 다른 룰(주로 더 심각한 R2)이 먼저 매칭된다. 발표 중 클릭 순서를 신경 쓰지 않아도 되게 분리한다.
+     *
+     * <p>이름은 데모 시드가 쓰는 호스트({@link DemoData})와 같은 계열로 맞춰 과거 데이터와 이어져 보이게 한다.
+     */
+    private static final Map<String, String> DEFAULT_HOSTS = Map.of(
+            PROCESS_CHAIN, "DESKTOP-KIM",
+            DOWNLOAD_EXEC, "DESKTOP-CHOI",
+            SCRIPT_EXEC, "LAPTOP-PARK",
+            FILE_AUTORUN, "DESKTOP-LEE");
+
+    /** 시나리오가 트리거할 detector 룰 id. alert 도착을 기다릴 때 쓴다. */
+    private static final Map<String, String> RULE_IDS = Map.of(
+            PROCESS_CHAIN, "SUSPICIOUS_PROCESS_CHAIN",
+            DOWNLOAD_EXEC, "DOWNLOAD_AND_EXECUTE",
+            SCRIPT_EXEC, "SCRIPT_FROM_TEMP_PATH",
+            FILE_AUTORUN, "FILE_IN_AUTORUN_PATH");
+
+    private static final long SECOND = 1000L;
+
+    public static List<String> names() {
+        return NAMES;
+    }
+
+    public static boolean isSupported(String name) {
+        return name != null && NAMES.contains(name);
+    }
+
+    /** 시나리오 기본 host. 미지원 이름은 IllegalArgumentException. */
+    public static String defaultHost(String name) {
+        return require(DEFAULT_HOSTS, name);
+    }
+
+    /** 시나리오가 트리거할 룰 id. 미지원 이름은 IllegalArgumentException. */
+    public static String expectedRuleId(String name) {
+        return require(RULE_IDS, name);
+    }
+
+    /**
+     * 정상 배경 로그 + 공격 시퀀스를 시간 순서로 생성한다. 호출자는 이 순서 그대로 발행해야 한다
+     * (detector 는 host 파티션 안 도착 순서대로 상관하므로 선행 이벤트가 먼저 나가야 룰이 성립한다).
+     *
+     * @param name     시나리오 이름
+     * @param host     엔드포인트 식별자
+     * @param baseTs   공격 첫 이벤트 시각 (epoch millis). 배경 로그는 이보다 앞에 놓인다.
+     * @param tenantId 조직(tenant) 식별자 — 발행되는 모든 이벤트에 태깅
+     */
+    public static List<CollectedEvent> build(String name, String host, long baseTs, String tenantId) {
+        if (!isSupported(name)) {
+            throw new IllegalArgumentException(
+                    "미지원 시나리오: " + name + " (지원: " + String.join(", ", NAMES) + ")");
+        }
+        List<CollectedEvent> events = new ArrayList<>(background(host, baseTs, tenantId));
+        events.addAll(switch (name) {
+            case PROCESS_CHAIN -> processChain(host, baseTs, tenantId);
+            case DOWNLOAD_EXEC -> downloadExec(host, baseTs, tenantId);
+            case SCRIPT_EXEC -> scriptExec(host, baseTs, tenantId);
+            default -> fileAutorun(host, baseTs, tenantId);
+        });
+        return List.copyOf(events);
+    }
+
+    /**
+     * 평소 돌고 있는 정상 프로세스. detector 의 baseline 억제 목록(Rules.BASELINE_SAFE)에 있는 이름만 쓴다.
+     *
+     * <p>이름을 아무거나 쓰면 안 되는 이유가 있다. detector 의 상관 버퍼는 host 별 5분이라 같은 시나리오를
+     * 5분 안에 두 번 돌리면 앞 회차의 network 이벤트가 버퍼에 남아 있고, R2("선행 network + 이후 아무
+     * process")가 이번 회차의 <b>배경</b> 프로세스에 CRITICAL 오탐을 낸다. baseline 억제 대상 이름만 쓰면
+     * 그 경로가 원천적으로 막힌다.
+     *
+     * <p>다른 룰에는 애초에 걸리지 않는다 (R1 은 office 부모 + shell 자식, R3/R4 는 script/file 타입만 본다).
+     */
+    private static List<CollectedEvent> background(String host, long baseTs, String tenantId) {
+        return List.of(
+                CollectedEvent.process(host, baseTs - 12 * SECOND, "OneDrive.exe", "explorer.exe",
+                        "\"C:\\Program Files\\Microsoft OneDrive\\OneDrive.exe\" /background", tenantId),
+                CollectedEvent.process(host, baseTs - 8 * SECOND, "Teams.exe", "explorer.exe",
+                        "\"C:\\Users\\Public\\AppData\\Local\\Microsoft\\Teams\\Teams.exe\"", tenantId),
+                CollectedEvent.process(host, baseTs - 4 * SECOND, "MsEdgeUpdate.exe", "services.exe",
+                        "\"C:\\Program Files (x86)\\Microsoft\\EdgeUpdate\\MicrosoftEdgeUpdate.exe\" /svc", tenantId));
+    }
+
+    /** office 앱 실행 → 그 앱을 부모로 shell 실행 (매크로 문서 침투). */
+    private static List<CollectedEvent> processChain(String host, long baseTs, String tenantId) {
+        return List.of(
+                CollectedEvent.process(host, baseTs, "winword.exe", "explorer.exe",
+                        "\"C:\\Users\\kim\\Documents\\견적서_2026.docm\"", tenantId),
+                CollectedEvent.process(host, baseTs + SECOND, "powershell.exe", "winword.exe",
+                        "powershell -nop -w hidden -enc SQBFAFgAIAAoAE4AZQB3AC0ATwBiAGoA...", tenantId));
+    }
+
+    /** 외부 다운로드 아웃바운드 → 내려받은 파일 실행 (download-and-execute). */
+    private static List<CollectedEvent> downloadExec(String host, long baseTs, String tenantId) {
+        return List.of(
+                CollectedEvent.network(host, baseTs, "chrome.exe", "185.220.101.5", 443, tenantId),
+                CollectedEvent.process(host, baseTs + SECOND, "update32.exe", "explorer.exe",
+                        "C:\\Users\\choi\\Downloads\\update32.exe", tenantId));
+    }
+
+    /** 다운로드 경로의 스크립트 실행. 단일 이벤트 point 룰. */
+    private static List<CollectedEvent> scriptExec(String host, long baseTs, String tenantId) {
+        return List.of(CollectedEvent.script(host, baseTs, "powershell.exe", "explorer.exe",
+                "powershell -ExecutionPolicy Bypass -File C:\\Users\\park\\Downloads\\invoice_setup.ps1",
+                tenantId));
+    }
+
+    /** 시작프로그램 경로에 파일 생성. 단일 이벤트 point 룰. */
+    private static List<CollectedEvent> fileAutorun(String host, long baseTs, String tenantId) {
+        return List.of(CollectedEvent.file(host, baseTs, "svc-update.lnk",
+                "C:\\Users\\lee\\AppData\\Roaming\\Microsoft\\Windows\\Start Menu\\Programs\\Startup\\svc-update.lnk",
+                tenantId));
+    }
+
+    private static String require(Map<String, String> table, String name) {
+        String value = name == null ? null : table.get(name);
+        if (value == null) {
+            throw new IllegalArgumentException(
+                    "미지원 시나리오: " + name + " (지원: " + String.join(", ", NAMES) + ")");
+        }
+        return value;
+    }
+}

--- a/api-service/src/main/java/com/edrdog/apiservice/demo/DemoTenant.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/demo/DemoTenant.java
@@ -1,0 +1,40 @@
+package com.edrdog.apiservice.demo;
+
+import com.edrdog.apiservice.auth.repository.UserRepository;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+/**
+ * 데모 계정이 속한 tenant 를 찾는다. 데모 API 가 쓸 조직을 서버가 직접 결정하는 지점이다.
+ *
+ * <p>데모 API 는 로그인 토큰을 받지 않는다(발표자가 스웨거에서 토큰을 복사해 붙이는 건 실사용 흐름이 아니다).
+ * 대신 이 조회 결과가 두 가지를 동시에 해결한다.
+ *
+ * <ul>
+ *   <li>쓰기 대상 고정 — 발행되는 이벤트는 항상 데모 계정의 tenant 로만 태깅된다. 호출자가 tenant 를
+ *       지정할 수 없으니 남의 조직 데이터에 섞일 경로가 없다.</li>
+ *   <li>환경 게이팅 — 데모 계정은 시드({@code edrdog.demo.seed=true})로만 생긴다. 시드를 켠 적 없는
+ *       환경에서는 여기서 empty 가 나와 API 가 아무 일도 하지 않는다.</li>
+ * </ul>
+ *
+ * <p>PK 를 상수로 박지 않고 매번 조회하는 이유는, 데모 계정이 다른 tenant 에 붙어 있는 환경에서
+ * 상수(99)를 그대로 쓰면 엉뚱한 조직에 이벤트를 넣게 되기 때문이다.
+ */
+@Component
+public class DemoTenant {
+
+    private final UserRepository users;
+
+    public DemoTenant(UserRepository users) {
+        this.users = users;
+    }
+
+    /** 데모 계정의 tenant PK 문자열. 계정이 없는 환경이면 empty. */
+    @Transactional(readOnly = true)
+    public Optional<String> resolve() {
+        return users.findByEmail(DemoAccountSeeder.EMAIL)
+                .map(user -> String.valueOf(user.getTenantId()));
+    }
+}

--- a/api-service/src/main/java/com/edrdog/apiservice/demo/EventsProducer.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/demo/EventsProducer.java
@@ -1,0 +1,36 @@
+package com.edrdog.apiservice.demo;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+
+/**
+ * 데모 이벤트를 events 토픽으로 발행한다 (detector Kafka Streams 의 입력).
+ * host 를 파티션 키로 보내 같은 엔드포인트 이벤트의 순서를 보존한다 — 시퀀스 룰이 순서에 의존한다.
+ *
+ * <p>osquery 수집 입구(EventsRawProducer, events-raw)와 달리 정규화된 events 로 바로 보낸다.
+ * 발표에서 보여줄 구간이 "Kafka → Streams → Kafka" 라 collector 정규화 단계는 지나가지 않는다.
+ */
+@Component
+public class EventsProducer {
+
+    private final KafkaTemplate<String, String> template;
+    private final String eventsTopic;
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    public EventsProducer(KafkaTemplate<String, String> template,
+                          @Value("${edrdog.kafka.events-topic}") String eventsTopic) {
+        this.template = template;
+        this.eventsTopic = eventsTopic;
+    }
+
+    /** 이벤트 1건 발행. 인자 순서대로 같은 파티션에 쌓이므로 호출 순서가 곧 판정 순서다. */
+    public void publish(CollectedEvent event) {
+        try {
+            template.send(eventsTopic, event.host(), mapper.writeValueAsString(event));
+        } catch (Exception e) {
+            throw new IllegalStateException("데모 이벤트 발행 실패: " + event, e);
+        }
+    }
+}

--- a/api-service/src/main/java/com/edrdog/apiservice/demo/web/DemoController.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/demo/web/DemoController.java
@@ -1,0 +1,77 @@
+package com.edrdog.apiservice.demo.web;
+
+import com.edrdog.apiservice.demo.DemoAccountSeeder;
+import com.edrdog.apiservice.demo.DemoFlowService;
+import com.edrdog.apiservice.demo.DemoScenario;
+import com.edrdog.apiservice.demo.DemoTenant;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+
+/**
+ * 발표용 전체 플로우 시연 REST. 스웨거에서 Execute 한 번이면 끝난다 — 토큰을 받아 붙이는 단계가 없다.
+ *
+ * <p>엔드포인트 에이전트가 로그를 보낸 것처럼 events 토픽에 발행하고, detector 의 판정이 alerts 토픽으로
+ * 돌아와 저장되기까지를 한 번의 호출로 보여준다. 실제 파이프라인을 그대로 태우므로 Slack 알림(alert-service)과
+ * responder 조치 판단도 같이 흘러간다.
+ *
+ * <p>인증을 받지 않는 대신 할 수 있는 일을 좁혀 뒀다. 이 API 는
+ * <b>데모 계정의 tenant</b>({@link DemoTenant})에만 쓰고, <b>미리 정해진 시나리오 4종</b>만 발행한다.
+ * 호출자가 tenant 를 지정할 수도, 임의 이벤트를 넣을 수도 없어서 남의 조직 데이터에 닿을 경로가 없다.
+ * 데모 계정이 없는 환경(시드를 켠 적 없는 곳)에서는 403 으로 아무 일도 하지 않는다.
+ *
+ * <p>임의 이벤트를 발행하고 싶으면 detector 의 {@code POST /api/events} 를 쓴다. 그쪽은 발표용이 아니라
+ * 개발용이라 이 API 와 목적이 다르다.
+ */
+@RestController
+@RequestMapping("/api/demo")
+@Tag(name = "demo", description = "발표용 전체 플로우 시연 (데모 조직 전용, 인증 없이 클릭 한 번)")
+public class DemoController {
+
+    private final DemoFlowService flow;
+    private final DemoTenant demoTenant;
+
+    public DemoController(DemoFlowService flow, DemoTenant demoTenant) {
+        this.flow = flow;
+        this.demoTenant = demoTenant;
+    }
+
+    @Operation(summary = "엔드포인트 로그 수집 시연 (전체 플로우)",
+            description = "선택한 공격 시나리오의 로그를 엔드포인트가 보낸 것처럼 events 토픽으로 발행하고, "
+                    + "detector Kafka Streams 가 판정을 alerts 토픽으로 되돌려 저장되기까지 기다린 뒤 "
+                    + "단계별 소요시간과 결과를 한 번에 돌려준다. 평소 돌고 있던 정상 프로세스 로그도 함께 실려 "
+                    + "실제 수집처럼 보인다. 결과는 데모 계정으로 로그인한 대시보드에 그대로 나타난다.\n\n"
+                    + "- process-chain: 매크로 문서가 shell 실행 (T1059, HIGH)\n"
+                    + "- download-exec: 외부 다운로드 후 그 파일 실행 (T1105+T1204, CRITICAL)\n"
+                    + "- script-exec: 다운로드 경로 스크립트 실행 (T1059, MEDIUM)\n"
+                    + "- file-autorun: 시작프로그램 경로에 파일 생성 (T1547, MEDIUM)\n\n"
+                    + "host 를 비워두면 시나리오별 기본 호스트를 쓴다. 시나리오마다 기본 호스트를 다르게 둔 "
+                    + "이유는 detector 상관 버퍼가 host 별 5분이라 같은 호스트로 여러 시나리오를 연달아 돌리면 "
+                    + "의도한 룰이 아닌 다른 룰이 먼저 매칭될 수 있기 때문이다. "
+                    + "판정까지 기다리므로 응답에 수 초가 걸린다.")
+    @PostMapping("/collect/{scenario}")
+    public DemoFlowResponse collect(
+            @Parameter(description = "공격 시나리오",
+                    schema = @Schema(allowableValues = {"process-chain", "download-exec", "script-exec", "file-autorun"}))
+            @PathVariable String scenario,
+            @Parameter(description = "엔드포인트 식별자. 비우면 시나리오 기본 호스트")
+            @RequestParam(required = false) String host) {
+        if (!DemoScenario.isSupported(scenario)) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                    "미지원 시나리오: " + scenario + " (지원: " + String.join(", ", DemoScenario.names()) + ")");
+        }
+        String tenantId = demoTenant.resolve().orElseThrow(() -> new ResponseStatusException(
+                HttpStatus.FORBIDDEN,
+                "데모 계정(" + DemoAccountSeeder.EMAIL + ")이 없는 환경입니다. "
+                        + "발표 환경에서 DEMO_SEED=true 로 시드를 켜야 이 API 가 동작합니다"));
+        return flow.run(scenario, host, tenantId);
+    }
+}

--- a/api-service/src/main/java/com/edrdog/apiservice/demo/web/DemoFlowResponse.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/demo/web/DemoFlowResponse.java
@@ -1,0 +1,34 @@
+package com.edrdog.apiservice.demo.web;
+
+import com.edrdog.apiservice.alert.web.AlertResponse;
+import com.edrdog.apiservice.demo.CollectedEvent;
+
+import java.util.List;
+
+/**
+ * 데모 수집 API 응답. 한 번의 호출로 "엔드포인트 로그 발행 → 판정 → 저장" 전 구간을 담는다.
+ *
+ * @param scenario       실행한 시나리오 이름
+ * @param host           로그를 보낸 것으로 꾸민 엔드포인트
+ * @param tenantId       조직(tenant) 식별자
+ * @param pipeline       지나간 경로 한 줄 요약 (발표 슬라이드와 대조용)
+ * @param alertId        기대한 alert id — 발행 전에 결정되므로 조회 API 에 그대로 넣어볼 수 있다
+ * @param totalElapsedMs 전체 소요 시간
+ * @param steps          단계별 결과
+ * @param collectedLogs  발행한 이벤트 원본 (수집된 로그 그 자체)
+ * @param alert          저장까지 끝난 판정 결과. 아직 안 왔으면 null
+ * @param nextSteps      발표에서 이어서 눌러볼 API 안내
+ */
+public record DemoFlowResponse(
+        String scenario,
+        String host,
+        String tenantId,
+        String pipeline,
+        String alertId,
+        long totalElapsedMs,
+        List<DemoFlowStep> steps,
+        List<CollectedEvent> collectedLogs,
+        AlertResponse alert,
+        List<String> nextSteps
+) {
+}

--- a/api-service/src/main/java/com/edrdog/apiservice/demo/web/DemoFlowStep.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/demo/web/DemoFlowStep.java
@@ -1,0 +1,32 @@
+package com.edrdog.apiservice.demo.web;
+
+/**
+ * 데모 플로우 한 단계의 결과. 발표에서 "지금 어디까지 갔는지" 를 그대로 읽어 보여주는 용도다.
+ *
+ * @param no        단계 번호 (1부터)
+ * @param name      단계 이름 (수집 / 탐지 / 저장)
+ * @param path      그 단계가 지나간 경로 (예: api-service → Kafka(events))
+ * @param status    OK 또는 TIMEOUT
+ * @param elapsedMs 앞 단계 끝난 시점부터 이 단계까지 걸린 시간
+ * @param detail    사람이 읽을 설명 (무엇이 몇 건, 어떤 룰에 걸렸는지)
+ */
+public record DemoFlowStep(
+        int no,
+        String name,
+        String path,
+        String status,
+        long elapsedMs,
+        String detail
+) {
+
+    public static final String OK = "OK";
+    public static final String TIMEOUT = "TIMEOUT";
+
+    public static DemoFlowStep ok(int no, String name, String path, long elapsedMs, String detail) {
+        return new DemoFlowStep(no, name, path, OK, elapsedMs, detail);
+    }
+
+    public static DemoFlowStep timeout(int no, String name, String path, long elapsedMs, String detail) {
+        return new DemoFlowStep(no, name, path, TIMEOUT, elapsedMs, detail);
+    }
+}

--- a/api-service/src/main/java/com/edrdog/apiservice/security/ApiKeyPolicy.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/security/ApiKeyPolicy.java
@@ -16,6 +16,7 @@ public class ApiKeyPolicy {
             "/api/alerts",  // 알림 조회·트리아지도 세션 Bearer 로 인증(AlertController)
             "/api/hosts",   // 호스트 목록·요약도 세션 Bearer 로 인증(HostController)
             "/api/me",      // 유저 개인 알림 설정도 세션 Bearer 로 인증(UserNotifyController)
+            "/api/demo/",   // 발표용 데모 시연도 세션 Bearer 로 인증하고 데모 계정만 통과시킨다(DemoController)
             "/api/internal/",  // 서비스 간 조회는 별도 X-Internal-Key 로 인증(TenantController), 프론트 키와 분리
             "/api/osquery/"  // 엔드포인트 수집은 자체 enroll_secret/node_key 로 인증(OsqueryController), 프론트 키와 분리
     );

--- a/api-service/src/main/resources/application.yml
+++ b/api-service/src/main/resources/application.yml
@@ -22,6 +22,11 @@ spring:
     producer:                            # osquery 수집 원시 로그를 events-raw 로 발행(문자열)
       key-serializer: org.apache.kafka.common.serialization.StringSerializer
       value-serializer: org.apache.kafka.common.serialization.StringSerializer
+    # 발행/소비 스팬 생성 → Kafka 를 건너도 traceId 가 이어진다
+    template:
+      observation-enabled: true
+    listener:
+      observation-enabled: true
 
 server:
   port: 8084
@@ -67,3 +72,26 @@ management:
     web:
       exposure:
         include: health, info
+  # 관측 — otel-lgtm(k8s/otel-lgtm.yaml) 으로 OTLP 전송. 스택 없이 개발할 땐 OTEL_ENABLED=false.
+  tracing:
+    enabled: ${OTEL_ENABLED:true}
+    sampling:
+      probability: ${OTEL_TRACE_SAMPLING:1.0}      # 데모 규모라 전량 샘플링
+  otlp:
+    tracing:
+      endpoint: ${OTEL_EXPORTER_OTLP_ENDPOINT:http://localhost:4318}/v1/traces
+    metrics:
+      export:
+        enabled: ${OTEL_ENABLED:true}
+        url: ${OTEL_EXPORTER_OTLP_ENDPOINT:http://localhost:4318}/v1/metrics
+        step: 10s                                  # 기본 1m 은 데모에서 그래프가 늦게 뜬다
+        base-time-unit: seconds                    # Prometheus 관례(초 단위) — 대시보드 쿼리가 이 이름에 맞춰져 있다
+  metrics:
+    distribution:
+      # 버킷을 발행해야 Grafana 에서 p50/p95/p99 를 계산할 수 있다. 끄면 +Inf 버킷만 나가 분위수가 NaN 이 된다.
+      percentiles-histogram:
+        http.server.requests: true
+      minimum-expected-value:
+        http.server.requests: 5ms                  # 버킷 개수를 이 범위로 제한 (카디널리티 방어)
+      maximum-expected-value:
+        http.server.requests: 10s

--- a/api-service/src/main/resources/application.yml
+++ b/api-service/src/main/resources/application.yml
@@ -30,6 +30,7 @@ edrdog:
   kafka:
     alerts-topic: alerts                 # detector 가 발행한 판정 결과 (소비 → MySQL 적재)
     events-raw-topic: events-raw         # osquery 수집 원시 result-log (발행 → collector 정규화)
+    events-topic: events                 # 정규화된 이벤트 (발표용 데모 수집 API 가 발행 → detector 판정)
   osquery:
     tls:                                 # osquery 전용 HTTPS 커넥터 (프론트 HTTP 8084 와 별도 포트)
       enabled: ${OSQUERY_TLS_ENABLED:false}          # 켜면 keystore 필수 (scripts/gen-dev-keystore.sh)
@@ -44,6 +45,10 @@ edrdog:
     # 발표용 시드. 켜면 부팅 시 데모 계정(test/1234, tenantId=1)과 최근 7일치 과거 데이터를 만든다.
     # 운영에 test/1234 가 새면 안 되므로 기본은 off. 발표 환경에서만 DEMO_SEED=true 로 켠다.
     seed: ${DEMO_SEED:false}
+    # /api/demo/collect 가 판정을 기다리는 상한. Kafka 왕복(발행→스트림즈→alerts)과 ClickHouse 적재를
+    # 각각 기다린다. 발표 환경이 느려 TIMEOUT 이 뜨면 늘린다.
+    detect-timeout-ms: ${DEMO_DETECT_TIMEOUT_MS:12000}
+    store-timeout-ms: ${DEMO_STORE_TIMEOUT_MS:8000}
   cors:
     # 브라우저에서 API 를 호출할 프론트 출처 (쉼표 구분). 기본값은 Vite dev 서버.
     # 배포 시엔 실제 프론트 도메인을 환경변수로 주입한다.

--- a/api-service/src/test/java/com/edrdog/apiservice/demo/CollectedEventTest.java
+++ b/api-service/src/test/java/com/edrdog/apiservice/demo/CollectedEventTest.java
@@ -1,0 +1,39 @@
+package com.edrdog.apiservice.demo;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * events 토픽 발행 형태를 못박는다. detector 는 자기 사본 레코드(Event)로 역직렬화하므로 필드명이
+ * 하나라도 어긋나면 그 필드가 null 로 들어가 <b>아무 alert 도 안 뜨고 조용히 실패</b>한다.
+ *
+ * <p>detector 쪽 짝은 DemoCollectContractTest(같은 JSON 을 토폴로지에 흘려 alert 를 확인). 이 두 테스트가
+ * 같은 문자열을 각자 적고 있어야 한쪽만 바뀌었을 때 드러난다.
+ */
+class CollectedEventTest {
+
+    private final ObjectMapper mapper = new ObjectMapper();   // EventsProducer 와 같은 기본 설정
+
+    @Test
+    void process_이벤트_직렬화_형태() throws Exception {
+        CollectedEvent event = CollectedEvent.process("PC-01", 1000L, "powershell.exe", "winword.exe",
+                "powershell -enc AAA", "99");
+
+        assertEquals("{\"host\":\"PC-01\",\"type\":\"process\",\"ts\":1000,\"process\":\"powershell.exe\","
+                        + "\"parent\":\"winword.exe\",\"cmdline\":\"powershell -enc AAA\","
+                        + "\"destIp\":null,\"destPort\":0,\"tenantId\":\"99\"}",
+                mapper.writeValueAsString(event));
+    }
+
+    @Test
+    void network_이벤트_직렬화_형태() throws Exception {
+        CollectedEvent event = CollectedEvent.network("PC-01", 1000L, "chrome.exe", "185.220.101.5", 443, "99");
+
+        assertEquals("{\"host\":\"PC-01\",\"type\":\"network\",\"ts\":1000,\"process\":\"chrome.exe\","
+                        + "\"parent\":null,\"cmdline\":null,\"destIp\":\"185.220.101.5\","
+                        + "\"destPort\":443,\"tenantId\":\"99\"}",
+                mapper.writeValueAsString(event));
+    }
+}

--- a/api-service/src/test/java/com/edrdog/apiservice/demo/DemoApiWithoutSeedTest.java
+++ b/api-service/src/test/java/com/edrdog/apiservice/demo/DemoApiWithoutSeedTest.java
@@ -1,0 +1,50 @@
+package com.edrdog.apiservice.demo;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * 데모 계정이 없는 환경에서는 데모 API 가 아무 일도 하지 않는다는 계약.
+ *
+ * <p>이 API 는 인증을 받지 않으므로, "쓸 수 있는 환경" 을 가르는 것은 데모 계정의 존재 여부다.
+ * 계정은 시드({@code edrdog.demo.seed=true})로만 생기니, 시드를 켠 적 없는 환경에서는 tenant 를
+ * 찾지 못해 403 이 되고 이벤트가 한 건도 나가지 않는다. 시드 플래그로 빈을 끄는 것과 같은 효과이면서,
+ * 발표 환경에서는 파드 재시작 없이 바로 쓸 수 있다.
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.ANY)
+@TestPropertySource(properties = {
+        "spring.kafka.listener.auto-startup=false",
+        "edrdog.demo.seed=false"
+})
+class DemoApiWithoutSeedTest {
+
+    @Autowired
+    private MockMvc mvc;
+
+    @MockitoBean
+    private EventsProducer producer;
+
+    @Test
+    void 데모_계정이_없으면_403_이고_이벤트를_발행하지_않는다() throws Exception {
+        // 404 가 아니라 403 이어야 한다. 404 면 빈이 안 올라온 것이고, 그러면 발표 환경에서
+        // 시드만 켜서 쓸 수 있다는 성질(파드 재시작 불필요)이 깨진다.
+        mvc.perform(post("/api/demo/collect/script-exec"))
+                .andExpect(status().isForbidden());
+
+        verify(producer, never()).publish(any());
+    }
+}

--- a/api-service/src/test/java/com/edrdog/apiservice/demo/DemoCollectIntegrationTest.java
+++ b/api-service/src/test/java/com/edrdog/apiservice/demo/DemoCollectIntegrationTest.java
@@ -1,0 +1,149 @@
+package com.edrdog.apiservice.demo;
+
+import com.edrdog.apiservice.alert.AlertService;
+import com.edrdog.apiservice.alert.web.AlertResponse;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultMatcher;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * 발표용 데모 수집 API 배선 검증. 데모 시드를 켜고 전체 컨텍스트를 띄운다 — 발표 당일에 빈 배선이
+ * 어긋나 있는 것보다 여기서 깨지는 게 낫다.
+ *
+ * <p>인증 헤더 없이 호출된다는 것 자체가 계약이다(스웨거에서 Execute 한 번). 대신 발행 대상 tenant 를
+ * 호출자가 못 정하고 서버가 데모 계정에서 찾아 쓴다는 것을 함께 확인한다.
+ *
+ * <p>Kafka/ClickHouse 없이 확인하려고 발행(EventsProducer)·도착 관측(AlertArrivals)·조회(AlertService)를
+ * 목으로 대체하고, 컨트롤러가 무엇을 어떤 순서로 발행하고 어떤 타임라인을 만드는지만 검증한다.
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.ANY)
+@TestPropertySource(properties = {
+        "spring.kafka.listener.auto-startup=false",
+        "edrdog.demo.seed=true",
+        // 대기 상한을 짧게: 테스트가 실제 12초를 흘려보낼 이유가 없다
+        "edrdog.demo.detect-timeout-ms=300",
+        "edrdog.demo.store-timeout-ms=300"
+})
+class DemoCollectIntegrationTest {
+
+    @Autowired
+    private MockMvc mvc;
+
+    @Autowired
+    private ObjectMapper om;
+
+    @MockitoBean
+    private EventsProducer producer;     // Kafka 대신 목: 발행 인자와 순서만 검증
+
+    @MockitoBean
+    private AlertArrivals arrivals;      // alerts 토픽 도착 관측 대체
+
+    @MockitoBean
+    private AlertService alerts;         // ClickHouse 조회 대체
+
+    @Test
+    void 인증_없이_호출해도_수집부터_저장까지_타임라인이_나온다() throws Exception {
+        givenDetectionSucceeds();
+
+        JsonNode res = collect(DemoScenario.DOWNLOAD_EXEC, status().isOk());
+
+        assertEquals("download-exec", res.get("scenario").asText());
+        assertEquals("DESKTOP-CHOI", res.get("host").asText());   // 시나리오 기본 host
+        assertEquals(3, res.get("steps").size());
+        for (JsonNode step : res.get("steps")) {
+            assertEquals("OK", step.get("status").asText(), step.toString());
+        }
+        assertEquals("DOWNLOAD_AND_EXECUTE", res.get("alert").get("ruleId").asText());
+        assertTrue(res.get("alertId").asText().length() > 0);
+    }
+
+    @Test
+    void 발행_대상_tenant_는_데모_계정에서_찾은_값이다() throws Exception {
+        // 호출자가 tenant 를 지정할 방법이 없다는 것이 이 API 의 안전장치다.
+        givenDetectionSucceeds();
+
+        JsonNode res = collect(DemoScenario.DOWNLOAD_EXEC, status().isOk());
+
+        String demoTenant = String.valueOf(DemoAccountSeeder.TENANT_ID);
+        assertEquals(demoTenant, res.get("tenantId").asText());
+        ArgumentCaptor<CollectedEvent> captor = ArgumentCaptor.forClass(CollectedEvent.class);
+        verify(producer, Mockito.atLeastOnce()).publish(captor.capture());
+        assertTrue(captor.getAllValues().stream().allMatch(e -> demoTenant.equals(e.tenantId())));
+    }
+
+    @Test
+    void 발행_순서가_배경_로그_다음_공격_이벤트다() throws Exception {
+        givenDetectionSucceeds();
+
+        collect(DemoScenario.DOWNLOAD_EXEC, status().isOk());
+
+        ArgumentCaptor<CollectedEvent> captor = ArgumentCaptor.forClass(CollectedEvent.class);
+        verify(producer, Mockito.times(5)).publish(captor.capture());
+        List<CollectedEvent> published = captor.getAllValues();
+        assertEquals(List.of("OneDrive.exe", "Teams.exe", "MsEdgeUpdate.exe", "chrome.exe", "update32.exe"),
+                published.stream().map(CollectedEvent::process).toList());
+        assertEquals(CollectedEvent.TYPE_NETWORK, published.get(3).type());
+        assertTrue(published.stream().allMatch(e -> "DESKTOP-CHOI".equals(e.host())));
+    }
+
+    @Test
+    void 판정이_돌아오지_않으면_탐지_단계가_TIMEOUT_으로_남는다() throws Exception {
+        when(arrivals.arrivedAt(anyString())).thenReturn(Optional.empty());
+
+        JsonNode res = collect(DemoScenario.SCRIPT_EXEC, status().isOk());
+
+        assertEquals(2, res.get("steps").size());   // 수집 OK + 탐지 TIMEOUT (저장은 시도하지 않는다)
+        assertEquals("OK", res.get("steps").get(0).get("status").asText());
+        assertEquals("TIMEOUT", res.get("steps").get(1).get("status").asText());
+        assertTrue(res.get("steps").get(1).get("detail").asText().contains("300ms"));
+        assertTrue(res.get("alert").isNull());
+    }
+
+    @Test
+    void 미지원_시나리오는_400_이고_아무것도_발행하지_않는다() throws Exception {
+        collect("ransomware", status().isBadRequest());
+
+        verify(producer, Mockito.never()).publish(any());
+    }
+
+    /** 판정이 alerts 토픽으로 돌아오고 조회까지 되는 정상 경로. */
+    private void givenDetectionSucceeds() {
+        when(arrivals.arrivedAt(anyString())).thenReturn(Optional.of(System.currentTimeMillis()));
+        when(alerts.get(anyString(), anyString())).thenAnswer(inv -> new AlertResponse(
+                inv.getArgument(1), "DESKTOP-CHOI", "DOWNLOAD_AND_EXECUTE", "다운로드 후 실행",
+                "T1105+T1204", "CRITICAL", "kill", System.currentTimeMillis(), "open",
+                List.of("network 185.220.101.5:443", "process update32.exe")));
+    }
+
+    /** 헤더 하나 없이 호출한다 — 발표에서 스웨거 Execute 를 누르는 것과 같다. */
+    private JsonNode collect(String scenario, ResultMatcher expected) throws Exception {
+        String body = mvc.perform(post("/api/demo/collect/" + scenario))
+                .andExpect(expected)
+                .andReturn().getResponse().getContentAsString();
+        return body.isEmpty() ? om.createObjectNode() : om.readTree(body);
+    }
+}

--- a/api-service/src/test/java/com/edrdog/apiservice/demo/DemoScenarioTest.java
+++ b/api-service/src/test/java/com/edrdog/apiservice/demo/DemoScenarioTest.java
@@ -1,0 +1,155 @@
+package com.edrdog.apiservice.demo;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * 발표용 수집 시나리오 생성(순수). baseTs 를 받아 결정적으로 만들고,
+ * detector 룰을 의도한 것만 트리거하도록(배경 로그가 오탐을 만들지 않도록) 보장한다.
+ */
+class DemoScenarioTest {
+
+    private static final String TENANT = "99";
+    private static final long BASE = 1_770_000_000_000L;   // 고정 기준 시각 (결정성 확인용)
+
+    @Test
+    void 지원_시나리오는_네_종류다() {
+        assertEquals(List.of(DemoScenario.PROCESS_CHAIN, DemoScenario.DOWNLOAD_EXEC,
+                DemoScenario.SCRIPT_EXEC, DemoScenario.FILE_AUTORUN), DemoScenario.names());
+        assertTrue(DemoScenario.names().stream().allMatch(DemoScenario::isSupported));
+        assertFalse(DemoScenario.isSupported("ransomware"));
+        assertFalse(DemoScenario.isSupported(null));
+    }
+
+    @Test
+    void 미지원_시나리오는_예외다() {
+        assertThrows(IllegalArgumentException.class,
+                () -> DemoScenario.build("ransomware", "PC-01", BASE, TENANT));
+    }
+
+    @Test
+    void 같은_입력이면_항상_같은_결과다() {
+        for (String name : DemoScenario.names()) {
+            assertEquals(DemoScenario.build(name, "PC-01", BASE, TENANT),
+                    DemoScenario.build(name, "PC-01", BASE, TENANT));
+        }
+    }
+
+    @Test
+    void 모든_이벤트가_지정_host_와_tenant_로_태깅된다() {
+        for (String name : DemoScenario.names()) {
+            List<CollectedEvent> events = DemoScenario.build(name, "PC-01", BASE, TENANT);
+            assertTrue(events.stream().allMatch(e -> "PC-01".equals(e.host())), name);
+            assertTrue(events.stream().allMatch(e -> TENANT.equals(e.tenantId())), name);
+        }
+    }
+
+    @Test
+    void 발행_순서가_시간_순서와_같다() {
+        // detector 는 host 파티션 안 순서대로 상관하므로 선행 이벤트가 먼저 나가야 룰이 성립한다.
+        for (String name : DemoScenario.names()) {
+            List<CollectedEvent> events = DemoScenario.build(name, "PC-01", BASE, TENANT);
+            for (int i = 1; i < events.size(); i++) {
+                assertTrue(events.get(i - 1).ts() <= events.get(i).ts(), name + " #" + i);
+            }
+        }
+    }
+
+    @Test
+    void 배경_로그는_공격보다_앞서고_공격은_baseTs_부터_시작한다() {
+        for (String name : DemoScenario.names()) {
+            List<CollectedEvent> events = DemoScenario.build(name, "PC-01", BASE, TENANT);
+            assertTrue(events.stream().anyMatch(e -> e.ts() < BASE), name + " 배경 로그 없음");
+            assertTrue(events.stream().anyMatch(e -> e.ts() >= BASE), name + " 공격 이벤트 없음");
+        }
+    }
+
+    @Test
+    void 배경_로그에는_network_이벤트가_없다() {
+        // R2(다운로드 후 실행)는 "선행 network(80/443/8080) + 이후 process" 만으로 CRITICAL 을 낸다.
+        // 배경 소음에 network 를 섞으면 뒤따르는 정상 프로세스가 R2 오탐으로 잡힌다.
+        for (String name : DemoScenario.names()) {
+            List<CollectedEvent> background = DemoScenario.build(name, "PC-01", BASE, TENANT).stream()
+                    .filter(e -> e.ts() < BASE)
+                    .toList();
+            assertTrue(background.stream().noneMatch(e -> CollectedEvent.TYPE_NETWORK.equals(e.type())), name);
+        }
+    }
+
+    @Test
+    void 배경_프로세스는_detector_baseline_억제_대상_이름만_쓴다() {
+        // detector Rules.BASELINE_SAFE = {onedrive.exe, teams.exe, gupdate.exe, msedgeupdate.exe, update.exe}.
+        // 같은 시나리오를 5분 안에 재실행하면 앞 회차 network 이벤트가 버퍼에 남아 R2 가 배경 프로세스에
+        // CRITICAL 오탐을 낸다. 억제 대상 이름만 쓰면 그 경로가 막힌다.
+        Set<String> baselineSafe = Set.of("onedrive.exe", "teams.exe", "gupdate.exe", "msedgeupdate.exe", "update.exe");
+        for (String name : DemoScenario.names()) {
+            List<CollectedEvent> background = DemoScenario.build(name, "PC-01", BASE, TENANT).stream()
+                    .filter(e -> e.ts() < BASE)
+                    .toList();
+            assertFalse(background.isEmpty(), name);
+            assertTrue(background.stream().allMatch(e -> baselineSafe.contains(e.process().toLowerCase())),
+                    name + " 배경 프로세스가 baseline 억제 대상이 아니다");
+        }
+    }
+
+    @Test
+    void network_이벤트는_download_exec_에만_있다() {
+        for (String name : DemoScenario.names()) {
+            boolean hasNetwork = DemoScenario.build(name, "PC-01", BASE, TENANT).stream()
+                    .anyMatch(e -> CollectedEvent.TYPE_NETWORK.equals(e.type()));
+            assertEquals(DemoScenario.DOWNLOAD_EXEC.equals(name), hasNetwork, name);
+        }
+    }
+
+    @Test
+    void 판정을_트리거하는_이벤트는_마지막_이벤트다() {
+        // 기대 alert 의 ts = 마지막 이벤트 ts. 이 계약으로 alert id 를 미리 계산해 도착을 기다린다.
+        List<CollectedEvent> chain = DemoScenario.build(DemoScenario.PROCESS_CHAIN, "PC-01", BASE, TENANT);
+        CollectedEvent trigger = chain.get(chain.size() - 1);
+        assertEquals("powershell.exe", trigger.process());
+        assertEquals("winword.exe", trigger.parent());
+
+        List<CollectedEvent> download = DemoScenario.build(DemoScenario.DOWNLOAD_EXEC, "PC-01", BASE, TENANT);
+        assertEquals(CollectedEvent.TYPE_PROCESS, download.get(download.size() - 1).type());
+    }
+
+    @Test
+    void 시나리오별_기대_룰이_있다() {
+        assertEquals("SUSPICIOUS_PROCESS_CHAIN", DemoScenario.expectedRuleId(DemoScenario.PROCESS_CHAIN));
+        assertEquals("DOWNLOAD_AND_EXECUTE", DemoScenario.expectedRuleId(DemoScenario.DOWNLOAD_EXEC));
+        assertEquals("SCRIPT_FROM_TEMP_PATH", DemoScenario.expectedRuleId(DemoScenario.SCRIPT_EXEC));
+        assertEquals("FILE_IN_AUTORUN_PATH", DemoScenario.expectedRuleId(DemoScenario.FILE_AUTORUN));
+    }
+
+    @Test
+    void 시나리오별_기본_host_가_서로_다르다() {
+        // detector 상관 버퍼는 host 별 5분이라 같은 host 로 다른 시나리오를 연달아 돌리면
+        // 앞 시나리오의 선행 이벤트가 남아 다른 룰이 먼저 매칭될 수 있다.
+        Set<String> hosts = new HashSet<>();
+        for (String name : DemoScenario.names()) {
+            assertTrue(hosts.add(DemoScenario.defaultHost(name)), name + " host 중복");
+        }
+    }
+
+    @Test
+    void script_와_file_시나리오는_판정_경로를_cmdline_에_담는다() {
+        // R3/R4 는 cmdline 의 경로 표식으로 판정한다(process 는 basename).
+        List<CollectedEvent> script = DemoScenario.build(DemoScenario.SCRIPT_EXEC, "PC-01", BASE, TENANT);
+        CollectedEvent scriptTrigger = script.get(script.size() - 1);
+        assertEquals(CollectedEvent.TYPE_SCRIPT, scriptTrigger.type());
+        assertTrue(scriptTrigger.cmdline().toLowerCase().contains("\\downloads\\"));
+
+        List<CollectedEvent> file = DemoScenario.build(DemoScenario.FILE_AUTORUN, "PC-01", BASE, TENANT);
+        CollectedEvent fileTrigger = file.get(file.size() - 1);
+        assertEquals(CollectedEvent.TYPE_FILE, fileTrigger.type());
+        assertTrue(fileTrigger.cmdline().toLowerCase().contains("\\startup\\"));
+    }
+}

--- a/archiver-service/build.gradle
+++ b/archiver-service/build.gradle
@@ -3,4 +3,5 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'   // RestClient (ClickHouse HTTP)
     implementation 'org.springframework.kafka:spring-kafka'
     implementation 'com.fasterxml.jackson.core:jackson-databind'        // events JSON 역직렬화 + JSONEachRow 직렬화
+    implementation 'io.micrometer:micrometer-registry-otlp'             // 메트릭 OTLP 전송 (ClickHouse 적재 지연/컨슈머 랙 관측 대상)
 }

--- a/archiver-service/src/main/resources/application.yml
+++ b/archiver-service/src/main/resources/application.yml
@@ -11,6 +11,8 @@ spring:
       properties:
         spring.json.value.default.type: com.edrdog.archiverservice.dto.Event
         spring.json.trusted.packages: com.edrdog.archiverservice.dto
+    listener:
+      observation-enabled: true         # 컨슈머 스팬 생성 → 발행 측 traceId 를 이어받아 한 트레이스로 연결
 
 server:
   port: 8083
@@ -30,3 +32,26 @@ management:
     web:
       exposure:
         include: health, info
+  # 관측 — otel-lgtm(k8s/otel-lgtm.yaml) 으로 OTLP 전송. 스택 없이 개발할 땐 OTEL_ENABLED=false.
+  tracing:
+    enabled: ${OTEL_ENABLED:true}
+    sampling:
+      probability: ${OTEL_TRACE_SAMPLING:1.0}      # 데모 규모라 전량 샘플링
+  otlp:
+    tracing:
+      endpoint: ${OTEL_EXPORTER_OTLP_ENDPOINT:http://localhost:4318}/v1/traces
+    metrics:
+      export:
+        enabled: ${OTEL_ENABLED:true}
+        url: ${OTEL_EXPORTER_OTLP_ENDPOINT:http://localhost:4318}/v1/metrics
+        step: 10s                                  # 기본 1m 은 데모에서 그래프가 늦게 뜬다
+        base-time-unit: seconds                    # Prometheus 관례(초 단위) — 대시보드 쿼리가 이 이름에 맞춰져 있다
+  metrics:
+    distribution:
+      # 버킷을 발행해야 Grafana 에서 p50/p95/p99 를 계산할 수 있다. 끄면 +Inf 버킷만 나가 분위수가 NaN 이 된다.
+      percentiles-histogram:
+        http.server.requests: true
+      minimum-expected-value:
+        http.server.requests: 5ms                  # 버킷 개수를 이 범위로 제한 (카디널리티 방어)
+      maximum-expected-value:
+        http.server.requests: 10s

--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,11 @@ subprojects {
 
     dependencies {
         implementation 'org.springframework.boot:spring-boot-starter-actuator'
+        // 분산 트레이싱 — 전 서비스 공통. Kafka 로 흩어진 이벤트 흐름을 traceId 하나로 잇는 게 목적.
+        // Micrometer Observation -> OTel 브리지 -> OTLP 로 otel-lgtm(Tempo) 전송.
+        // 메트릭 익스포터(micrometer-registry-otlp)는 필요한 모듈에만 개별 추가한다.
+        implementation 'io.micrometer:micrometer-tracing-bridge-otel'
+        implementation 'io.opentelemetry:opentelemetry-exporter-otlp'
         testImplementation 'org.springframework.boot:spring-boot-starter-test'
         testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     }

--- a/collector-service/src/main/resources/application.yml
+++ b/collector-service/src/main/resources/application.yml
@@ -11,6 +11,11 @@ spring:
     producer:                           # 정규화 결과(Event JSON 문자열)를 events 로 발행
       key-serializer: org.apache.kafka.common.serialization.StringSerializer
       value-serializer: org.apache.kafka.common.serialization.StringSerializer
+    # 발행/소비 스팬 생성 → Kafka 를 건너도 traceId 가 이어진다
+    template:
+      observation-enabled: true
+    listener:
+      observation-enabled: true
 
 server:
   port: 8082
@@ -25,3 +30,11 @@ management:
     web:
       exposure:
         include: health, info
+  # 관측 — 트레이스만 보낸다(메트릭 익스포터는 api/detector/archiver 에만).
+  tracing:
+    enabled: ${OTEL_ENABLED:true}
+    sampling:
+      probability: ${OTEL_TRACE_SAMPLING:1.0}
+  otlp:
+    tracing:
+      endpoint: ${OTEL_EXPORTER_OTLP_ENDPOINT:http://localhost:4318}/v1/traces

--- a/detector-service/build.gradle
+++ b/detector-service/build.gradle
@@ -3,6 +3,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter'
     implementation 'org.springframework.boot:spring-boot-starter-web'    // 데모용 이벤트 발행/조회 REST + Swagger 호스팅
     implementation 'org.springframework.kafka:spring-kafka'
+    implementation 'io.micrometer:micrometer-registry-otlp'   // 메트릭 OTLP 전송 (판정 처리량/지연 관측 대상)
     implementation 'org.apache.kafka:kafka-streams'
     implementation 'com.fasterxml.jackson.core:jackson-databind'   // 이벤트 JSON serde
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.9'  // Swagger UI (/swagger-ui.html)

--- a/detector-service/src/main/resources/application.yml
+++ b/detector-service/src/main/resources/application.yml
@@ -17,6 +17,11 @@ spring:
       auto-offset-reset: latest
       key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
       value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+    # 발행/소비 스팬 생성 → Kafka 를 건너도 traceId 가 이어진다
+    template:
+      observation-enabled: true
+    listener:
+      observation-enabled: true
 
 server:
   port: 8081
@@ -31,3 +36,26 @@ management:
     web:
       exposure:
         include: health, info
+  # 관측 — otel-lgtm(k8s/otel-lgtm.yaml) 으로 OTLP 전송. 스택 없이 개발할 땐 OTEL_ENABLED=false.
+  tracing:
+    enabled: ${OTEL_ENABLED:true}
+    sampling:
+      probability: ${OTEL_TRACE_SAMPLING:1.0}      # 데모 규모라 전량 샘플링
+  otlp:
+    tracing:
+      endpoint: ${OTEL_EXPORTER_OTLP_ENDPOINT:http://localhost:4318}/v1/traces
+    metrics:
+      export:
+        enabled: ${OTEL_ENABLED:true}
+        url: ${OTEL_EXPORTER_OTLP_ENDPOINT:http://localhost:4318}/v1/metrics
+        step: 10s                                  # 기본 1m 은 데모에서 그래프가 늦게 뜬다
+        base-time-unit: seconds                    # Prometheus 관례(초 단위) — 대시보드 쿼리가 이 이름에 맞춰져 있다
+  metrics:
+    distribution:
+      # 버킷을 발행해야 Grafana 에서 p50/p95/p99 를 계산할 수 있다. 끄면 +Inf 버킷만 나가 분위수가 NaN 이 된다.
+      percentiles-histogram:
+        http.server.requests: true
+      minimum-expected-value:
+        http.server.requests: 5ms                  # 버킷 개수를 이 범위로 제한 (카디널리티 방어)
+      maximum-expected-value:
+        http.server.requests: 10s

--- a/detector-service/src/test/java/com/edrdog/detectorservice/kafkastreams/topology/DemoCollectContractTest.java
+++ b/detector-service/src/test/java/com/edrdog/detectorservice/kafkastreams/topology/DemoCollectContractTest.java
@@ -1,0 +1,184 @@
+package com.edrdog.detectorservice.kafkastreams.topology;
+
+import com.edrdog.detectorservice.dto.Alert;
+import com.edrdog.detectorservice.dto.Event;
+import com.edrdog.detectorservice.kafkastreams.serde.JsonSerde;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.streams.TestInputTopic;
+import org.apache.kafka.streams.TestOutputTopic;
+import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.TopologyTestDriver;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Properties;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * api-service 의 발표용 수집 API(POST /api/demo/collect/{scenario})가 events 토픽에 넣는
+ * <b>실제 JSON 그대로</b>를 토폴로지에 흘려 의도한 alert 가 나오는지 검증한다.
+ *
+ * <p>api-service 는 자기 사본 레코드(CollectedEvent)를 직렬화해 발행한다. 필드명이 detector 의
+ * {@link Event} 와 하나라도 어긋나면 그 필드가 null 로 역직렬화돼 <b>아무 alert 도 안 뜨고 조용히 실패</b>한다.
+ * 발표 당일에 그걸 발견하는 대신 여기서 깨지게 한다. JSON 을 문자열 리터럴로 박는 것이 요점이다 —
+ * 양쪽 레코드를 공유하면 이름이 같이 바뀌어 어긋남을 못 잡는다.
+ *
+ * <p>배경 로그가 어떤 룰도 트리거하지 않는다는 것(정확히 1건만 발행된다는 것)도 같이 확인한다.
+ */
+class DemoCollectContractTest {
+
+    private static final String EVENTS = "events";
+    private static final String ALERTS = "alerts";
+
+    /** 발표용 배경 로그 3건. detector 의 baseline 억제 대상 이름이라 어떤 룰도 트리거하지 않아야 한다. */
+    private static final List<String> BACKGROUND = List.of(
+            json("DESKTOP-DEMO", "process", 88_000, "OneDrive.exe", "explorer.exe",
+                    "\\\"C:\\\\Program Files\\\\Microsoft OneDrive\\\\OneDrive.exe\\\" /background", null, 0),
+            json("DESKTOP-DEMO", "process", 92_000, "Teams.exe", "explorer.exe",
+                    "\\\"C:\\\\Users\\\\Public\\\\AppData\\\\Local\\\\Microsoft\\\\Teams\\\\Teams.exe\\\"", null, 0),
+            json("DESKTOP-DEMO", "process", 96_000, "MsEdgeUpdate.exe", "services.exe",
+                    "\\\"C:\\\\Program Files (x86)\\\\Microsoft\\\\EdgeUpdate\\\\MicrosoftEdgeUpdate.exe\\\" /svc", null, 0));
+
+    private TopologyTestDriver driver;
+    private TestInputTopic<String, String> events;
+    private TestOutputTopic<String, Alert> alerts;
+
+    @BeforeEach
+    void setUp() {
+        StreamsBuilder builder = new StreamsBuilder();
+        DetectionTopology.build(builder, EVENTS, ALERTS, DetectionTopology.WINDOW_MS);
+
+        Properties props = new Properties();
+        props.put("application.id", "detector-demo-contract");
+        props.put("bootstrap.servers", "dummy:9092");
+
+        driver = new TopologyTestDriver(builder.build(), props);
+        // api-service 는 JSON 문자열로 발행한다. 역직렬화까지 포함해 검증하려고 String 으로 넣는다.
+        events = driver.createInputTopic(EVENTS, Serdes.String().serializer(), Serdes.String().serializer());
+        alerts = driver.createOutputTopic(ALERTS, Serdes.String().deserializer(),
+                new JsonSerde<>(Alert.class).deserializer());
+    }
+
+    @AfterEach
+    void tearDown() {
+        driver.close();
+    }
+
+    @Test
+    @DisplayName("배경 로그만 흘리면 어떤 alert 도 안 뜬다")
+    void background_noAlert() {
+        BACKGROUND.forEach(this::send);
+
+        assertThat(alerts.isEmpty()).isTrue();
+    }
+
+    @Test
+    @DisplayName("process-chain: 배경 로그 + 매크로 문서 체인 → HIGH 1건만")
+    void processChain() {
+        BACKGROUND.forEach(this::send);
+        send(json("DESKTOP-DEMO", "process", 100_000, "winword.exe", "explorer.exe",
+                "\\\"C:\\\\Users\\\\kim\\\\Documents\\\\견적서_2026.docm\\\"", null, 0));
+        send(json("DESKTOP-DEMO", "process", 101_000, "powershell.exe", "winword.exe",
+                "powershell -nop -w hidden -enc SQBFAFgAIAAoAE4AZQB3AC0ATwBiAGoA...", null, 0));
+
+        Alert alert = onlyAlert();
+        assertThat(alert.ruleId()).isEqualTo("SUSPICIOUS_PROCESS_CHAIN");
+        assertThat(alert.mitre()).isEqualTo("T1059");
+        assertThat(alert.severity()).isEqualTo(Alert.SEV_HIGH);
+        assertThat(alert.ts()).isEqualTo(101_000);      // 판정 ts = 마지막 이벤트 ts (alert id 계산 근거)
+        assertThat(alert.tenantId()).isEqualTo("99");
+    }
+
+    @Test
+    @DisplayName("download-exec: 배경 로그 + 다운로드 후 실행 → CRITICAL 1건만")
+    void downloadExec() {
+        BACKGROUND.forEach(this::send);
+        send(json("DESKTOP-DEMO", "network", 100_000, "chrome.exe", null, null, "185.220.101.5", 443));
+        send(json("DESKTOP-DEMO", "process", 101_000, "update32.exe", "explorer.exe",
+                "C:\\\\Users\\\\choi\\\\Downloads\\\\update32.exe", null, 0));
+
+        Alert alert = onlyAlert();
+        assertThat(alert.ruleId()).isEqualTo("DOWNLOAD_AND_EXECUTE");
+        assertThat(alert.severity()).isEqualTo(Alert.SEV_CRITICAL);
+        assertThat(alert.ts()).isEqualTo(101_000);
+    }
+
+    @Test
+    @DisplayName("script-exec: 다운로드 경로 스크립트 → MEDIUM 1건만")
+    void scriptExec() {
+        BACKGROUND.forEach(this::send);
+        send(json("DESKTOP-DEMO", "script", 100_000, "powershell.exe", "explorer.exe",
+                "powershell -ExecutionPolicy Bypass -File C:\\\\Users\\\\park\\\\Downloads\\\\invoice_setup.ps1",
+                null, 0));
+
+        Alert alert = onlyAlert();
+        assertThat(alert.ruleId()).isEqualTo("SCRIPT_FROM_TEMP_PATH");
+        assertThat(alert.severity()).isEqualTo(Alert.SEV_MEDIUM);
+        assertThat(alert.ts()).isEqualTo(100_000);
+    }
+
+    @Test
+    @DisplayName("file-autorun: 시작프로그램 경로 파일 생성 → MEDIUM 1건만")
+    void fileAutorun() {
+        BACKGROUND.forEach(this::send);
+        send(json("DESKTOP-DEMO", "file", 100_000, "svc-update.lnk", null,
+                "C:\\\\Users\\\\lee\\\\AppData\\\\Roaming\\\\Microsoft\\\\Windows\\\\Start Menu"
+                        + "\\\\Programs\\\\Startup\\\\svc-update.lnk", null, 0));
+
+        Alert alert = onlyAlert();
+        assertThat(alert.ruleId()).isEqualTo("FILE_IN_AUTORUN_PATH");
+        assertThat(alert.mitre()).isEqualTo("T1547");
+        assertThat(alert.ts()).isEqualTo(100_000);
+    }
+
+    @Test
+    @DisplayName("같은 시나리오를 윈도우 안에서 두 번 돌려도 배경 로그가 오탐을 만들지 않는다")
+    void repeatedRun_noFalsePositiveOnBackground() {
+        // 1회차 network 이벤트가 버퍼에 남은 상태에서 2회차 배경 로그가 들어온다.
+        // 배경 프로세스가 baseline 억제 대상이 아니면 여기서 R2 오탐이 잡힌다.
+        BACKGROUND.forEach(this::send);
+        send(json("DESKTOP-DEMO", "network", 100_000, "chrome.exe", null, null, "185.220.101.5", 443));
+        send(json("DESKTOP-DEMO", "process", 101_000, "update32.exe", "explorer.exe",
+                "C:\\\\Users\\\\choi\\\\Downloads\\\\update32.exe", null, 0));
+        assertThat(alerts.getQueueSize()).isEqualTo(1);
+        alerts.readValue();
+
+        BACKGROUND.forEach(this::send);   // 2회차 배경 로그 — 오탐이 나오면 안 된다
+
+        assertThat(alerts.isEmpty()).isTrue();
+    }
+
+    private void send(String eventJson) {
+        events.pipeInput("DESKTOP-DEMO", eventJson);
+    }
+
+    private Alert onlyAlert() {
+        assertThat(alerts.getQueueSize()).isEqualTo(1);
+        return alerts.readValue();
+    }
+
+    /**
+     * api-service 의 CollectedEvent 를 Jackson 이 직렬화한 형태 그대로. 필드명을 손으로 적는 것이 요점이다
+     * (레코드를 공유하면 이름이 같이 바뀌어 어긋남을 못 잡는다).
+     */
+    private static String json(String host, String type, long ts, String process, String parent,
+                               String cmdline, String destIp, int destPort) {
+        return "{\"host\":" + quoted(host)
+                + ",\"type\":" + quoted(type)
+                + ",\"ts\":" + ts
+                + ",\"process\":" + quoted(process)
+                + ",\"parent\":" + quoted(parent)
+                + ",\"cmdline\":" + quoted(cmdline)
+                + ",\"destIp\":" + quoted(destIp)
+                + ",\"destPort\":" + destPort
+                + ",\"tenantId\":\"99\"}";
+    }
+
+    private static String quoted(String value) {
+        return value == null ? "null" : "\"" + value + "\"";
+    }
+}

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -1,6 +1,6 @@
 # EDRdog 로컬 인프라 (k8s / kind)
 
-모든 모듈의 전제. kind 클러스터에 Kafka(토픽 `events`/`alerts`) + ClickHouse 를 띄운다.
+모든 모듈의 전제. kind 클러스터에 Kafka(토픽 `events`/`alerts`) + ClickHouse + 모니터링 스택을 띄운다.
 호스트에서 도는 Spring 서비스가 NodePort 매핑으로 접근한다.
 
 ## 기동
@@ -8,7 +8,8 @@
 ```bash
 kind create cluster --config k8s/kind-cluster.yaml   # 클러스터 생성 (name: edrdog)
 # kind-cluster.yaml 은 kind 전용이라 apply 대상에서 제외 (아래는 실제 매니페스트만)
-kubectl apply -f k8s/00-namespace.yaml -f k8s/kafka.yaml -f k8s/clickhouse.yaml
+kubectl apply -f k8s/00-namespace.yaml -f k8s/kafka.yaml -f k8s/clickhouse.yaml \
+              -f k8s/otel-lgtm.yaml -f k8s/alloy.yaml
 kubectl -n edrdog get pods                            # Running 확인
 ```
 
@@ -19,8 +20,12 @@ kubectl -n edrdog get pods                            # Running 확인
 | Kafka | `localhost:9092` | detector 등 (EXTERNAL 리스너) |
 | ClickHouse HTTP | `http://localhost:8123` | user/pw/db = `edrdog` |
 | ClickHouse native | `localhost:9000` | JDBC/드라이버용 |
+| Grafana | `http://localhost:3000` | admin / admin. 첫 화면이 EDRdog Overview |
+| OTLP HTTP | `http://localhost:4318` | 서비스가 메트릭·트레이스를 보내는 곳 |
+| OTLP gRPC | `localhost:4317` | 〃 |
 
 클러스터 내부(파드 간) Kafka 주소: `kafka.edrdog.svc.cluster.local:9094`
+클러스터 내부 OTLP 주소: `http://otel-lgtm:4318` (각 서비스 Deployment 의 `OTEL_EXPORTER_OTLP_ENDPOINT`)
 
 ## 확인
 
@@ -31,6 +36,13 @@ kubectl -n edrdog exec deploy/kafka -- \
 
 # ClickHouse ping
 curl http://localhost:8123/ping     # -> Ok.
+
+# Grafana 헬스 + 대시보드 프로비저닝 확인 (EDRdog 폴더에 4개 있어야 함)
+curl http://localhost:3000/api/health
+curl "http://localhost:3000/api/search?type=dash-db"
+
+# 로그 수집 확인 (수집 중인 서비스 목록)
+curl "http://localhost:3000/api/datasources/proxy/uid/loki/loki/api/v1/label/service_name/values"
 ```
 
 ## 종료
@@ -44,3 +56,33 @@ kind delete cluster --name edrdog    # 클러스터째 삭제 (데이터 emptyDi
 - 개발용이라 **영속성 없음**(emptyDir). 파드 재시작 시 데이터 소멸.
 - ClickHouse `edrdog.events` **테이블은 archiver 부팅 시 자동 생성**(`CREATE TABLE IF NOT EXISTS`). 여기선 `edrdog` DB 만 준비.
 - watchdog 클러스터와 호스트 포트(9092/8123/9000)가 겹치므로 **동시 실행 불가**.
+- `extraPortMappings` 는 **클러스터 생성 시에만** 반영된다. 이미 만들어 둔 클러스터에 3000/4317/4318 을 뚫으려면
+  클러스터를 다시 만들거나 `kubectl -n edrdog port-forward svc/otel-lgtm 3000:3000 4318:4318` 로 우회한다.
+
+## 모니터링 (otel-lgtm)
+
+- 구성: Grafana + Prometheus + Tempo + Loki 올인원 이미지(`grafana/otel-lgtm`) + 로그 수집기 Alloy(`k8s/alloy.yaml`).
+- 신호별 경로
+  - **메트릭**: api / detector / archiver 만 OTLP 로 전송 (`micrometer-registry-otlp` 를 그 3개 모듈 `build.gradle` 에만 추가)
+  - **트레이스**: 6개 서비스 전부 OTLP 로 전송
+  - **로그**: 앱은 그냥 stdout 에 찍고, Alloy 가 `*-service` 파드 로그를 읽어 Loki 로 보낸다 (앱 코드 변경 없음)
+- Kafka 발행·소비 구간에도 스팬이 생겨(`spring.kafka.*.observation-enabled`), api → collector → detector → archiver 흐름이
+  트레이스 하나로 이어진다.
+- 로그에는 Spring 기본 패턴의 `[traceId-spanId]` 를 Alloy 가 뽑아 structured metadata 로 붙인다.
+  Grafana 에서 로그 한 줄을 펼치면 trace_id 링크로 Tempo 트레이스까지 바로 넘어간다.
+- 대시보드는 **EDRdog 폴더에 4개**. 첫 화면은 Overview.
+
+  | 대시보드 | 내용 |
+  |---|---|
+  | EDRdog Overview | 요청률·에러율·p95·컨슈머 랙 요약, 서비스별 트래픽, 힙, 로그 볼륨 |
+  | EDRdog HTTP | 상태코드별 요청률, 분위(p50/95/99), 느린·많이 불린 엔드포인트 Top |
+  | EDRdog JVM & Kafka | 힙/GC/스레드/클래스, 컨슈머 랙·소비 처리량·커밋률 |
+  | EDRdog Logs & Traces | 레벨별 로그 볼륨, 로그 스트림, 에러 로그, 최근 트레이스 목록 |
+
+  이미지 기본 대시보드(RED / JVM Overview)도 루트에 그대로 남아 있다.
+  대시보드를 고치려면 `otel-lgtm.yaml` ConfigMap 안의 JSON 을 고치고 apply 한 뒤 파드를 재시작한다
+  (subPath 마운트라 ConfigMap 만 바꿔서는 반영되지 않는다).
+- 스택 없이 서비스만 띄우려면 `OTEL_ENABLED=false`. 샘플링은 `OTEL_TRACE_SAMPLING`(기본 1.0 = 전량).
+- **Grafana 는 비번 없이 들어가진다.** otel-lgtm 이미지가 익명 접속을 Admin 권한으로 열어두기 때문이다
+  (`GF_AUTH_ANONYMOUS_ENABLED=true`, `GF_AUTH_ANONYMOUS_ORG_ROLE=Admin`). 데모용으로 편한 대신,
+  포트에 닿는 사람은 누구나 설정을 바꿀 수 있다. 오래 띄워둘 거면 이 두 env 를 Deployment 에서 꺼야 한다.

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -66,6 +66,8 @@ kind delete cluster --name edrdog    # 클러스터째 삭제 (데이터 emptyDi
   - **메트릭**: api / detector / archiver 만 OTLP 로 전송 (`micrometer-registry-otlp` 를 그 3개 모듈 `build.gradle` 에만 추가)
   - **트레이스**: 6개 서비스 전부 OTLP 로 전송
   - **로그**: 앱은 그냥 stdout 에 찍고, Alloy 가 `*-service` 파드 로그를 읽어 Loki 로 보낸다 (앱 코드 변경 없음)
+  - **인프라 메트릭**: Alloy 가 kubelet 의 cAdvisor·resource 엔드포인트를 긁어 컨테이너·노드 CPU/메모리를
+    Prometheus 로 remote write 한다. 별도 exporter 를 띄우지 않는다.
 - Kafka 발행·소비 구간에도 스팬이 생겨(`spring.kafka.*.observation-enabled`), api → collector → detector → archiver 흐름이
   트레이스 하나로 이어진다.
 - 로그에는 Spring 기본 패턴의 `[traceId-spanId]` 를 Alloy 가 뽑아 structured metadata 로 붙인다.
@@ -76,13 +78,16 @@ kind delete cluster --name edrdog    # 클러스터째 삭제 (데이터 emptyDi
   |---|---|
   | EDRdog Overview | 요청률·에러율·p95·컨슈머 랙 요약, 서비스별 트래픽, 힙, 로그 볼륨 |
   | EDRdog HTTP | 상태코드별 요청률, 분위(p50/95/99), 느린·많이 불린 엔드포인트 Top |
-  | EDRdog JVM & Kafka | 힙/GC/스레드/클래스, 컨슈머 랙·소비 처리량·커밋률 |
+  | EDRdog Resources | 힙/GC/스레드/클래스, 컨슈머 랙·소비 처리량·커밋률, 컨테이너·노드 CPU/메모리 |
   | EDRdog Logs & Traces | 레벨별 로그 볼륨, 로그 스트림, 에러 로그, 최근 트레이스 목록 |
 
   이미지 기본 대시보드(RED / JVM Overview)도 루트에 그대로 남아 있다.
   대시보드를 고치려면 `otel-lgtm.yaml` ConfigMap 안의 JSON 을 고치고 apply 한 뒤 파드를 재시작한다
   (subPath 마운트라 ConfigMap 만 바꿔서는 반영되지 않는다).
 - 스택 없이 서비스만 띄우려면 `OTEL_ENABLED=false`. 샘플링은 `OTEL_TRACE_SAMPLING`(기본 1.0 = 전량).
+- 지표는 **PVC(`otel-lgtm-data`, 5Gi)** 에 남는다. 여기만 emptyDir 이 아니다. 파드가 재시작돼도 그동안의
+  지표·로그·트레이스가 살아 있어야 발표 중에 그래프가 비지 않기 때문이다. 기본 StorageClass 를 쓴다.
+  RWO 볼륨이라 Deployment 전략은 `Recreate`(롤링이면 새 파드가 볼륨을 못 잡고 서로 기다린다).
 - **Grafana 는 비번 없이 들어가진다.** otel-lgtm 이미지가 익명 접속을 Admin 권한으로 열어두기 때문이다
   (`GF_AUTH_ANONYMOUS_ENABLED=true`, `GF_AUTH_ANONYMOUS_ORG_ROLE=Admin`). 데모용으로 편한 대신,
   포트에 닿는 사람은 누구나 설정을 바꿀 수 있다. 오래 띄워둘 거면 이 두 env 를 Deployment 에서 꺼야 한다.

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -51,6 +51,19 @@ curl "http://localhost:3000/api/datasources/proxy/uid/loki/loki/api/v1/label/ser
 kind delete cluster --name edrdog    # 클러스터째 삭제 (데이터 emptyDir 라 함께 소멸)
 ```
 
+## 시크릿 (Infisical)
+
+매니페스트에 평문으로 박혀 있던 값(`DB_PASSWORD`, `CLICKHOUSE_PASSWORD` 등)을 Infisical 로 옮긴다.
+Operator 가 Infisical 을 읽어 `edrdog-secrets` k8s Secret 으로 동기화하고, 서비스는 그 Secret 을 `envFrom` 으로 받는다.
+
+설치와 연결 절차는 `k8s/infisical.yaml` 주석에 있다. 요약하면 Operator 설치 1회,
+Machine Identity 자격증명 Secret 생성 1회, `kubectl apply -f k8s/infisical.yaml`, 서비스에 `envFrom` patch.
+
+- 릴리스된 Operator(v0.11.5)에는 문서에 나오는 v1beta1 CRD 가 아직 없다. 실제로 도는 건 v1alpha1 `InfisicalSecret` 이다.
+- Deployment 에 같은 이름의 env 가 직접 박혀 있으면 그쪽이 `envFrom` 을 이긴다. Infisical 값을 쓰려면
+  `kubectl -n edrdog set env deployment/<이름> <키>-` 로 기존 env 를 먼저 지운다.
+- CD 는 `infisicalsecrets` CRD 가 있을 때만 이 파일을 apply 한다. Operator 가 없으면 건너뛴다.
+
 ## 메모
 
 - 개발용이라 **영속성 없음**(emptyDir). 파드 재시작 시 데이터 소멸.

--- a/k8s/alert-service.yaml
+++ b/k8s/alert-service.yaml
@@ -27,6 +27,9 @@ spec:
             # tenant Slack webhook 조회용 api-service 내부 엔드포인트 (Service port 80)
             - name: EDRDOG_API_BASE_URL
               value: "http://api-service"
+            # 트레이스 OTLP 수집기 (k8s/otel-lgtm.yaml)
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: "http://otel-lgtm:4318"
           readinessProbe:
             httpGet:
               path: /actuator/health

--- a/k8s/alloy.yaml
+++ b/k8s/alloy.yaml
@@ -22,6 +22,12 @@ rules:
   - apiGroups: [""]
     resources: ["pods", "pods/log", "namespaces"]
     verbs: ["get", "list", "watch"]
+  # 인프라 메트릭: kubelet 이 노출하는 컨테이너/노드 사용량을 긁기 위해 필요
+  - apiGroups: [""]
+    resources: ["nodes", "nodes/metrics", "nodes/proxy"]
+    verbs: ["get", "list", "watch"]
+  - nonResourceURLs: ["/metrics", "/metrics/cadvisor", "/metrics/resource"]
+    verbs: ["get"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -124,6 +130,76 @@ data:
     loki.write "otel_lgtm" {
       endpoint {
         url = "http://otel-lgtm:3100/loki/api/v1/push"
+      }
+    }
+
+    // ---- 인프라 메트릭 ----
+    // 앱이 내보내는 JVM 지표만으로는 "힙은 여유로운데 파드가 왜 느리지" 같은 상황을 못 본다.
+    // kubelet 이 이미 노출하고 있는 컨테이너·노드 사용량을 긁어 채운다(별도 exporter 배포 없음).
+    discovery.kubernetes "nodes" {
+      role = "node"
+    }
+
+    discovery.relabel "cadvisor" {
+      targets = discovery.kubernetes.nodes.targets
+
+      rule {
+        target_label = "__metrics_path__"
+        replacement  = "/metrics/cadvisor"
+      }
+    }
+
+    discovery.relabel "kubelet_resource" {
+      targets = discovery.kubernetes.nodes.targets
+
+      rule {
+        target_label = "__metrics_path__"
+        replacement  = "/metrics/resource"
+      }
+    }
+
+    // 컨테이너별 CPU·메모리·네트워크
+    prometheus.scrape "cadvisor" {
+      targets           = discovery.relabel.cadvisor.output
+      forward_to        = [prometheus.relabel.infra.receiver]
+      job_name          = "kubelet/cadvisor"
+      scheme            = "https"
+      scrape_interval   = "30s"
+      bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+
+      tls_config {
+        insecure_skip_verify = true
+      }
+    }
+
+    // 노드 전체 CPU·메모리
+    prometheus.scrape "kubelet_resource" {
+      targets           = discovery.relabel.kubelet_resource.output
+      forward_to        = [prometheus.relabel.infra.receiver]
+      job_name          = "kubelet/resource"
+      scheme            = "https"
+      scrape_interval   = "30s"
+      bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+
+      tls_config {
+        insecure_skip_verify = true
+      }
+    }
+
+    // cAdvisor 는 시리즈가 수천 개다. 대시보드에서 실제로 쓰는 것만 남긴다.
+    prometheus.relabel "infra" {
+      forward_to = [prometheus.remote_write.otel_lgtm.receiver]
+
+      rule {
+        source_labels = ["__name__"]
+        regex         = "container_cpu_usage_seconds_total|container_memory_working_set_bytes|container_network_receive_bytes_total|container_network_transmit_bytes_total|node_cpu_usage_seconds_total|node_memory_working_set_bytes|machine_cpu_cores|machine_memory_bytes"
+        action        = "keep"
+      }
+    }
+
+    prometheus.remote_write "otel_lgtm" {
+      endpoint {
+        url = "http://otel-lgtm:9090/api/v1/write"
       }
     }
 ---

--- a/k8s/alloy.yaml
+++ b/k8s/alloy.yaml
@@ -1,0 +1,176 @@
+# 로그 수집 (Grafana Alloy) — edrdog 네임스페이스 파드의 stdout 을 읽어 otel-lgtm 안의 Loki 로 보낸다.
+# 앱은 건드리지 않는다. Spring 기본 로그 패턴에 이미 [traceId-spanId] 가 찍히므로
+# 그것만 뽑아 structured metadata 로 붙여 두면 Grafana 에서 로그 -> 트레이스로 바로 넘어갈 수 있다.
+#
+#   기동:  kubectl apply -f k8s/alloy.yaml
+#   확인:  Grafana > Dashboards > EDRdog > Logs & Traces
+#
+# DaemonSet 이 아니라 단일 Deployment 인 이유: loki.source.kubernetes 는 노드 파일이 아니라
+# 쿠버네티스 API 로 로그를 읽는다. DaemonSet 으로 띄우면 노드마다 같은 파드를 중복 수집한다.
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: alloy
+  namespace: edrdog
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: edrdog-alloy-logs
+rules:
+  - apiGroups: [""]
+    resources: ["pods", "pods/log", "namespaces"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: edrdog-alloy-logs
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: edrdog-alloy-logs
+subjects:
+  - kind: ServiceAccount
+    name: alloy
+    namespace: edrdog
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: alloy-config
+  namespace: edrdog
+data:
+  config.alloy: |
+    // 수집 대상: edrdog 네임스페이스 파드만
+    discovery.kubernetes "pods" {
+      role = "pod"
+
+      namespaces {
+        names = ["edrdog"]
+      }
+    }
+
+    // 파드 메타데이터를 Loki 라벨로 (카디널리티가 낮은 것만 라벨로 승격)
+    discovery.relabel "pods" {
+      targets = discovery.kubernetes.pods.targets
+
+      // 앱 서비스만 수집. 모니터링 스택 자신(otel-lgtm, alloy)의 로그까지 담으면
+      // 볼륨 그래프가 스택 노이즈로 뒤덮인다. 스택 로그는 kubectl logs 로 본다.
+      rule {
+        source_labels = ["__meta_kubernetes_pod_label_app"]
+        regex         = ".*-service"
+        action        = "keep"
+      }
+
+      rule {
+        source_labels = ["__meta_kubernetes_pod_label_app"]
+        target_label  = "service_name"
+      }
+      // 파드 라벨은 archiver-service, 메트릭의 job 라벨은 archiver 라 이름이 어긋난다.
+      // -service 접미사를 떼서 양쪽 이름을 맞춘다(로그와 메트릭을 같은 이름으로 필터하려고).
+      rule {
+        source_labels = ["__meta_kubernetes_pod_label_app"]
+        regex         = "(.*)-service"
+        replacement   = "$1"
+        target_label  = "service_name"
+      }
+      rule {
+        source_labels = ["__meta_kubernetes_namespace"]
+        target_label  = "namespace"
+      }
+      rule {
+        source_labels = ["__meta_kubernetes_pod_name"]
+        target_label  = "pod"
+      }
+      rule {
+        source_labels = ["__meta_kubernetes_pod_container_name"]
+        target_label  = "container"
+      }
+    }
+
+    loki.source.kubernetes "pods" {
+      targets    = discovery.relabel.pods.output
+      forward_to = [loki.process.spring.receiver]
+    }
+
+    loki.process "spring" {
+      // 로그 레벨은 값 종류가 적으니 라벨로 (레벨별 필터/집계용)
+      stage.regex {
+        expression = "^\\S+\\s+(?P<level>TRACE|DEBUG|INFO|WARN|ERROR)\\s"
+      }
+      stage.labels {
+        values = {
+          level = "",
+        }
+      }
+
+      // traceId 는 값 종류가 무한하니 라벨이 아니라 structured metadata 로.
+      // Grafana 의 Loki 데이터소스가 trace_id 를 잡아 Tempo 링크를 만들어 준다.
+      stage.regex {
+        expression = "\\[(?P<trace_id>[0-9a-f]{32})-(?P<span_id>[0-9a-f]{16})\\]"
+      }
+      stage.structured_metadata {
+        values = {
+          trace_id = "",
+          span_id  = "",
+        }
+      }
+
+      forward_to = [loki.write.otel_lgtm.receiver]
+    }
+
+    loki.write "otel_lgtm" {
+      endpoint {
+        url = "http://otel-lgtm:3100/loki/api/v1/push"
+      }
+    }
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: alloy
+  namespace: edrdog
+  labels:
+    app: alloy
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: alloy
+  template:
+    metadata:
+      labels:
+        app: alloy
+    spec:
+      serviceAccountName: alloy
+      containers:
+        - name: alloy
+          image: grafana/alloy:v1.18.0
+          args:
+            - run
+            - /etc/alloy/config.alloy
+            - --storage.path=/tmp/alloy
+            - --server.http.listen-addr=0.0.0.0:12345
+          ports:
+            - containerPort: 12345  # Alloy 자체 UI (디버깅용, 노출 안 함)
+          volumeMounts:
+            - name: config
+              mountPath: /etc/alloy
+          readinessProbe:
+            httpGet:
+              path: /-/ready
+              port: 12345
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          resources:
+            requests:
+              cpu: 50m
+              memory: 128Mi
+            limits:
+              memory: 256Mi
+      volumes:
+        - name: config
+          configMap:
+            name: alloy-config

--- a/k8s/api-service.yaml
+++ b/k8s/api-service.yaml
@@ -38,6 +38,9 @@ spec:
             # 발표 환경에서만 true (데모 계정 test/1234 + 과거 7일 시드)
             - name: DEMO_SEED
               value: "false"
+            # 메트릭/트레이스 OTLP 수집기 (k8s/otel-lgtm.yaml)
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: "http://otel-lgtm:4318"
           readinessProbe:
             httpGet:
               path: /actuator/health

--- a/k8s/archiver-service.yaml
+++ b/k8s/archiver-service.yaml
@@ -26,6 +26,9 @@ spec:
               value: "kafka:9094"
             - name: EDRDOG_CLICKHOUSE_URL
               value: "http://clickhouse:8123"
+            # 메트릭/트레이스 OTLP 수집기 (k8s/otel-lgtm.yaml)
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: "http://otel-lgtm:4318"
           readinessProbe:
             httpGet:
               path: /actuator/health

--- a/k8s/detector-service.yaml
+++ b/k8s/detector-service.yaml
@@ -25,6 +25,9 @@ spec:
             # 실제 Kafka 주소로 교체 (ConfigMap 으로 분리해도 됨)
             - name: SPRING_KAFKA_BOOTSTRAP_SERVERS
               value: "kafka:9094"
+            # 메트릭/트레이스 OTLP 수집기 (k8s/otel-lgtm.yaml)
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: "http://otel-lgtm:4318"
           readinessProbe:
             httpGet:
               path: /actuator/health

--- a/k8s/infisical.yaml
+++ b/k8s/infisical.yaml
@@ -1,0 +1,55 @@
+# Infisical 연동 — Infisical 에 등록한 값을 k8s Secret(edrdog-secrets) 으로 동기화한다.
+# 매니페스트에 비밀번호를 평문으로 박아두던 걸(DB_PASSWORD, CLICKHOUSE_PASSWORD 등) 여기로 옮기는 게 목적이다.
+#
+# 문서에는 v1beta1(InfisicalConnection/InfisicalAuth/InfisicalStaticSecret)이 나오지만
+# 릴리스된 Operator(v0.11.5)에는 아직 그 CRD 가 없다. 실제로 도는 건 v1alpha1 InfisicalSecret 이다.
+#
+# 1) Operator 설치 (1회)
+#   kubectl apply -f https://raw.githubusercontent.com/Infisical/kubernetes-operator/infisical-k8-operator/v0.11.5/kubectl-install/install-secrets-operator.yaml
+#
+# 2) Machine Identity 자격증명 (1회, 값이 비밀이라 레포에 두지 않는다)
+#    Infisical > Access Control > Identities 에서 Universal Auth 로 발급하고
+#    프로젝트 멤버로 추가한 뒤, 서버에서 직접 만든다:
+#   kubectl -n edrdog create secret generic infisical-universal-auth \
+#     --from-literal=clientId=<Client ID> \
+#     --from-literal=clientSecret=<Client Secret>
+#
+# 3) 적용
+#   kubectl apply -f k8s/infisical.yaml
+#   kubectl -n edrdog get infisicalsecret edrdog          # 상태 확인
+#   kubectl -n edrdog get secret edrdog-secrets -o jsonpath='{.data}' | tr ',' '\n'
+#
+# 4) 서비스가 이 Secret 을 읽게 한다(Service 객체를 안 건드리려고 patch 로 넣는다)
+#   for m in detector-service responder-service archiver-service api-service alert-service; do
+#     kubectl -n edrdog patch deployment "$m" --type=strategic \
+#       -p "{\"spec\":{\"template\":{\"spec\":{\"containers\":[{\"name\":\"$m\",\"envFrom\":[{\"secretRef\":{\"name\":\"edrdog-secrets\"}}]}]}}}}"
+#   done
+#
+#   주의: Deployment 에 같은 이름의 env 가 직접 박혀 있으면 그쪽이 envFrom 을 이긴다.
+#   예를 들어 api-service 의 DB_PASSWORD 는 매니페스트에 평문으로 있어서, Infisical 값을 쓰려면
+#   `kubectl -n edrdog set env deployment/api-service DB_PASSWORD-` 로 먼저 지워야 한다.
+---
+apiVersion: secrets.infisical.com/v1alpha1
+kind: InfisicalSecret
+metadata:
+  name: edrdog
+  namespace: edrdog
+spec:
+  hostAPI: https://app.infisical.com/api
+  resyncInterval: 60
+
+  authentication:
+    universalAuth:
+      credentialsRef:
+        secretName: infisical-universal-auth
+        secretNamespace: edrdog
+      secretsScope:
+        # 프로젝트 슬러그는 Infisical 프로젝트 Settings 에서 확인한다. 비밀값이 아니다.
+        projectSlug: REPLACE_WITH_INFISICAL_PROJECT_SLUG
+        envSlug: prod        # Infisical 의 Production 환경 슬러그
+        secretsPath: /
+
+  managedSecretReference:
+    secretName: edrdog-secrets
+    secretNamespace: edrdog
+    creationPolicy: Owner

--- a/k8s/kafdrop.yaml
+++ b/k8s/kafdrop.yaml
@@ -1,0 +1,63 @@
+# Kafdrop — Kafka 토픽/메시지 웹 UI (운영 확인용).
+# 배포서버에서는 Caddy 가 https://<도메인>/kafdrop 으로 프록시한다.
+#   Caddyfile 예:  handle /kafdrop* { reverse_proxy localhost:30901 }   ← 접두어 유지(handle_path 아님)
+#   (서브패스로 서비스하므로 SERVER_SERVLET_CONTEXTPATH 를 /kafdrop 로 맞춰둔다)
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kafdrop
+  namespace: edrdog
+  labels:
+    app: kafdrop
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: kafdrop
+  template:
+    metadata:
+      labels:
+        app: kafdrop
+    spec:
+      containers:
+        - name: kafdrop
+          image: obsidiandynamics/kafdrop:4.1.0
+          ports:
+            - containerPort: 9000
+          env:
+            - name: KAFKA_BROKERCONNECT
+              value: "kafka.edrdog.svc.cluster.local:9094"
+            - name: SERVER_SERVLET_CONTEXTPATH
+              value: "/kafdrop"
+            - name: JVM_OPTS
+              value: "-Xms64M -Xmx256M"
+          readinessProbe:
+            httpGet:
+              path: /kafdrop/actuator/health
+              port: 9000
+            initialDelaySeconds: 20
+            periodSeconds: 10
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              memory: 512Mi
+---
+# NodePort 30901 — 호스트(EC2)에서 도는 Caddy 가 localhost:30901 로 프록시한다.
+# EC2 보안그룹에 30901 을 열지 않으면 외부에서 직접은 못 들어오고 Caddy 경유만 가능.
+apiVersion: v1
+kind: Service
+metadata:
+  name: kafdrop
+  namespace: edrdog
+  labels:
+    app: kafdrop
+spec:
+  type: NodePort
+  selector:
+    app: kafdrop
+  ports:
+    - port: 9000
+      targetPort: 9000
+      nodePort: 30901

--- a/k8s/kind-cluster.yaml
+++ b/k8s/kind-cluster.yaml
@@ -22,3 +22,12 @@ nodes:
       - containerPort: 30306   # MySQL               -> host localhost:3306
         hostPort: 3306
         protocol: TCP
+      - containerPort: 30300   # Grafana (otel-lgtm) -> host localhost:3000
+        hostPort: 3000
+        protocol: TCP
+      - containerPort: 30317   # OTLP gRPC           -> host localhost:4317
+        hostPort: 4317
+        protocol: TCP
+      - containerPort: 30318   # OTLP HTTP           -> host localhost:4318
+        hostPort: 4318
+        protocol: TCP

--- a/k8s/otel-lgtm.yaml
+++ b/k8s/otel-lgtm.yaml
@@ -1,10 +1,23 @@
 # 모니터링 스택 (otel-lgtm) — Grafana + Prometheus + Tempo + Loki 를 담은 올인원 이미지.
-# 서비스들이 OTLP 로 메트릭/트레이스를 밀어넣고(로그는 k8s/alloy.yaml 이 수집), Grafana 에서 본다.
-# 개발용이라 영속성 없음(emptyDir).
+# 서비스들이 OTLP 로 메트릭/트레이스를 밀어넣고(로그·인프라 메트릭은 k8s/alloy.yaml 이 수집), Grafana 에서 본다.
 #
 #   기동:  kubectl apply -f k8s/otel-lgtm.yaml -f k8s/alloy.yaml
-#   접속:  http://localhost:3000  (admin / admin)
+#   접속:  http://localhost:3000  (익명 Admin 으로 열려 있음)
 #   OTLP:  호스트 실행 서비스 -> http://localhost:4318, 클러스터 내부 -> http://otel-lgtm:4318
+---
+# 지표 보관용 볼륨. emptyDir 로 두면 파드가 한 번 재시작될 때 그동안의 지표·로그·트레이스가
+# 통째로 사라져 발표 중 그래프가 빈다. 기본 StorageClass 를 쓴다(kind: standard, k3s: local-path).
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: otel-lgtm-data
+  namespace: edrdog
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -1032,7 +1045,7 @@ data:
   edrdog-jvm-kafka.json: |
     {
       "uid": "edrdog-jvm-kafka",
-      "title": "EDRdog JVM & Kafka",
+      "title": "EDRdog Resources",
       "tags": [
         "edrdog"
       ],
@@ -1492,6 +1505,145 @@ data:
               "refId": "A"
             }
           ]
+        },
+        {
+          "type": "row",
+          "id": 213,
+          "title": "컨테이너 / 노드",
+          "collapsed": false,
+          "panels": [],
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 27
+          }
+        },
+        {
+          "type": "timeseries",
+          "id": 214,
+          "title": "컨테이너 CPU",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${ds}"
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 0,
+            "y": 28
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "short",
+              "custom": {
+                "fillOpacity": 10,
+                "showPoints": "never"
+              },
+              "min": 0
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            }
+          },
+          "targets": [
+            {
+              "expr": "sum by (pod) (rate(container_cpu_usage_seconds_total{namespace=\"edrdog\", container!=\"\"}[$__rate_interval]))",
+              "legendFormat": "{{pod}}",
+              "refId": "A"
+            }
+          ]
+        },
+        {
+          "type": "timeseries",
+          "id": 215,
+          "title": "컨테이너 메모리",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${ds}"
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 8,
+            "y": 28
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "bytes",
+              "custom": {
+                "fillOpacity": 10,
+                "showPoints": "never"
+              },
+              "min": 0
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            }
+          },
+          "targets": [
+            {
+              "expr": "sum by (pod) (container_memory_working_set_bytes{namespace=\"edrdog\", container!=\"\"})",
+              "legendFormat": "{{pod}}",
+              "refId": "A"
+            }
+          ]
+        },
+        {
+          "type": "timeseries",
+          "id": 216,
+          "title": "노드 사용률",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${ds}"
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 16,
+            "y": 28
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "percentunit",
+              "custom": {
+                "fillOpacity": 10,
+                "showPoints": "never"
+              },
+              "min": 0,
+              "max": 1
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            }
+          },
+          "targets": [
+            {
+              "expr": "sum(rate(node_cpu_usage_seconds_total[$__rate_interval])) / clamp_min(sum(machine_cpu_cores), 1)",
+              "legendFormat": "CPU",
+              "refId": "A"
+            },
+            {
+              "expr": "sum(node_memory_working_set_bytes) / clamp_min(sum(machine_memory_bytes), 1)",
+              "legendFormat": "메모리",
+              "refId": "B"
+            }
+          ]
         }
       ]
     }
@@ -1832,6 +1984,9 @@ metadata:
     app: otel-lgtm
 spec:
   replicas: 1
+  # ReadWriteOnce PVC 라 롤링 업데이트로는 새 파드가 볼륨을 못 잡고 서로 기다린다. 먼저 내리고 띄운다.
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app: otel-lgtm
@@ -1848,10 +2003,14 @@ spec:
             - containerPort: 3100  # Loki (Alloy 가 로그를 밀어넣는 곳)
             - containerPort: 4317  # OTLP gRPC
             - containerPort: 4318  # OTLP HTTP
+            - containerPort: 9090  # Prometheus (Alloy 가 인프라 메트릭을 밀어넣는 곳)
           env:
             # 첫 화면을 EDRdog 대시보드로 (기본 Grafana 홈 대신)
             - name: GF_DASHBOARDS_DEFAULT_HOME_DASHBOARD_PATH
               value: /otel-lgtm/edrdog-dashboards/edrdog-overview.json
+          # Alloy 가 인프라 메트릭을 밀어넣는 remote write 수신은 이미지 기본 실행 인자에
+          # 이미 켜져 있다(--web.enable-remote-write-receiver). PROMETHEUS_EXTRA_ARGS 로
+          # 같은 플래그를 또 주면 중복으로 Prometheus 가 아예 뜨지 않으니 넣지 말 것.
           volumeMounts:
             # 프로비저닝 디렉터리는 통째로 덮으면 기본 대시보드가 사라지므로 파일 하나만 subPath 로 얹는다.
             - name: dashboards
@@ -1888,7 +2047,8 @@ spec:
           configMap:
             name: otel-lgtm-dashboards
         - name: data
-          emptyDir: {}
+          persistentVolumeClaim:
+            claimName: otel-lgtm-data
 ---
 apiVersion: v1
 kind: Service
@@ -1918,3 +2078,7 @@ spec:
       port: 4318
       targetPort: 4318
       nodePort: 30318
+    - name: prometheus
+      port: 9090
+      targetPort: 9090
+      nodePort: 30909

--- a/k8s/otel-lgtm.yaml
+++ b/k8s/otel-lgtm.yaml
@@ -1,0 +1,1920 @@
+# 모니터링 스택 (otel-lgtm) — Grafana + Prometheus + Tempo + Loki 를 담은 올인원 이미지.
+# 서비스들이 OTLP 로 메트릭/트레이스를 밀어넣고(로그는 k8s/alloy.yaml 이 수집), Grafana 에서 본다.
+# 개발용이라 영속성 없음(emptyDir).
+#
+#   기동:  kubectl apply -f k8s/otel-lgtm.yaml -f k8s/alloy.yaml
+#   접속:  http://localhost:3000  (admin / admin)
+#   OTLP:  호스트 실행 서비스 -> http://localhost:4318, 클러스터 내부 -> http://otel-lgtm:4318
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: otel-lgtm-dashboards
+  namespace: edrdog
+data:
+  # 이미지 기본 프로비저닝(RED / JVM 대시보드)을 유지한 채 EDRdog 폴더만 추가한다.
+  edrdog-dashboards.yaml: |
+    apiVersion: 1
+
+    providers:
+      - name: "EDRdog"
+        type: file
+        folder: "EDRdog"
+        options:
+          path: /otel-lgtm/edrdog-dashboards
+          foldersFromFilesStructure: false
+
+  edrdog-overview.json: |
+    {
+      "uid": "edrdog-overview",
+      "title": "EDRdog Overview",
+      "tags": [
+        "edrdog"
+      ],
+      "timezone": "browser",
+      "editable": true,
+      "schemaVersion": 39,
+      "refresh": "10s",
+      "time": {
+        "from": "now-30m",
+        "to": "now"
+      },
+      "links": [
+        {
+          "type": "dashboards",
+          "title": "EDRdog",
+          "tags": [
+            "edrdog"
+          ],
+          "asDropdown": true,
+          "includeVars": true,
+          "keepTime": true,
+          "icon": "external link"
+        }
+      ],
+      "templating": {
+        "list": [
+          {
+            "name": "ds",
+            "type": "datasource",
+            "query": "prometheus",
+            "current": {
+              "text": "Prometheus",
+              "value": "prometheus"
+            },
+            "hide": 0
+          },
+          {
+            "name": "job",
+            "label": "service",
+            "type": "query",
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${ds}"
+            },
+            "query": {
+              "query": "label_values(jvm_threads_live, job)",
+              "refId": "job"
+            },
+            "refresh": 2,
+            "includeAll": true,
+            "allValue": ".*",
+            "multi": true,
+            "current": {
+              "text": "All",
+              "value": "$__all"
+            }
+          }
+        ]
+      },
+      "panels": [
+        {
+          "type": "row",
+          "id": 1,
+          "title": "서비스 요약",
+          "collapsed": false,
+          "panels": [],
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 0
+          }
+        },
+        {
+          "type": "stat",
+          "id": 2,
+          "title": "요청률",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${ds}"
+          },
+          "gridPos": {
+            "h": 5,
+            "w": 6,
+            "x": 0,
+            "y": 1
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "reqps",
+              "decimals": 2,
+              "color": {
+                "mode": "fixed",
+                "fixedColor": "text"
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "graphMode": "area",
+            "colorMode": "value",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            }
+          },
+          "targets": [
+            {
+              "refId": "A",
+              "expr": "sum(rate(http_server_requests_seconds_count{job=~\"$job\"}[$__rate_interval]))"
+            }
+          ]
+        },
+        {
+          "type": "stat",
+          "id": 3,
+          "title": "에러율 (5xx)",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${ds}"
+          },
+          "gridPos": {
+            "h": 5,
+            "w": 6,
+            "x": 6,
+            "y": 1
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "percentunit",
+              "decimals": 2,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "orange",
+                    "value": 0.01
+                  },
+                  {
+                    "color": "red",
+                    "value": 0.05
+                  }
+                ]
+              },
+              "min": 0,
+              "max": 1
+            },
+            "overrides": []
+          },
+          "options": {
+            "graphMode": "area",
+            "colorMode": "value",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            }
+          },
+          "targets": [
+            {
+              "refId": "A",
+              "expr": "(sum(rate(http_server_requests_seconds_count{job=~\"$job\", outcome=\"SERVER_ERROR\"}[$__rate_interval])) or vector(0)) / clamp_min(sum(rate(http_server_requests_seconds_count{job=~\"$job\"}[$__rate_interval])), 0.0001)"
+            }
+          ]
+        },
+        {
+          "type": "stat",
+          "id": 4,
+          "title": "응답시간 p95",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${ds}"
+          },
+          "gridPos": {
+            "h": 5,
+            "w": 6,
+            "x": 12,
+            "y": 1
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "s",
+              "decimals": 3,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "orange",
+                    "value": 0.5
+                  },
+                  {
+                    "color": "red",
+                    "value": 1
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "graphMode": "area",
+            "colorMode": "value",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            }
+          },
+          "targets": [
+            {
+              "refId": "A",
+              "expr": "histogram_quantile(0.95, sum by (le) (rate(http_server_requests_seconds_bucket{job=~\"$job\"}[$__rate_interval])))"
+            }
+          ]
+        },
+        {
+          "type": "stat",
+          "id": 5,
+          "title": "Kafka 컨슈머 최대 랙",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${ds}"
+          },
+          "gridPos": {
+            "h": 5,
+            "w": 6,
+            "x": 18,
+            "y": 1
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "short",
+              "decimals": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "orange",
+                    "value": 1000
+                  },
+                  {
+                    "color": "red",
+                    "value": 10000
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "graphMode": "area",
+            "colorMode": "value",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            }
+          },
+          "targets": [
+            {
+              "refId": "A",
+              "expr": "max(kafka_consumer_fetch_manager_records_lag_max{job=~\"$job\"} >= 0) or vector(0)"
+            }
+          ]
+        },
+        {
+          "type": "row",
+          "id": 6,
+          "title": "트래픽",
+          "collapsed": false,
+          "panels": [],
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 6
+          }
+        },
+        {
+          "type": "timeseries",
+          "id": 7,
+          "title": "서비스별 요청률",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${ds}"
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 0,
+            "y": 7
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "reqps",
+              "custom": {
+                "fillOpacity": 10,
+                "showPoints": "never",
+                "stacking": {
+                  "mode": "normal"
+                }
+              },
+              "min": 0
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            }
+          },
+          "targets": [
+            {
+              "expr": "sum by (job) (rate(http_server_requests_seconds_count{job=~\"$job\"}[$__rate_interval]))",
+              "legendFormat": "{{job}}",
+              "refId": "A"
+            }
+          ]
+        },
+        {
+          "type": "timeseries",
+          "id": 8,
+          "title": "서비스별 에러율",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${ds}"
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 8,
+            "y": 7
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "percentunit",
+              "custom": {
+                "fillOpacity": 10,
+                "showPoints": "never"
+              },
+              "min": 0,
+              "max": 1
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            }
+          },
+          "targets": [
+            {
+              "expr": "(sum by (job) (rate(http_server_requests_seconds_count{job=~\"$job\", outcome=\"SERVER_ERROR\"}[$__rate_interval])) or 0 * sum by (job) (rate(http_server_requests_seconds_count{job=~\"$job\"}[$__rate_interval]))) / clamp_min(sum by (job) (rate(http_server_requests_seconds_count{job=~\"$job\"}[$__rate_interval])), 0.0001)",
+              "legendFormat": "{{job}}",
+              "refId": "A"
+            }
+          ]
+        },
+        {
+          "type": "timeseries",
+          "id": 9,
+          "title": "응답시간 분위 (전체)",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${ds}"
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 16,
+            "y": 7
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "s",
+              "custom": {
+                "fillOpacity": 0,
+                "showPoints": "never"
+              },
+              "min": 0
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            }
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.99, sum by (le) (rate(http_server_requests_seconds_bucket{job=~\"$job\"}[$__rate_interval])))",
+              "legendFormat": "p99",
+              "refId": "A"
+            },
+            {
+              "expr": "histogram_quantile(0.95, sum by (le) (rate(http_server_requests_seconds_bucket{job=~\"$job\"}[$__rate_interval])))",
+              "legendFormat": "p95",
+              "refId": "B"
+            },
+            {
+              "expr": "histogram_quantile(0.50, sum by (le) (rate(http_server_requests_seconds_bucket{job=~\"$job\"}[$__rate_interval])))",
+              "legendFormat": "p50",
+              "refId": "C"
+            }
+          ]
+        },
+        {
+          "type": "row",
+          "id": 10,
+          "title": "리소스 / 로그",
+          "collapsed": false,
+          "panels": [],
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 15
+          }
+        },
+        {
+          "type": "timeseries",
+          "id": 11,
+          "title": "힙 사용률",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${ds}"
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 0,
+            "y": 16
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "percentunit",
+              "custom": {
+                "fillOpacity": 10,
+                "showPoints": "never"
+              },
+              "min": 0,
+              "max": 1
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            }
+          },
+          "targets": [
+            {
+              "expr": "sum by (job) (jvm_memory_used_bytes{job=~\"$job\", area=\"heap\"}) / clamp_min(sum by (job) (jvm_memory_max_bytes{job=~\"$job\", area=\"heap\"}), 1)",
+              "legendFormat": "{{job}}",
+              "refId": "A"
+            }
+          ]
+        },
+        {
+          "type": "timeseries",
+          "id": 12,
+          "title": "Kafka 컨슈머 랙",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${ds}"
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 8,
+            "y": 16
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "short",
+              "custom": {
+                "fillOpacity": 10,
+                "showPoints": "never"
+              },
+              "min": 0
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            }
+          },
+          "targets": [
+            {
+              "expr": "max by (job) (kafka_consumer_fetch_manager_records_lag_max{job=~\"$job\"} >= 0)",
+              "legendFormat": "{{job}}",
+              "refId": "A"
+            }
+          ]
+        },
+        {
+          "type": "timeseries",
+          "id": 13,
+          "title": "로그 볼륨 (레벨별)",
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 16,
+            "y": 16
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "cps",
+              "custom": {
+                "fillOpacity": 10,
+                "showPoints": "never",
+                "stacking": {
+                  "mode": "normal"
+                }
+              },
+              "min": 0
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            }
+          },
+          "targets": [
+            {
+              "expr": "sum by (level) (count_over_time({namespace=\"edrdog\"} [$__auto]))",
+              "legendFormat": "{{level}}",
+              "queryType": "range",
+              "refId": "A"
+            }
+          ]
+        }
+      ]
+    }
+
+  edrdog-http.json: |
+    {
+      "uid": "edrdog-http",
+      "title": "EDRdog HTTP",
+      "tags": [
+        "edrdog"
+      ],
+      "timezone": "browser",
+      "editable": true,
+      "schemaVersion": 39,
+      "refresh": "10s",
+      "time": {
+        "from": "now-30m",
+        "to": "now"
+      },
+      "links": [
+        {
+          "type": "dashboards",
+          "title": "EDRdog",
+          "tags": [
+            "edrdog"
+          ],
+          "asDropdown": true,
+          "includeVars": true,
+          "keepTime": true,
+          "icon": "external link"
+        }
+      ],
+      "templating": {
+        "list": [
+          {
+            "name": "ds",
+            "type": "datasource",
+            "query": "prometheus",
+            "current": {
+              "text": "Prometheus",
+              "value": "prometheus"
+            },
+            "hide": 0
+          },
+          {
+            "name": "job",
+            "label": "service",
+            "type": "query",
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${ds}"
+            },
+            "query": {
+              "query": "label_values(jvm_threads_live, job)",
+              "refId": "job"
+            },
+            "refresh": 2,
+            "includeAll": true,
+            "allValue": ".*",
+            "multi": true,
+            "current": {
+              "text": "All",
+              "value": "$__all"
+            }
+          }
+        ]
+      },
+      "panels": [
+        {
+          "type": "row",
+          "id": 101,
+          "title": "처리량 / 오류",
+          "collapsed": false,
+          "panels": [],
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 0
+          }
+        },
+        {
+          "type": "timeseries",
+          "id": 102,
+          "title": "서비스별 요청률",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${ds}"
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 0,
+            "y": 1
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "reqps",
+              "custom": {
+                "fillOpacity": 10,
+                "showPoints": "never",
+                "stacking": {
+                  "mode": "normal"
+                }
+              },
+              "min": 0
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            }
+          },
+          "targets": [
+            {
+              "expr": "sum by (job) (rate(http_server_requests_seconds_count{job=~\"$job\"}[$__rate_interval]))",
+              "legendFormat": "{{job}}",
+              "refId": "A"
+            }
+          ]
+        },
+        {
+          "type": "timeseries",
+          "id": 103,
+          "title": "상태코드별 요청률",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${ds}"
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 8,
+            "y": 1
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "reqps",
+              "custom": {
+                "fillOpacity": 10,
+                "showPoints": "never",
+                "stacking": {
+                  "mode": "normal"
+                }
+              },
+              "min": 0
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            }
+          },
+          "targets": [
+            {
+              "expr": "sum by (status) (rate(http_server_requests_seconds_count{job=~\"$job\"}[$__rate_interval]))",
+              "legendFormat": "{{status}}",
+              "refId": "A"
+            }
+          ]
+        },
+        {
+          "type": "timeseries",
+          "id": 104,
+          "title": "서비스별 에러율",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${ds}"
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 16,
+            "y": 1
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "percentunit",
+              "custom": {
+                "fillOpacity": 10,
+                "showPoints": "never"
+              },
+              "min": 0,
+              "max": 1
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            }
+          },
+          "targets": [
+            {
+              "expr": "(sum by (job) (rate(http_server_requests_seconds_count{job=~\"$job\", outcome=\"SERVER_ERROR\"}[$__rate_interval])) or 0 * sum by (job) (rate(http_server_requests_seconds_count{job=~\"$job\"}[$__rate_interval]))) / clamp_min(sum by (job) (rate(http_server_requests_seconds_count{job=~\"$job\"}[$__rate_interval])), 0.0001)",
+              "legendFormat": "{{job}}",
+              "refId": "A"
+            }
+          ]
+        },
+        {
+          "type": "row",
+          "id": 105,
+          "title": "응답시간",
+          "collapsed": false,
+          "panels": [],
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 9
+          }
+        },
+        {
+          "type": "timeseries",
+          "id": 106,
+          "title": "분위 (전체)",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${ds}"
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 10
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "s",
+              "custom": {
+                "fillOpacity": 0,
+                "showPoints": "never"
+              },
+              "min": 0
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            }
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.99, sum by (le) (rate(http_server_requests_seconds_bucket{job=~\"$job\"}[$__rate_interval])))",
+              "legendFormat": "p99",
+              "refId": "A"
+            },
+            {
+              "expr": "histogram_quantile(0.95, sum by (le) (rate(http_server_requests_seconds_bucket{job=~\"$job\"}[$__rate_interval])))",
+              "legendFormat": "p95",
+              "refId": "B"
+            },
+            {
+              "expr": "histogram_quantile(0.50, sum by (le) (rate(http_server_requests_seconds_bucket{job=~\"$job\"}[$__rate_interval])))",
+              "legendFormat": "p50",
+              "refId": "C"
+            }
+          ]
+        },
+        {
+          "type": "timeseries",
+          "id": 107,
+          "title": "서비스별 p95",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${ds}"
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 10
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "s",
+              "custom": {
+                "fillOpacity": 0,
+                "showPoints": "never"
+              },
+              "min": 0
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            }
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.95, sum by (le, job) (rate(http_server_requests_seconds_bucket{job=~\"$job\"}[$__rate_interval])))",
+              "legendFormat": "{{job}}",
+              "refId": "A"
+            }
+          ]
+        },
+        {
+          "type": "row",
+          "id": 108,
+          "title": "엔드포인트",
+          "collapsed": false,
+          "panels": [],
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 18
+          }
+        },
+        {
+          "type": "table",
+          "id": 109,
+          "title": "느린 엔드포인트 Top (p95)",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${ds}"
+          },
+          "gridPos": {
+            "h": 9,
+            "w": 12,
+            "x": 0,
+            "y": 19
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "s",
+              "decimals": 3
+            },
+            "overrides": []
+          },
+          "options": {
+            "showHeader": true,
+            "sortBy": [
+              {
+                "displayName": "p95",
+                "desc": true
+              }
+            ]
+          },
+          "targets": [
+            {
+              "refId": "A",
+              "format": "table",
+              "instant": true,
+              "expr": "topk(10, histogram_quantile(0.95, sum by (le, job, uri, method) (rate(http_server_requests_seconds_bucket{job=~\"$job\"}[$__rate_interval]))))"
+            }
+          ],
+          "transformations": [
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true
+                },
+                "renameByName": {
+                  "Value": "p95"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "type": "table",
+          "id": 110,
+          "title": "호출 많은 엔드포인트 Top",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${ds}"
+          },
+          "gridPos": {
+            "h": 9,
+            "w": 12,
+            "x": 12,
+            "y": 19
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "reqps",
+              "decimals": 2
+            },
+            "overrides": []
+          },
+          "options": {
+            "showHeader": true,
+            "sortBy": [
+              {
+                "displayName": "req/s",
+                "desc": true
+              }
+            ]
+          },
+          "targets": [
+            {
+              "refId": "A",
+              "format": "table",
+              "instant": true,
+              "expr": "topk(10, sum by (job, uri, method) (rate(http_server_requests_seconds_count{job=~\"$job\"}[$__rate_interval])))"
+            }
+          ],
+          "transformations": [
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true
+                },
+                "renameByName": {
+                  "Value": "req/s"
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+
+  edrdog-jvm-kafka.json: |
+    {
+      "uid": "edrdog-jvm-kafka",
+      "title": "EDRdog JVM & Kafka",
+      "tags": [
+        "edrdog"
+      ],
+      "timezone": "browser",
+      "editable": true,
+      "schemaVersion": 39,
+      "refresh": "10s",
+      "time": {
+        "from": "now-30m",
+        "to": "now"
+      },
+      "links": [
+        {
+          "type": "dashboards",
+          "title": "EDRdog",
+          "tags": [
+            "edrdog"
+          ],
+          "asDropdown": true,
+          "includeVars": true,
+          "keepTime": true,
+          "icon": "external link"
+        }
+      ],
+      "templating": {
+        "list": [
+          {
+            "name": "ds",
+            "type": "datasource",
+            "query": "prometheus",
+            "current": {
+              "text": "Prometheus",
+              "value": "prometheus"
+            },
+            "hide": 0
+          },
+          {
+            "name": "job",
+            "label": "service",
+            "type": "query",
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${ds}"
+            },
+            "query": {
+              "query": "label_values(jvm_threads_live, job)",
+              "refId": "job"
+            },
+            "refresh": 2,
+            "includeAll": true,
+            "allValue": ".*",
+            "multi": true,
+            "current": {
+              "text": "All",
+              "value": "$__all"
+            }
+          }
+        ]
+      },
+      "panels": [
+        {
+          "type": "row",
+          "id": 201,
+          "title": "JVM 메모리",
+          "collapsed": false,
+          "panels": [],
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 0
+          }
+        },
+        {
+          "type": "timeseries",
+          "id": 202,
+          "title": "힙 사용률",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${ds}"
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 0,
+            "y": 1
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "percentunit",
+              "custom": {
+                "fillOpacity": 10,
+                "showPoints": "never"
+              },
+              "min": 0,
+              "max": 1
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            }
+          },
+          "targets": [
+            {
+              "expr": "sum by (job) (jvm_memory_used_bytes{job=~\"$job\", area=\"heap\"}) / clamp_min(sum by (job) (jvm_memory_max_bytes{job=~\"$job\", area=\"heap\"}), 1)",
+              "legendFormat": "{{job}}",
+              "refId": "A"
+            }
+          ]
+        },
+        {
+          "type": "timeseries",
+          "id": 203,
+          "title": "힙 사용량",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${ds}"
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 8,
+            "y": 1
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "bytes",
+              "custom": {
+                "fillOpacity": 10,
+                "showPoints": "never"
+              },
+              "min": 0
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            }
+          },
+          "targets": [
+            {
+              "expr": "sum by (job) (jvm_memory_used_bytes{job=~\"$job\", area=\"heap\"})",
+              "legendFormat": "{{job}} used",
+              "refId": "A"
+            }
+          ]
+        },
+        {
+          "type": "timeseries",
+          "id": 204,
+          "title": "GC 정지 시간",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${ds}"
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 16,
+            "y": 1
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "s",
+              "custom": {
+                "fillOpacity": 10,
+                "showPoints": "never"
+              },
+              "min": 0
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            }
+          },
+          "targets": [
+            {
+              "expr": "sum by (job) (rate(jvm_gc_pause_seconds_sum{job=~\"$job\"}[$__rate_interval]))",
+              "legendFormat": "{{job}}",
+              "refId": "A"
+            }
+          ]
+        },
+        {
+          "type": "row",
+          "id": 205,
+          "title": "JVM 런타임",
+          "collapsed": false,
+          "panels": [],
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 9
+          }
+        },
+        {
+          "type": "timeseries",
+          "id": 206,
+          "title": "스레드",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${ds}"
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 0,
+            "y": 10
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "short",
+              "custom": {
+                "fillOpacity": 0,
+                "showPoints": "never"
+              },
+              "min": 0
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            }
+          },
+          "targets": [
+            {
+              "expr": "sum by (job) (jvm_threads_live{job=~\"$job\"})",
+              "legendFormat": "{{job}}",
+              "refId": "A"
+            }
+          ]
+        },
+        {
+          "type": "timeseries",
+          "id": 207,
+          "title": "로드된 클래스",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${ds}"
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 8,
+            "y": 10
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "short",
+              "custom": {
+                "fillOpacity": 0,
+                "showPoints": "never"
+              },
+              "min": 0
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            }
+          },
+          "targets": [
+            {
+              "expr": "sum by (job) (jvm_classes_loaded{job=~\"$job\"})",
+              "legendFormat": "{{job}}",
+              "refId": "A"
+            }
+          ]
+        },
+        {
+          "type": "timeseries",
+          "id": 208,
+          "title": "GC 할당률",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${ds}"
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 16,
+            "y": 10
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "Bps",
+              "custom": {
+                "fillOpacity": 10,
+                "showPoints": "never"
+              },
+              "min": 0
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            }
+          },
+          "targets": [
+            {
+              "expr": "sum by (job) (rate(jvm_gc_memory_allocated_bytes_total{job=~\"$job\"}[$__rate_interval]))",
+              "legendFormat": "{{job}}",
+              "refId": "A"
+            }
+          ]
+        },
+        {
+          "type": "row",
+          "id": 209,
+          "title": "Kafka 컨슈머",
+          "collapsed": false,
+          "panels": [],
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 18
+          }
+        },
+        {
+          "type": "timeseries",
+          "id": 210,
+          "title": "컨슈머 랙",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${ds}"
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 0,
+            "y": 19
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "short",
+              "custom": {
+                "fillOpacity": 10,
+                "showPoints": "never"
+              },
+              "min": 0
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            }
+          },
+          "targets": [
+            {
+              "expr": "max by (job) (kafka_consumer_fetch_manager_records_lag_max{job=~\"$job\"} >= 0)",
+              "legendFormat": "{{job}}",
+              "refId": "A"
+            }
+          ]
+        },
+        {
+          "type": "timeseries",
+          "id": 211,
+          "title": "소비 처리량",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${ds}"
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 8,
+            "y": 19
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "cps",
+              "custom": {
+                "fillOpacity": 10,
+                "showPoints": "never"
+              },
+              "min": 0
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            }
+          },
+          "targets": [
+            {
+              "expr": "sum by (job) (rate(kafka_consumer_fetch_manager_records_consumed_total{job=~\"$job\"}[$__rate_interval]))",
+              "legendFormat": "{{job}}",
+              "refId": "A"
+            }
+          ]
+        },
+        {
+          "type": "timeseries",
+          "id": 212,
+          "title": "커밋률",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${ds}"
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 16,
+            "y": 19
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "cps",
+              "custom": {
+                "fillOpacity": 10,
+                "showPoints": "never"
+              },
+              "min": 0
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            }
+          },
+          "targets": [
+            {
+              "expr": "sum by (job) (rate(kafka_consumer_coordinator_commit_total{job=~\"$job\"}[$__rate_interval]))",
+              "legendFormat": "{{job}}",
+              "refId": "A"
+            }
+          ]
+        }
+      ]
+    }
+
+  edrdog-logs-traces.json: |
+    {
+      "uid": "edrdog-logs-traces",
+      "title": "EDRdog Logs & Traces",
+      "tags": [
+        "edrdog"
+      ],
+      "timezone": "browser",
+      "editable": true,
+      "schemaVersion": 39,
+      "refresh": "10s",
+      "time": {
+        "from": "now-30m",
+        "to": "now"
+      },
+      "links": [
+        {
+          "type": "dashboards",
+          "title": "EDRdog",
+          "tags": [
+            "edrdog"
+          ],
+          "asDropdown": true,
+          "includeVars": true,
+          "keepTime": true,
+          "icon": "external link"
+        }
+      ],
+      "templating": {
+        "list": [
+          {
+            "name": "service",
+            "label": "service",
+            "type": "query",
+            "datasource": {
+              "type": "loki",
+              "uid": "loki"
+            },
+            "query": {
+              "label": "service_name",
+              "stream": "{namespace=\"edrdog\"}",
+              "type": 1,
+              "refId": "service"
+            },
+            "refresh": 2,
+            "includeAll": true,
+            "allValue": ".+",
+            "multi": true,
+            "current": {
+              "text": "All",
+              "value": "$__all"
+            }
+          }
+        ]
+      },
+      "panels": [
+        {
+          "type": "row",
+          "id": 301,
+          "title": "로그",
+          "collapsed": false,
+          "panels": [],
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 0
+          }
+        },
+        {
+          "type": "stat",
+          "id": 302,
+          "title": "ERROR (구간 합계)",
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "gridPos": {
+            "h": 5,
+            "w": 6,
+            "x": 0,
+            "y": 1
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "short",
+              "decimals": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 1
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "graphMode": "area",
+            "colorMode": "value",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            }
+          },
+          "targets": [
+            {
+              "refId": "A",
+              "expr": "sum(count_over_time({namespace=\"edrdog\", service_name=~\"$service\", level=\"ERROR\"} [$__range])) or vector(0)"
+            }
+          ]
+        },
+        {
+          "type": "stat",
+          "id": 303,
+          "title": "WARN (구간 합계)",
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "gridPos": {
+            "h": 5,
+            "w": 6,
+            "x": 6,
+            "y": 1
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "short",
+              "decimals": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "orange",
+                    "value": 1
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "graphMode": "area",
+            "colorMode": "value",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            }
+          },
+          "targets": [
+            {
+              "refId": "A",
+              "expr": "sum(count_over_time({namespace=\"edrdog\", service_name=~\"$service\", level=\"WARN\"} [$__range])) or vector(0)"
+            }
+          ]
+        },
+        {
+          "type": "timeseries",
+          "id": 304,
+          "title": "로그 볼륨 (레벨별)",
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "gridPos": {
+            "h": 5,
+            "w": 12,
+            "x": 12,
+            "y": 1
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "cps",
+              "custom": {
+                "fillOpacity": 10,
+                "showPoints": "never",
+                "stacking": {
+                  "mode": "normal"
+                }
+              },
+              "min": 0
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            }
+          },
+          "targets": [
+            {
+              "expr": "sum by (level) (count_over_time({namespace=\"edrdog\", service_name=~\"$service\"} [$__auto]))",
+              "legendFormat": "{{level}}",
+              "refId": "A"
+            }
+          ]
+        },
+        {
+          "type": "logs",
+          "id": 305,
+          "title": "로그 스트림",
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "gridPos": {
+            "h": 11,
+            "w": 24,
+            "x": 0,
+            "y": 6
+          },
+          "options": {
+            "showTime": true,
+            "wrapLogMessage": true,
+            "sortOrder": "Descending",
+            "enableLogDetails": true,
+            "dedupStrategy": "none",
+            "prettifyLogMessage": false,
+            "showLabels": false,
+            "showCommonLabels": false,
+            "enableInfiniteScrolling": false,
+            "syntaxHighlighting": true
+          },
+          "targets": [
+            {
+              "refId": "A",
+              "expr": "{namespace=\"edrdog\", service_name=~\"$service\"}",
+              "queryType": "range"
+            }
+          ]
+        },
+        {
+          "type": "logs",
+          "id": 306,
+          "title": "에러 로그만",
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "gridPos": {
+            "h": 9,
+            "w": 24,
+            "x": 0,
+            "y": 17
+          },
+          "options": {
+            "showTime": true,
+            "wrapLogMessage": true,
+            "sortOrder": "Descending",
+            "enableLogDetails": true,
+            "dedupStrategy": "none",
+            "prettifyLogMessage": false,
+            "showLabels": false,
+            "showCommonLabels": false,
+            "enableInfiniteScrolling": false,
+            "syntaxHighlighting": true
+          },
+          "targets": [
+            {
+              "refId": "A",
+              "queryType": "range",
+              "expr": "{namespace=\"edrdog\", service_name=~\"$service\", level=~\"ERROR|WARN\"}"
+            }
+          ]
+        },
+        {
+          "type": "row",
+          "id": 307,
+          "title": "트레이스",
+          "collapsed": false,
+          "panels": [],
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 26
+          }
+        },
+        {
+          "type": "table",
+          "id": 308,
+          "title": "최근 트레이스 (Tempo)",
+          "datasource": {
+            "type": "tempo",
+            "uid": "tempo"
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 24,
+            "x": 0,
+            "y": 27
+          },
+          "options": {
+            "showHeader": true
+          },
+          "targets": [
+            {
+              "refId": "A",
+              "queryType": "traceqlSearch",
+              "filters": [],
+              "limit": 20,
+              "tableType": "traces"
+            }
+          ]
+        }
+      ]
+    }
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: otel-lgtm
+  namespace: edrdog
+  labels:
+    app: otel-lgtm
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: otel-lgtm
+  template:
+    metadata:
+      labels:
+        app: otel-lgtm
+    spec:
+      containers:
+        - name: otel-lgtm
+          image: grafana/otel-lgtm:0.29.2
+          ports:
+            - containerPort: 3000  # Grafana
+            - containerPort: 3100  # Loki (Alloy 가 로그를 밀어넣는 곳)
+            - containerPort: 4317  # OTLP gRPC
+            - containerPort: 4318  # OTLP HTTP
+          env:
+            # 첫 화면을 EDRdog 대시보드로 (기본 Grafana 홈 대신)
+            - name: GF_DASHBOARDS_DEFAULT_HOME_DASHBOARD_PATH
+              value: /otel-lgtm/edrdog-dashboards/edrdog-overview.json
+          volumeMounts:
+            # 프로비저닝 디렉터리는 통째로 덮으면 기본 대시보드가 사라지므로 파일 하나만 subPath 로 얹는다.
+            - name: dashboards
+              mountPath: /otel-lgtm/grafana/conf/provisioning/dashboards/edrdog-dashboards.yaml
+              subPath: edrdog-dashboards.yaml
+            - name: dashboards
+              mountPath: /otel-lgtm/edrdog-dashboards/edrdog-overview.json
+              subPath: edrdog-overview.json
+            - name: dashboards
+              mountPath: /otel-lgtm/edrdog-dashboards/edrdog-http.json
+              subPath: edrdog-http.json
+            - name: dashboards
+              mountPath: /otel-lgtm/edrdog-dashboards/edrdog-jvm-kafka.json
+              subPath: edrdog-jvm-kafka.json
+            - name: dashboards
+              mountPath: /otel-lgtm/edrdog-dashboards/edrdog-logs-traces.json
+              subPath: edrdog-logs-traces.json
+            - name: data
+              mountPath: /data
+          readinessProbe:
+            httpGet:
+              path: /api/health
+              port: 3000
+            initialDelaySeconds: 15
+            periodSeconds: 10
+          resources:
+            requests:
+              cpu: 250m
+              memory: 768Mi   # 실측 유휴 ~670Mi (Grafana/Prometheus/Tempo/Loki 동시 구동)
+            limits:
+              memory: 2Gi
+      volumes:
+        - name: dashboards
+          configMap:
+            name: otel-lgtm-dashboards
+        - name: data
+          emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: otel-lgtm
+  namespace: edrdog
+  labels:
+    app: otel-lgtm
+spec:
+  type: NodePort
+  selector:
+    app: otel-lgtm
+  ports:
+    - name: grafana
+      port: 3000
+      targetPort: 3000
+      nodePort: 30300
+    - name: loki
+      port: 3100
+      targetPort: 3100
+      nodePort: 30310
+    - name: otlp-grpc
+      port: 4317
+      targetPort: 4317
+      nodePort: 30317
+    - name: otlp-http
+      port: 4318
+      targetPort: 4318
+      nodePort: 30318

--- a/k8s/responder-service.yaml
+++ b/k8s/responder-service.yaml
@@ -24,6 +24,9 @@ spec:
           env:
             - name: SPRING_KAFKA_BOOTSTRAP_SERVERS
               value: "kafka:9094"
+            # 트레이스 OTLP 수집기 (k8s/otel-lgtm.yaml)
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: "http://otel-lgtm:4318"
             # 실제 조치(kill) 실행은 기본 OFF(dry-run). 신뢰가 쌓인 뒤 아래를 채워 켠다.
             # 켤 때 FLEET_BASE_URL 은 https 여야 하며(FleetTls), 자가서명 인증서면 FLEET_TLS_TRUSTSTORE 를 지정한다.
             # - name: RESPONDER_EXECUTE_ENABLED

--- a/responder-service/src/main/resources/application.yml
+++ b/responder-service/src/main/resources/application.yml
@@ -11,6 +11,8 @@ spring:
       properties:
         spring.json.value.default.type: com.edrdog.responderservice.dto.Alert
         spring.json.trusted.packages: com.edrdog.responderservice.dto
+    listener:
+      observation-enabled: true         # 컨슈머 스팬 생성 → 발행 측 traceId 를 이어받아 한 트레이스로 연결
 
 server:
   port: 8082
@@ -37,3 +39,11 @@ management:
     web:
       exposure:
         include: health, info
+  # 관측 — 트레이스만 보낸다(메트릭 익스포터는 api/detector/archiver 에만).
+  tracing:
+    enabled: ${OTEL_ENABLED:true}
+    sampling:
+      probability: ${OTEL_TRACE_SAMPLING:1.0}
+  otlp:
+    tracing:
+      endpoint: ${OTEL_EXPORTER_OTLP_ENDPOINT:http://localhost:4318}/v1/traces


### PR DESCRIPTION
이번 main 반영으로 **CD 가 배포 서버에 모니터링 스택을 올린다**. 지금까지 CD 는 `set image` 만 했다.

## 포함

| PR | 내용 |
|---|---|
| #79 | 서비스 OTLP 계측(트레이스 6개 전부, 메트릭 3개) + otel-lgtm 스택 + Alloy 로그 수집 |
| #80 | 지표 영속성(PVC), 인프라 메트릭(kubelet cAdvisor), CD 에서 모니터링 매니페스트 apply |
| #78 | 발표용 전체 플로우 시연 API |
| #77 | Kafdrop 배포 매니페스트 |

## 배포 시 일어나는 일

1. `k8s/otel-lgtm.yaml` apply → PVC(5Gi) + Grafana/Prometheus/Tempo/Loki + 대시보드 4종
2. `k8s/alloy.yaml` apply → 파드 로그 수집 + kubelet 인프라 메트릭 수집
3. 서비스 5개 `set image` 롤링 (기존과 동일)

**서비스 매니페스트는 apply 하지 않는다.** 레포는 ClusterIP 인데 서버는 NodePort 30084 로 떠 있어서(Caddy 프록시 대상) apply 하면 사이트가 죽는다. CD 가 그 파일을 건드리지 않도록 대상 파일을 명시했다.

## 배포 전 서버에서 이미 처리한 것

- Infisical CLI 로 `edrdog-secrets` Secret 생성, 서비스 5개에 `envFrom` patch
- `OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-lgtm:4318` 주입 완료
- ClickHouse 비밀번호를 Infisical 값과 일치시킴 (안 맞아 archiver 가 인증 실패로 죽던 것 해결)
- StorageClass `local-path (default)` 확인, 노드 메모리 여유 확인(요청 20% → 26% 예상)

`envFrom` 과 env 는 Deployment 스펙에 저장돼 있어 `set image` 후에도 유지된다.

## 배포 후 확인

```bash
sudo kubectl -n edrdog get pods,pvc | grep -E "otel-lgtm|alloy"
ssh -L 3000:localhost:30300 ubuntu@<서버>   # localhost:3000 에서 EDRdog Overview
```

## 알려진 것

- Grafana 는 익명 Admin 으로 열려 있다(otel-lgtm 이미지 기본값). 데모용으로 그대로 둔다.
- `k8s/clickhouse.yaml` 은 비밀번호가 평문 `edrdog` 인 채로 남아 있다. CD 는 이 파일을 apply 하지 않지만,
  누가 수동으로 apply 하면 비번이 되돌아가 archiver 가 죽는다. 발표 후 정리 대상.
- `collector-service` 는 k8s 매니페스트도 CI 이미지 매트릭스도 없어 배포 환경에서는 관측 대상이 아니다.