### PR TITLE
fix: osquery 수집이 실제로 동작하도록 플래그·배포 포트 수정

### DIFF
--- a/collector-service/README.md
+++ b/collector-service/README.md
@@ -68,7 +68,13 @@ OSQUERY_TLS_KEYSTORE_PASSWORD=changeit \
 공용 파일: OS별 플래그 [`osquery/osquery.mac.flags`](osquery/osquery.mac.flags) /
 [`osquery/osquery.win.flags`](osquery/osquery.win.flags).
 `--tls_hostname` 은 **엔드포인트에서 도달 가능한 api-service HTTPS 주소**로 맞출 것
-(같은 머신 데모면 `localhost:8443`, 원격이면 실주소).
+(로컬 `bootRun` 데모면 `localhost:8443`, k8s 배포면 `<서버주소>:30443` — `k8s/README.md` 참고).
+서버 인증서 SAN 이 이 호스트와 다르면 enroll 단계에서 조용히 실패한다.
+
+퍼블리셔별 활성 플래그가 플래그 파일에 이미 들어 있다. 지우면 **에러 없이 이벤트만 0건**이 되므로 주의:
+macOS 는 `--disable_endpointsecurity=false`(프로세스) · `--enable_file_events=true`(FIM) ·
+`--disable_audit=false --audit_allow_config=true --audit_allow_sockets=true`(소켓),
+Windows 는 `--enable_process_etw_events=true`(프로세스) · `--enable_ntfs_event_publisher=true`(FIM).
 
 ### macOS
 
@@ -79,11 +85,14 @@ OSQUERY_TLS_KEYSTORE_PASSWORD=changeit \
 3. **FDA 부여**: 시스템 설정 → 개인정보 보호 및 보안 → 전체 디스크 접근 → osqueryd 바이너리 추가.
    - `.app` 번들이 아니라 그 안의 유닉스 바이너리를 지정
      (`/opt/osquery/lib/osquery.app/Contents/MacOS/osqueryd`, `Cmd+Shift+G`).
-4. **launchd 데몬으로 실행**(포그라운드/대화형은 TCC 가 터미널 앱에 귀속돼 안 됨):
+4. **launchd 데몬으로 실행**(포그라운드/대화형은 TCC 가 터미널 앱에 귀속돼 안 됨).
+   launchd 잡(`io.osquery.agent`)은 flagfile 경로가 `/var/osquery/osquery.flags` 로 박혀 있으므로
+   플래그 파일을 **그 경로에 두고** 띄운다. 다른 경로에 두면 `osqueryctl start` 가 그냥 무시한다.
    ```bash
-   sudo osqueryd --flagfile /path/to/osquery/osquery.mac.flags
-   # 또는 osqueryctl 로 데몬 등록 후 sudo osqueryctl start
+   sudo cp collector-service/osquery/osquery.mac.flags /var/osquery/osquery.flags
+   sudo osqueryctl start     # /var/osquery/io.osquery.agent.plist 를 LaunchDaemons 로 복사 후 load
    ```
+   중지는 `sudo osqueryctl stop`(unload + plist 삭제).
 5. **재부팅**: TCC(FDA) 권한은 살아있는 세션에 즉시 반영되지 않는다. 재부팅 후 exec 이벤트 수집 확인.
 6. 이벤트가 안 잡히면 FDA/EndpointSecurity 권한부터 의심.
 
@@ -92,12 +101,19 @@ OSQUERY_TLS_KEYSTORE_PASSWORD=changeit \
 `process_etw_events`(ETW)로 프로세스 생성을 감시. **관리자 권한**으로 실행.
 network 이벤트는 core osquery 에 실시간 소켓 테이블이 없어 **Zeek 가 담당**한다.
 
+설치 경로는 `C:\Program Files\osquery` 이고 데몬은 PATH 에 없다. 전체 경로로 부른다.
+
 ```powershell
-osqueryd.exe --flagfile C:\ProgramData\osquery\osquery.win.flags
+winget install --id osquery.osquery -e
+& "C:\Program Files\osquery\osqueryd\osqueryd.exe" --flagfile C:\ProgramData\osquery\osquery.win.flags
 ```
 
