### PR TITLE
fix: CI 빌드에 MAXMIND_LICENSE_KEY 주입 (위협 지도가 비는 원인)

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -18,6 +18,10 @@ jobs:
           java-version: '21'
       - uses: gradle/actions/setup-gradle@v4
       - name: Build + test
+        # GeoLite2 mmdb 는 빌드 시점에 받아 jar 에 번들된다. 이 키가 없으면 다운로드를 건너뛰고
+        # 빌드는 그대로 성공하지만, 런타임에 GET /api/events/geo 가 항상 빈 배열을 준다(위협 지도가 빈다).
+        env:
+          MAXMIND_LICENSE_KEY: ${{ secrets.MAXMIND_LICENSE_KEY }}
         run: ./gradlew build
       - name: Strip plain jars
         if: github.event_name == 'push'


### PR DESCRIPTION
## 문제

배포된 api-service 에 GeoLite2 mmdb 가 없다. `GET /api/events/geo` 가 항상 빈 배열을 준다.

`api-service/build.gradle` 의 `downloadGeoLite2` 태스크는 빌드 시점에 MaxMind 에서 mmdb 를 받아 jar 에 번들한다. 키가 없으면 **다운로드를 건너뛰고 빌드는 그대로 성공**한다. CI 워크플로가 그 키를 주입하지 않고 있어서, 빌드는 계속 초록불인데 지도 API 만 조용히 빈 배열을 반환해 왔다.

저장소 시크릿에도 `EC2_HOST`, `EC2_SSH_KEY` 둘뿐이다.

## 수정

`Build + test` 스텝에 `MAXMIND_LICENSE_KEY` 를 전달한다.

시크릿이 없으면 지금과 동작이 완전히 같다(다운로드 skip, 빌드 성공). 즉 이 PR 자체는 안전하다.

## 켜려면

저장소 Settings → Secrets and variables → Actions 에 `MAXMIND_LICENSE_KEY` 를 추가해야 한다. MaxMind 계정에서 GeoLite2 무료 라이선스 키를 발급받으면 된다.

## 연관

프론트에서 위협 지도가 잘못된 경로(`/alerts/geo`)를 부르던 것도 별도 PR 로 고쳤다. 두 개가 다 들어가야 지도에 데이터가 찍힌다.