### PR TITLE
feat: webhook 테스트 전송 API (POST /api/me/webhook/test)

### DIFF
--- a/api-service/src/main/java/com/edrdog/apiservice/auth/exception/AuthException.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/auth/exception/AuthException.java
@@ -9,7 +9,8 @@ public class AuthException extends RuntimeException {
         INVALID_INPUT,  // 400
         UNAUTHORIZED,   // 401
         NOT_FOUND,      // 404
-        DUPLICATE       // 409
+        DUPLICATE,      // 409
+        UPSTREAM_ERROR  // 502 (외부 연동 실패, 예: Slack webhook 테스트 발송)
     }
 
     private final Kind kind;
@@ -37,5 +38,9 @@ public class AuthException extends RuntimeException {
 
     public static AuthException duplicate(String message) {
         return new AuthException(Kind.DUPLICATE, message);
+    }
+
+    public static AuthException upstreamError(String message) {
+        return new AuthException(Kind.UPSTREAM_ERROR, message);
     }
 }

--- a/api-service/src/main/java/com/edrdog/apiservice/auth/exception/AuthExceptionHandler.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/auth/exception/AuthExceptionHandler.java
@@ -22,6 +22,7 @@ public class AuthExceptionHandler {
             case UNAUTHORIZED -> HttpStatus.UNAUTHORIZED;
             case NOT_FOUND -> HttpStatus.NOT_FOUND;
             case DUPLICATE -> HttpStatus.CONFLICT;
+            case UPSTREAM_ERROR -> HttpStatus.BAD_GATEWAY;
         };
         return ResponseEntity.status(status).body(Map.of("error", e.getMessage()));
     }

--- a/api-service/src/main/java/com/edrdog/apiservice/notify/SlackWebhookClient.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/notify/SlackWebhookClient.java
@@ -1,0 +1,47 @@
+package com.edrdog.apiservice.notify;
+
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+import java.util.Map;
+
+/**
+ * 개인 Slack Incoming Webhook 으로 직접 POST 한다. alert-service 의 SlackNotifier 와 달리
+ * 여기서는 실패를 삼키지 않고 Slack 이 준 HTTP 상태코드를 그대로 호출측에 돌려준다
+ * (테스트 알림 API 가 "실제로 도달했는지"를 판단해야 하기 때문).
+ * 요청 스레드가 오래 붙잡히지 않도록 연결/읽기 타임아웃을 짧게 건다.
+ */
+@Component
+public class SlackWebhookClient {
+
+    private static final int TIMEOUT_MS = 3000;
+
+    private final RestClient client;
+
+    public SlackWebhookClient(RestClient.Builder builder) {
+        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
+        factory.setConnectTimeout(TIMEOUT_MS);
+        factory.setReadTimeout(TIMEOUT_MS);
+        this.client = builder.requestFactory(factory).build();
+    }
+
+    /**
+     * webhookUrl 로 {"text": text} 를 POST 하고 Slack 이 응답한 HTTP 상태코드를 돌려준다.
+     * 4xx/5xx 여도 예외를 던지지 않고 상태코드만 돌려준다(호출측이 성공/실패를 판단).
+     * 연결 실패/타임아웃은 RestClientException 이 그대로 전파된다.
+     */
+    public int send(String webhookUrl, String text) {
+        ResponseEntity<Void> response = client.post()
+                .uri(webhookUrl)
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(Map.of("text", text))
+                .retrieve()
+                .onStatus(HttpStatusCode::isError, (req, res) -> { })
+                .toBodilessEntity();
+        return response.getStatusCode().value();
+    }
+}

--- a/api-service/src/main/java/com/edrdog/apiservice/notify/UserNotifyService.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/notify/UserNotifyService.java
@@ -9,6 +9,7 @@ import com.edrdog.apiservice.tenant.WebhookValidation;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.RestClientException;
 
 import java.time.Instant;
 import java.util.List;