-`process_etw_events.type` 리터럴은 버전마다 다를 수 있다. 안 잡히면
-`osqueryi.exe` 에서 `SELECT DISTINCT type FROM process_etw_events;` 로 확인 후 서버 `OsqueryConfig` 의 `WHERE` 수정.
+`process_etw_events.type` 리터럴은 버전마다 다를 수 있다. 확인은 **osqueryd 를 멈춘 상태에서**
+`osqueryi.exe --disable_events=false --enable_process_etw_events=true` 로 직접 띄운 뒤
+`SELECT DISTINCT type FROM process_etw_events;` 를 본다.
+osqueryd 가 도는 중에 그냥 `osqueryi` 를 띄우면 별도 프로세스라 osqueryd 의 이벤트 버퍼가 아니라
+자기 자신의 빈 버퍼를 보게 되고(DB 도 잠겨 있음), 항상 0건으로 보인다.
+값이 다르면 서버 `OsqueryConfig` 의 `WHERE` 를 고친다.
 
 ## 수집 API 배선 검증 (FDA 없이)
 

--- a/collector-service/osquery/osquery.mac.flags
+++ b/collector-service/osquery/osquery.mac.flags
@@ -1,14 +1,20 @@
 # EDRdog osquery 엔드포인트 플래그 (macOS). api-service 수집 TLS API 로 붙는다.
 # 수집 쿼리(schedule)는 서버가 /api/osquery/config 로 내려주므로 여기엔 config 파일이 없다.
 #
-# 실행(FDA 때문에 launchd 데몬 권장):
-#   sudo osqueryd --flagfile=osquery.mac.flags
+# 실행: FDA(TCC)는 실행한 프로세스에 붙으므로 터미널 포그라운드로 띄우면 권한이 터미널 앱에 귀속돼 안 된다.
+# launchd 데몬(io.osquery.agent)은 flagfile 경로가 /var/osquery/osquery.flags 로 박혀 있으므로,
+# 이 파일을 그 경로에 복사한 뒤 osqueryctl 로 띄운다:
+#   sudo cp osquery.mac.flags /var/osquery/osquery.flags && sudo osqueryctl start
 # enroll secret 발급: 프론트 로그인 후 POST /api/tenant/enroll-secret → 값 하나를 enroll_secret_path 파일에 저장.
 
 # --- TLS remote 플러그인 ---
+# gflags 는 줄 끝 주석을 잘라내지 않는다. 주석은 반드시 줄 전체로 쓸 것
+# (--tls_hostname=host:8443  # 설명  → 호스트 값에 "# 설명" 까지 들어가 붙지 않는다).
 --enroll_secret_path=/etc/osquery/enroll.secret
---tls_hostname=localhost:8443                        # api-service osquery HTTPS 커넥터 (dev)
---tls_server_certs=/etc/osquery/osquery-server.pem   # scripts/gen-dev-keystore.sh 가 만든 서버 cert 를 핀
+# api-service osquery HTTPS 커넥터. 로컬 bootRun 이면 localhost:8443, k8s 배포면 <서버주소>:30443
+--tls_hostname=localhost:8443
+# scripts/gen-dev-keystore.sh 가 만든 서버 cert 를 핀
+--tls_server_certs=/etc/osquery/osquery-server.pem
 
 --config_plugin=tls
 --config_tls_endpoint=/api/osquery/config
@@ -21,10 +27,23 @@
 --logger_tls_period=10
 --disable_carver=true
 
-# --- evented 테이블 + EndpointSecurity(es_process_events) ---
-# FDA(전체 디스크 접근)가 없으면 EndpointSecurity 는 에러 없이 조용히 빈 결과가 된다. README 참고.
+# --- evented 테이블 ---
+# 서버가 내려주는 macOS 스케줄은 3종류 테이블을 쓴다. 퍼블리셔마다 켜는 플래그가 따로 있고,
+# 안 켜면 osquery 는 에러 없이 조용히 빈 결과를 준다(그래서 "수집은 도는데 이벤트가 0" 이 된다).
 --disable_events=false
+
+# es_process_events (EndpointSecurity) → process_events / script_events 스케줄
+# FDA(전체 디스크 접근)가 없으면 여기까지 맞춰도 조용히 빈 결과가 된다. README 참고.
 --disable_endpointsecurity=false
+
+# file_events (FSEvents) → file_events 스케줄(자동실행 경로 FIM, detector T1547 판정 입력)
+--enable_file_events=true
+
+# socket_events (OpenBSM) → socket_events 스케줄(아웃바운드 연결, detector network 룰 입력)
+# audit_allow_config 는 osquery 가 /etc/security/audit_control 을 런타임에 고쳐 필요한 audit 클래스를 켜게 한다.
+--disable_audit=false
+--audit_allow_config=true
+--audit_allow_sockets=true
 
 --host_identifier=hostname
 --disable_watchdog=true

--- a/collector-service/osquery/osquery.win.flags
+++ b/collector-service/osquery/osquery.win.flags
@@ -1,14 +1,18 @@
 # EDRdog osquery 엔드포인트 플래그 (Windows). api-service 수집 TLS API 로 붙는다.
 # 수집 쿼리(schedule)는 서버가 /api/osquery/config 로 내려주므로 여기엔 config 파일이 없다.
 #
-# 실행(관리자 PowerShell):
-#   osqueryd.exe --flagfile=C:\ProgramData\osquery\osquery.win.flags
+# 실행(관리자 PowerShell). osqueryd.exe 는 PATH 에 없으므로 전체 경로로 부른다:
+#   & "C:\Program Files\osquery\osqueryd\osqueryd.exe" --flagfile=C:\ProgramData\osquery\osquery.win.flags
 # enroll secret 발급: 프론트 로그인 후 POST /api/tenant/enroll-secret → 값을 enroll_secret_path 파일에 저장.
 
 # --- TLS remote 플러그인 ---
+# gflags 는 줄 끝 주석을 잘라내지 않는다. 주석은 반드시 줄 전체로 쓸 것
+# (--tls_hostname=host:8443  # 설명  → 호스트 값에 "# 설명" 까지 들어가 붙지 않는다).
 --enroll_secret_path=C:\ProgramData\osquery\enroll.secret
+# api-service osquery HTTPS 커넥터. 로컬 bootRun 이면 localhost:8443, k8s 배포면 <서버주소>:30443
 --tls_hostname=localhost:8443
---tls_server_certs=C:\ProgramData\osquery\osquery-server.pem   # gen-dev-keystore.sh 산출 PEM 을 핀(dev)
+# gen-dev-keystore.sh 산출 PEM 을 핀(dev)
+--tls_server_certs=C:\ProgramData\osquery\osquery-server.pem
 
 --config_plugin=tls
 --config_tls_endpoint=/api/osquery/config
@@ -21,9 +25,17 @@
 --logger_tls_period=10
 --disable_carver=true
 
-# --- evented 테이블 + ETW(process_etw_events) 로 프로세스 생성 감시 ---
+# --- evented 테이블 ---
+# 퍼블리셔마다 켜는 플래그가 따로 있고, 안 켜면 osquery 는 에러 없이 조용히 빈 결과를 준다.
 # network 이벤트는 core osquery 에 실시간 소켓 테이블이 없어 Zeek 가 담당한다.
 --disable_events=false
+
+# process_etw_events (ETW) → process_etw_events / script_etw_events 스케줄
+# 이 플래그가 없으면 Windows 수집은 전부 0건이다(퍼블리셔가 setUp 에서 바로 빠진다).
+--enable_process_etw_events=true
+
+# file_events (NTFS USN 저널) → file_events 스케줄(시작프로그램 FIM, detector T1547 판정 입력)
+--enable_ntfs_event_publisher=true
 
 --host_identifier=hostname
 --disable_watchdog=true

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -23,6 +23,7 @@ kubectl -n edrdog get pods                            # Running 확인
 | Grafana | `http://localhost:3000` | admin / admin. 첫 화면이 EDRdog Overview |
 | OTLP HTTP | `http://localhost:4318` | 서비스가 메트릭·트레이스를 보내는 곳 |
 | OTLP gRPC | `localhost:4317` | 〃 |
+| osquery 수집 HTTPS | `localhost:8443` (NodePort 30443) | 엔드포인트 osquery 가 붙는 곳. 아래 시크릿을 만들어야 열린다 |
 
 클러스터 내부(파드 간) Kafka 주소: `kafka.edrdog.svc.cluster.local:9094`
 클러스터 내부 OTLP 주소: `http://otel-lgtm:4318` (각 서비스 Deployment 의 `OTEL_EXPORTER_OTLP_ENDPOINT`)
@@ -50,6 +51,46 @@ curl "http://localhost:3000/api/datasources/proxy/uid/loki/loki/api/v1/label/ser
 ```bash
 kind delete cluster --name edrdog    # 클러스터째 삭제 (데이터 emptyDir 라 함께 소멸)
 ```