@@ -17,17 +18,23 @@ import java.util.Optional;
 /**
  * 유저 개인 알림 설정: 개인 Slack webhook 등록/조회, 소유 host 등록/조회/해제,
  * 그리고 탐지 알림의 라우팅 대상(host 소유자의 목적지) 해결.
- * 검증 실패 400 / 없음 404 / 소유 충돌 409 는 AuthException 으로 던져 전역 핸들러가 매핑한다.
+ * 검증 실패 400 / 없음 404 / 소유 충돌 409 / 외부 연동 실패 502 는 AuthException 으로 던져 전역 핸들러가 매핑한다.
  */
 @Service
 public class UserNotifyService {
 
+    private static final String TEST_MESSAGE =
+            "EDRDOG 테스트 알림입니다. 이 메시지가 보이면 webhook 연동이 정상입니다.";
+
     private final UserRepository users;
     private final HostOwnerRepository hostOwners;
+    private final SlackWebhookClient slackWebhookClient;
 
-    public UserNotifyService(UserRepository users, HostOwnerRepository hostOwners) {
+    public UserNotifyService(UserRepository users, HostOwnerRepository hostOwners,
+                              SlackWebhookClient slackWebhookClient) {
         this.users = users;
         this.hostOwners = hostOwners;
+        this.slackWebhookClient = slackWebhookClient;
     }
 
     /** 개인 webhook 등록/갱신. URL 검증 실패 400, 유저 없음 404. */
@@ -45,6 +52,27 @@ public class UserNotifyService {
     @Transactional(readOnly = true)
     public Optional<String> getWebhook(Long userId) {
         return Optional.ofNullable(user(userId).getSlackWebhookUrl());
+    }
+
+    /**
+     * 저장된 개인 webhook 으로 테스트 메시지를 실제로 보내 도달 여부를 확인한다.
+     * webhook 미등록 404, Slack 이 4xx/5xx 를 주거나 연결 자체가 실패하면 502.
+     * 성공 시 Slack 이 준 HTTP 상태코드를 그대로 돌려준다.
+     */
+    @Transactional(readOnly = true)
+    public int sendTestWebhook(Long userId) {
+        String url = getWebhook(userId)
+                .orElseThrow(() -> AuthException.notFound("등록된 webhook 이 없습니다"));
+        int status;
+        try {
+            status = slackWebhookClient.send(url, TEST_MESSAGE);
+        } catch (RestClientException e) {
+            throw AuthException.upstreamError("Slack 연결에 실패했습니다: " + e.getMessage());
+        }
+        if (status < 200 || status >= 300) {
+            throw AuthException.upstreamError("Slack 이 오류를 반환했습니다 (status=" + status + ")");
+        }
+        return status;
     }
 
     /**

--- a/api-service/src/main/java/com/edrdog/apiservice/notify/web/UserNotifyController.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/notify/web/UserNotifyController.java
@@ -20,6 +20,8 @@ import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.Map;
+
 /**
  * 유저 개인 알림 설정. host 소유 유저에게 개별로 탐지 알림을 보내기 위한 관리 API.
  * /api/me/** 은 로그인 유저(Bearer)가 자기 것만 다룬다.
@@ -58,6 +60,16 @@ public class UserNotifyController {
             @RequestHeader(name = "Authorization", required = false) String authorization) {
         Principal p = principal(authorization);
         return new UserWebhookResponse(p.userId(), notify.getWebhook(p.userId()).orElse(null));
+    }
+
+    @Operation(summary = "내 webhook 테스트 알림",
+            description = "저장된 개인 Slack webhook 으로 테스트 메시지를 보내 실제 도달 여부를 확인한다.")
+    @PostMapping("/api/me/webhook/test")
+    public ResponseEntity<Map<String, Object>> testWebhook(
+            @RequestHeader(name = "Authorization", required = false) String authorization) {
+        Principal p = principal(authorization);
+        int status = notify.sendTestWebhook(p.userId());
+        return ResponseEntity.ok(Map.of("ok", true, "status", status));
     }
 
     @Operation(summary = "내 host 등록", description = "로그인 유저가 소유한 host 를 등록한다. 그 host 탐지 알림이 내 webhook 으로 온다.")

--- a/api-service/src/test/java/com/edrdog/apiservice/notify/UserNotifyServiceTest.java
+++ b/api-service/src/test/java/com/edrdog/apiservice/notify/UserNotifyServiceTest.java
@@ -8,6 +8,7 @@ import com.edrdog.apiservice.notify.repository.HostOwnerRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.web.client.ResourceAccessException;
 
 import java.time.Instant;
 import java.util.List;
@@ -17,25 +18,29 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
- * UserNotifyService: 리포지토리는 목킹, WebhookValidation 은 실제 사용.
+ * UserNotifyService: 리포지토리와 SlackWebhookClient 는 목킹, WebhookValidation 은 실제 사용.
  */
 class UserNotifyServiceTest {
 
     private UserRepository users;
     private HostOwnerRepository hostOwners;
+    private SlackWebhookClient slackWebhookClient;
     private UserNotifyService service;
 
     @BeforeEach
     void setUp() {
         users = mock(UserRepository.class);
         hostOwners = mock(HostOwnerRepository.class);
-        service = new UserNotifyService(users, hostOwners);
+        slackWebhookClient = mock(SlackWebhookClient.class);
+        service = new UserNotifyService(users, hostOwners, slackWebhookClient);
     }
 
     private static AppUser newUser(Long tenantId) {
@@ -77,6 +82,60 @@ class UserNotifyServiceTest {
     void getWebhook_unset_empty() {
         when(users.findById(10L)).thenReturn(Optional.of(newUser(1L)));
         assertThat(service.getWebhook(10L)).isEmpty();
+    }
+
+    // --- webhook 테스트 발송 ---
+
+    @Test
+    @DisplayName("sendTestWebhook: 등록된 webhook 없으면 404, Slack 호출 안 함")
+    void sendTestWebhook_noWebhook_404() {
+        when(users.findById(10L)).thenReturn(Optional.of(newUser(1L)));
+
+        AuthException e = assertThrows(AuthException.class, () -> service.sendTestWebhook(10L));
+
+        assertEquals(AuthException.Kind.NOT_FOUND, e.getKind());
+        verify(slackWebhookClient, never()).send(anyString(), anyString());
+    }
+
+    @Test
+    @DisplayName("sendTestWebhook: Slack 이 2xx 주면 그 상태코드를 반환")
+    void sendTestWebhook_ok_returnsStatus() {
+        AppUser u = newUser(1L);
+        u.updateWebhook("https://hooks.slack.com/services/x");
+        when(users.findById(10L)).thenReturn(Optional.of(u));
+        when(slackWebhookClient.send(eq("https://hooks.slack.com/services/x"), anyString())).thenReturn(200);
+
+        int status = service.sendTestWebhook(10L);
+
+        assertEquals(200, status);
+        verify(slackWebhookClient).send(eq("https://hooks.slack.com/services/x"), anyString());
+    }
+
+    @Test
+    @DisplayName("sendTestWebhook: Slack 이 4xx/5xx 주면 502")
+    void sendTestWebhook_slackError_502() {
+        AppUser u = newUser(1L);
+        u.updateWebhook("https://hooks.slack.com/services/x");
+        when(users.findById(10L)).thenReturn(Optional.of(u));
+        when(slackWebhookClient.send(anyString(), anyString())).thenReturn(404);
+
+        AuthException e = assertThrows(AuthException.class, () -> service.sendTestWebhook(10L));
+
+        assertEquals(AuthException.Kind.UPSTREAM_ERROR, e.getKind());
+    }
+
+    @Test
+    @DisplayName("sendTestWebhook: 연결 실패/타임아웃이면 502")
+    void sendTestWebhook_connectionFailure_502() {
+        AppUser u = newUser(1L);
+        u.updateWebhook("https://hooks.slack.com/services/x");
+        when(users.findById(10L)).thenReturn(Optional.of(u));
+        when(slackWebhookClient.send(anyString(), anyString()))
+                .thenThrow(new ResourceAccessException("timeout"));
+
+        AuthException e = assertThrows(AuthException.class, () -> service.sendTestWebhook(10L));
+
+        assertEquals(AuthException.Kind.UPSTREAM_ERROR, e.getKind());
     }
 
     // --- host 등록 ---

--- a/api-service/src/test/java/com/edrdog/apiservice/notify/web/UserNotifyControllerTest.java
+++ b/api-service/src/test/java/com/edrdog/apiservice/notify/web/UserNotifyControllerTest.java
@@ -1,0 +1,119 @@
+package com.edrdog.apiservice.notify.web;
+
+import com.edrdog.apiservice.notify.SlackWebhookClient;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.web.client.ResourceAccessException;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * POST /api/me/webhook/test 배선(Bearer 유저 해석, webhook 미등록 404, Slack 실제 발송, 오류 매핑)을 검증한다.
+ * Slack 은 실제로 부르지 않고 SlackWebhookClient 를 목으로 대체한다.
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.ANY)
+@TestPropertySource(properties = "spring.kafka.listener.auto-startup=false")
+class UserNotifyControllerTest {
+
+    @Autowired
+    private MockMvc mvc;
+
+    @Autowired
+    private ObjectMapper om;
+
+    @MockitoBean
+    private SlackWebhookClient slackWebhookClient;
+
+    private String signup(String email) throws Exception {
+        MvcResult res = mvc.perform(post("/api/auth/signup")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"email\":\"" + email + "\",\"password\":\"password1\"}"))
+                .andExpect(status().isCreated())
+                .andReturn();
+        return om.readTree(res.getResponse().getContentAsString()).get("token").asText();
+    }
+
+    @Test
+    void 등록된_webhook_없으면_404() throws Exception {
+        String token = signup("no-webhook@edrdog.com");
+
+        mvc.perform(post("/api/me/webhook/test").header("Authorization", "Bearer " + token))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.error").value("등록된 webhook 이 없습니다"));
+
+        verify(slackWebhookClient, never()).send(anyString(), anyString());
+    }
+
+    @Test
+    void 저장된_webhook으로_발송하고_슬랙_상태코드를_돌려준다() throws Exception {
+        String token = signup("has-webhook@edrdog.com");
+        mvc.perform(put("/api/me/webhook")
+                        .header("Authorization", "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"webhookUrl\":\"https://hooks.slack.com/services/x\"}"))
+                .andExpect(status().isOk());
+        when(slackWebhookClient.send(eq("https://hooks.slack.com/services/x"), anyString())).thenReturn(200);
+
+        mvc.perform(post("/api/me/webhook/test").header("Authorization", "Bearer " + token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.ok").value(true))
+                .andExpect(jsonPath("$.status").value(200));
+
+        verify(slackWebhookClient).send(eq("https://hooks.slack.com/services/x"), anyString());
+    }
+
+    @Test
+    void 슬랙이_오류를_주면_502() throws Exception {
+        String token = signup("slack-error@edrdog.com");
+        mvc.perform(put("/api/me/webhook")
+                        .header("Authorization", "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"webhookUrl\":\"https://hooks.slack.com/services/x\"}"))
+                .andExpect(status().isOk());
+        when(slackWebhookClient.send(anyString(), anyString())).thenReturn(404);
+
+        mvc.perform(post("/api/me/webhook/test").header("Authorization", "Bearer " + token))
+                .andExpect(status().isBadGateway())
+                .andExpect(jsonPath("$.error").exists());
+    }
+
+    @Test
+    void 연결_실패면_502() throws Exception {
+        String token = signup("slack-timeout@edrdog.com");
+        mvc.perform(put("/api/me/webhook")
+                        .header("Authorization", "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"webhookUrl\":\"https://hooks.slack.com/services/x\"}"))
+                .andExpect(status().isOk());
+        when(slackWebhookClient.send(anyString(), anyString()))
+                .thenThrow(new ResourceAccessException("timeout"));
+
+        mvc.perform(post("/api/me/webhook/test").header("Authorization", "Bearer " + token))
+                .andExpect(status().isBadGateway())
+                .andExpect(jsonPath("$.error").exists());
+    }
+
+    @Test
+    void 토큰_없으면_401() throws Exception {
+        mvc.perform(post("/api/me/webhook/test")).andExpect(status().isUnauthorized());
+    }
+}


### PR DESCRIPTION
## 왜

webhook 저장은 "DB 에 문자열이 들어갔다"는 뜻일 뿐이었다. 검증이 `url.startsWith("https://")` 가 전부라 **폐기된 webhook, 삭제된 채널, 오타 난 토큰이 전부 통과**한다. 사용자는 실제 침해가 나서 Slack 이 안 울려야 그걸 안다.

온보딩 화면에서 저장 직후 도달 여부를 확인할 수 있게 한다. 프론트 PR 의 "테스트 알림 보내기" 버튼이 이 API 를 부른다.

## 계약

`POST /api/me/webhook/test`, `Authorization: Bearer <token>`, 요청 바디 없음.

| 상황 | 응답 |
|---|---|
| 성공 | `200` `{"ok": true, "status": <슬랙 상태코드>}` |
| 등록된 webhook 없음 | `404` `{"error": "등록된 webhook 이 없습니다"}` |
| Slack 이 4xx/5xx | `502` `{"error": "Slack 이 오류를 반환했습니다 (status=n)"}` |
| 연결 실패·타임아웃 | `502` `{"error": "Slack 연결에 실패했습니다: ..."}` |

`/api/me` 는 `ApiKeyPolicy` 면제 경로라 `X-API-Key` 는 필요 없다. 기존 `/api/me/**` 메서드들과 동일하다.

## 구현

- `SlackWebhookClient`(신규): 저장된 webhook 으로 실제 POST 하고 Slack 이 준 상태코드를 그대로 돌려준다. `alert-service` 의 `SlackNotifier` 와 달리 실패를 삼키지 않는다. 요청 스레드가 묶이지 않게 연결·읽기 타임아웃 3초.
- `AuthException` 에 `UPSTREAM_ERROR`(502) 추가. 인증 예외 타입을 외부 호출 실패에 재사용하는 게 이름상 어색하지만, 기존 `AuthExceptionHandler` 매핑 경로를 하나로 유지하려는 선택이다.

## 테스트

서비스 4건(미등록 404 / 성공 / Slack 오류 502 / 연결 실패 502), 컨트롤러 5건(401 포함) 추가. 실제 Slack 은 부르지 않는다.

`./gradlew :api-service:build` 통과.