+
+## osquery 수집 포트 (api-service 8443 / NodePort 30443)
+
+엔드포인트의 osquery TLS logger 는 평문 HTTP 로 붙지 않는다. 그래서 api-service 는 프론트용 8084 와 별도로
+osquery 전용 HTTPS 커넥터를 8443 에 연다. **이 커넥터는 `osquery-tls` Secret 이 있을 때만 켜진다**
+(Secret 이 없으면 값이 안 들어와 `OSQUERY_TLS_ENABLED` 가 기본 false 로 남고, api-service 는 그대로 정상 기동한다).
+
+```bash
+# 1) 서버 인증서 + 키스토어 생성. 인자는 엔드포인트가 실제로 붙을 주소(도메인 또는 공인 IP).
+#    osquery 가 이 인증서를 핀하므로 SAN 이 --tls_hostname 의 호스트와 같아야 한다.
+./scripts/gen-dev-keystore.sh ./dev-tls edrdog.example.com
+
+# 2) Secret 생성 (키스토어 + 스위치 + 비번을 한 Secret 에)
+kubectl -n edrdog create secret generic osquery-tls \
+  --from-file=keystore.p12=./dev-tls/osquery-keystore.p12 \
+  --from-literal=OSQUERY_TLS_ENABLED=true \
+  --from-literal=OSQUERY_TLS_KEYSTORE_PASSWORD=changeit
+
+kubectl -n edrdog rollout restart deploy/api-service
+
+# 3) 확인 (self-signed 라 -k)
+curl -sk https://localhost:8443/api/osquery/enroll -H 'Content-Type: application/json' \
+  -d '{"enroll_secret":"틀린값"}'      # -> {"node_invalid":true} 면 커넥터 정상
+```
+
+엔드포인트에는 `./dev-tls/osquery-server.pem` 을 배포하고 플래그를 맞춘다.
+
+```
+--tls_hostname=edrdog.example.com:30443
+--tls_server_certs=<osquery-server.pem 경로>
+```
+
+- **Caddy 로 프록시하면 안 된다.** osquery 가 서버 인증서를 핀하므로 중간에서 TLS 를 다시 종단하면
+  엔드포인트가 enroll 단계에서 조용히 실패한다. 노출하려면 NodePort 30443 을 보안그룹에서 직접 열거나
+  L4(TCP) 통과 프록시를 쓴다.
+- 인증서 SAN 이 `--tls_hostname` 의 호스트와 다르면 역시 enroll 단계에서 실패한다. 주소가 바뀌면 인증서를
+  다시 만들고 Secret 을 갱신한 뒤 엔드포인트의 PEM 까지 교체해야 한다.
+- kind 로컬에서는 `kind-cluster.yaml` 의 `30443 -> hostPort 8443` 매핑을 쓴다.
+  **`extraPortMappings` 는 클러스터 생성 시에만 반영**되므로 기존 클러스터라면 다시 만들거나
+  `kubectl -n edrdog port-forward svc/api-service-osquery 8443:8443` 로 우회한다.
 
 ## 시크릿 (Infisical)
 

--- a/k8s/api-service.yaml
+++ b/k8s/api-service.yaml
@@ -21,7 +21,27 @@ spec:
           image: ghcr.io/2026-siheung-bootcamp-team-i/backend/api-service:latest
           ports:
             - containerPort: 8084
+            - containerPort: 8443   # osquery 수집 전용 HTTPS 커넥터 (osquery-tls Secret 이 있을 때만 열린다)
           env:
+            # --- osquery 수집 HTTPS 커넥터 ---
+            # 엔드포인트의 osquery TLS logger 는 평문 HTTP 로 안 붙으므로 이 포트가 없으면 수집 자체가 불가능하다.
+            # 스위치와 비번은 osquery-tls Secret 에서 온다. Secret 이 없으면 값이 안 들어와 커넥터는 꺼진 채(기본 false)
+            # 뜨므로 api-service 는 그대로 정상 기동한다. 생성 절차는 k8s/README.md 참고.
+            - name: OSQUERY_TLS_ENABLED
+              valueFrom:
+                secretKeyRef:
+                  name: osquery-tls
+                  key: OSQUERY_TLS_ENABLED
+                  optional: true
+            - name: OSQUERY_TLS_KEYSTORE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: osquery-tls
+                  key: OSQUERY_TLS_KEYSTORE_PASSWORD
+                  optional: true
+            # 키스토어는 아래 volume 으로 마운트된 파일을 읽는다 (Secret 없으면 이 경로도 비어 있지만 커넥터가 꺼져 있어 무해).
+            - name: OSQUERY_TLS_KEYSTORE
+              value: "/etc/osquery-tls/keystore.p12"
             - name: KAFKA_BOOTSTRAP
               value: "kafka:9094"
             - name: DB_URL
@@ -60,6 +80,19 @@ spec:
             limits:
               cpu: 500m
               memory: 512Mi
+          volumeMounts:
+            - name: osquery-tls
+              mountPath: /etc/osquery-tls
+              readOnly: true
+      volumes:
+        # optional:true 라 Secret 이 없어도 파드는 뜬다(빈 디렉터리로 마운트). 그때는 커넥터도 꺼져 있다.
+        - name: osquery-tls
+          secret:
+            secretName: osquery-tls
+            optional: true
+            items:
+              - key: keystore.p12
+                path: keystore.p12
 ---
 apiVersion: v1
 kind: Service
@@ -74,3 +107,23 @@ spec:
   ports:
     - port: 80
       targetPort: 8084
+---
+# osquery 엔드포인트가 붙는 수집 포트. NodePort 30443 로 직접 노출한다.
+# Caddy 로 프록시하면 안 된다: osquery 가 --tls_server_certs 로 서버 인증서를 핀하기 때문에
+# 중간에서 TLS 를 다시 종단하면 엔드포인트가 등록 단계에서 실패한다(프록시하려면 L4 TCP 통과여야 함).
+# EC2 보안그룹에 30443/TCP 를 열어야 외부 기기가 붙을 수 있다.
+apiVersion: v1
+kind: Service
+metadata:
+  name: api-service-osquery
+  namespace: edrdog
+  labels:
+    app: api-service
+spec:
+  type: NodePort
+  selector:
+    app: api-service
+  ports:
+    - port: 8443
+      targetPort: 8443
+      nodePort: 30443

--- a/k8s/kind-cluster.yaml
+++ b/k8s/kind-cluster.yaml
@@ -31,3 +31,6 @@ nodes:
       - containerPort: 30318   # OTLP HTTP           -> host localhost:4318
         hostPort: 4318
         protocol: TCP
+      - containerPort: 30443   # osquery 수집 HTTPS  -> host localhost:8443
+        hostPort: 8443
+        protocol: TCP

--- a/scripts/gen-dev-keystore.sh
+++ b/scripts/gen-dev-keystore.sh
@@ -18,8 +18,16 @@ ALIAS="${OSQUERY_TLS_KEY_ALIAS:-osquery}"
 
 mkdir -p "$OUT"
 
+# osquery 는 --tls_hostname 의 호스트를 서버 인증서의 SAN 과 대조한다.
+# 배포 주소가 IP 면 dns: 로 넣어봐야 검증에 실패하므로 IPv4 는 ip: 로 넣는다.
+if [[ "$HOST" =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  SAN="ip:$HOST,ip:127.0.0.1"
+else
+  SAN="dns:$HOST,ip:127.0.0.1"
+fi
+
 keytool -genkeypair -alias "$ALIAS" -keyalg RSA -keysize 2048 -validity 825 \
-  -dname "CN=$HOST" -ext "SAN=dns:$HOST,ip:127.0.0.1" \
+  -dname "CN=$HOST" -ext "SAN=$SAN" \
   -keystore "$OUT/osquery-keystore.p12" -storetype PKCS12 \
   -storepass "$PASS" -keypass "$PASS"
 
@@ -38,5 +46,12 @@ echo "  OSQUERY_TLS_KEYSTORE=$OUT/osquery-keystore.p12 \\"
 echo "  OSQUERY_TLS_KEYSTORE_PASSWORD=$PASS \\"
 echo "  ./gradlew :api-service:bootRun"
 echo
+echo "k8s(api-service) 에 태우려면 Secret 하나 만들면 끝(만들기 전엔 커넥터 OFF):"
+echo "  kubectl -n edrdog create secret generic osquery-tls \\"
+echo "    --from-file=keystore.p12=$OUT/osquery-keystore.p12 \\"
+echo "    --from-literal=OSQUERY_TLS_ENABLED=true \\"
+echo "    --from-literal=OSQUERY_TLS_KEYSTORE_PASSWORD=$PASS"
+echo "  kubectl -n edrdog rollout restart deploy/api-service"
+echo
 echo "osquery 엔드포인트 플래그: collector-service/osquery/osquery.mac.flags · osquery.win.flags"
-echo "  (--tls_server_certs 를 $OUT/osquery-server.pem 로 지정)"
+echo "  (--tls_server_certs 를 $OUT/osquery-server.pem 로 지정, --tls_hostname 은 $HOST:30443)"


### PR DESCRIPTION
## 요약

온보딩 안내대로 엔드포인트를 설치해도 수집이 되지 않는 상태였다. 두 지점이 막혀 있었다.

1. **플래그**: 이벤트 퍼블리셔 활성 플래그가 빠져 있어 osquery 가 에러 없이 조용히 빈 결과를 준다. 특히 Windows 는 `--enable_process_etw_events` 가 없어 수집이 전부 0건이었다.
2. **배포**: osquery 가 붙을 8443 포트가 매니페스트에 아예 없었다(`OSQUERY_TLS_ENABLED` 기본 false, containerPort/Service 없음). 붙을 주소 자체가 없는 상태.

## 변경

### 1. 퍼블리셔 플래그 (`collector-service/osquery/*.flags`)

서버가 내려주는 schedule(`OsqueryConfig`)이 쓰는 테이블별로 채웠다.

| 테이블 | 필요한 플래그 |
|---|---|
| `process_etw_events` (Win) | `--enable_process_etw_events=true` |
| `file_events` (Win) | `--enable_ntfs_event_publisher=true` |
| `file_events` (mac) | `--enable_file_events=true` |
| `socket_events` (mac) | `--disable_audit=false`, `--audit_allow_config=true`, `--audit_allow_sockets=true` |
| `es_process_events` (mac) | `--disable_endpointsecurity=false` (기존에 있었음) |

플래그 이름은 osquery 소스에서 확인했다: `etw_publisher_processes.cpp`, `ntfs_event_publisher.cpp`, `fsevents.cpp`, `tables/events/darwin/socket_events.cpp`.

같은 파일에서 두 가지를 함께 고쳤다.

- **줄 끝 주석 제거**: gflags 는 flagfile 에서 줄 전체가 `#` 으로 시작할 때만 주석으로 본다(`gflags.cc` ProcessOptionsFromStringLocked). `--tls_hostname=host:8443  # 설명` 이면 호스트 값에 주석까지 들어간다. 주석을 위쪽 줄로 옮겼다.
- **실행 방법 정정**: macOS launchd 잡은 `--flagfile=/private/var/osquery/osquery.flags` 로 고정이라 다른 경로 플래그 파일은 `osqueryctl start` 가 무시한다. Windows 는 `osqueryd.exe` 가 PATH 에 없어 전체 경로로 호출해야 한다. `osqueryi` 로 수집을 확인하던 안내도 정정했다(osqueryd 와 별개 프로세스라 항상 0건으로 보인다).

### 2. 수집 포트 노출 (`k8s/`)

- `api-service` Deployment 에 containerPort 8443 + 키스토어 볼륨 + `osquery-tls` Secret 참조
- **Secret 참조는 전부 `optional: true`**. Secret 이 없으면 커넥터는 꺼진 채 남고 파드는 정상 기동한다(`@ConditionalOnProperty`). 시크릿을 안 만든 사람이 크래시 루프를 겪지 않게 한 선택.
- `api-service-osquery` Service (NodePort 30443) 추가
- `kind-cluster.yaml`: 30443 → hostPort 8443
- `gen-dev-keystore.sh`: 인자가 IPv4 면 SAN 을 `ip:` 로. 전에는 `dns:1.2.3.4` 라 IP 주소로 배포하면 인증서 검증이 실패했다

## 주의

- **Caddy 로 프록시하면 안 된다.** osquery 가 서버 인증서를 핀하므로 중간에서 TLS 를 다시 종단하면 enroll 단계에서 실패한다. 보안그룹에서 30443/TCP 를 직접 열어야 한다.
- **CD 는 이 매니페스트를 apply 하지 않는다.** `cicd.yml` 이 api-service 매니페스트를 일부러 건너뛴다(서버 Service 가 NodePort 30084 라 레포의 ClusterIP 를 apply 하면 사이트가 죽는다). 배포서버 반영은 Deployment 문서와 신규 Service 만 골라 수동 apply 해야 하고, 절차는 `k8s/README.md` 에 적어뒀다.

## 검증

- `kubectl apply --dry-run=client -f k8s/api-service.yaml` 통과
- `bash -n scripts/gen-dev-keystore.sh` 통과
- 플래그 이름 4종 osquery 소스 대조
- 실제 엔드포인트에서 osqueryd 를 띄워 확인한 것은 아님(기기 없음)

## 관련

프론트 온보딩 화면도 같은 내용이 그대로 박혀 있어 별도로 고쳤다 (Frontend `fix/onboarding-osquery-flags`).