### PR TITLE
release: dev → main (osquery 수집 배선, webhook 테스트 API, Kafka UI)

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -103,8 +103,11 @@ jobs:
           MODULES="detector-service responder-service archiver-service api-service alert-service"
 
           # 모니터링 스택과 Kafka UI 만 매니페스트로 apply 한다.
-          # 서비스 5개 매니페스트는 손대지 않는다. 레포의 api-service Service 는 ClusterIP 인데
-          # 서버는 NodePort 30084 로 떠 있어(Caddy 가 이 포트로 프록시) apply 하면 사이트가 죽는다.
+          # 서비스 5개 매니페스트는 손대지 않는다. apply 하면 image 가 :latest 로 되돌아갔다가
+          # 아래 set image 로 다시 :sha 가 되면서 롤아웃이 두 번 돌기 때문이다.
+          # (레포 api-service Service 가 ClusterIP 라 apply 하면 NodePort 30084 가 벗겨져 사이트가
+          #  죽던 문제는 매니페스트를 실제 상태에 맞추면서 해소됐다. 매니페스트 변경 반영은
+          #  k8s/README.md 의 수동 apply 절차를 따른다.)
           # 서버 브랜치를 건드리지 않으려고 FETCH_HEAD 에서 파일만 꺼내 적용한다.
           if [ -d ~/Backend/.git ]; then
           git -C ~/Backend fetch --quiet origin main

--- a/alert-service/src/main/java/com/edrdog/alertservice/AlertListener.java
+++ b/alert-service/src/main/java/com/edrdog/alertservice/AlertListener.java
@@ -50,7 +50,11 @@ public class AlertListener {
         }
         String key = route.get().cooldownId() + "|" + alert.host() + "|" + alert.ruleId();
         if (cooldown.allow(key, alert.ts())) {
-            slack.send(alert, route.get().webhookUrl());
+            // 발송이 실패하면 기록을 되돌린다. 안 그러면 실패한 발송이 쿨다운 창을 태워
+            // 같은 alert 의 재발생분까지 조용히 막힌다.
+            if (!slack.send(alert, route.get().webhookUrl())) {
+                cooldown.forget(key);
+            }
         }
     }
 }

--- a/alert-service/src/main/java/com/edrdog/alertservice/Cooldown.java
+++ b/alert-service/src/main/java/com/edrdog/alertservice/Cooldown.java
@@ -26,4 +26,13 @@ public class Cooldown {
         lastSent.put(key, nowMs);
         return true;
     }
+
+    /**
+     * 기록을 지워 다음 요청이 다시 통과하게 한다.
+     * allow 는 발송 전에 호출되므로, 발송이 실패했는데 기록이 남으면 그 실패가 쿨다운 창을 태워
+     * 같은 alert 의 재발생분까지 막는다. 실패 시 롤백해 그 상황을 없앤다.
+     */
+    public void forget(String key) {
+        lastSent.remove(key);
+    }
 }

--- a/alert-service/src/main/java/com/edrdog/alertservice/slack/SlackNotifier.java
+++ b/alert-service/src/main/java/com/edrdog/alertservice/slack/SlackNotifier.java
@@ -25,8 +25,12 @@ public class SlackNotifier {
         this.client = builder.build();
     }
 
-    /** alert 를 주어진 webhook URL 로 전송. 실패는 경고 로그만 남기고 삼킨다. */
-    public void send(Alert alert, String webhookUrl) {
+    /**
+     * alert 를 주어진 webhook URL 로 전송하고 성공 여부를 돌려준다.
+     * 예외를 밖으로 던지지는 않는다(한 건 실패로 컨슈머를 멈추지 않는다). 대신 false 를 돌려줘
+     * 호출자가 쿨다운을 롤백할 수 있게 한다.
+     */
+    public boolean send(Alert alert, String webhookUrl) {
         try {
             client.post()
                     .uri(webhookUrl)
@@ -34,9 +38,11 @@ public class SlackNotifier {
                     .body(Map.of("text", format(alert)))
                     .retrieve()
                     .toBodilessEntity();
+            return true;
         } catch (Exception e) {
             log.warn("Slack 발송 실패 (tenant={}, host={}, rule={}): {}",
                     alert.tenantId(), alert.host(), alert.ruleId(), e.getMessage());
+            return false;
         }
     }
 

--- a/alert-service/src/test/java/com/edrdog/alertservice/AlertListenerTest.java
+++ b/alert-service/src/test/java/com/edrdog/alertservice/AlertListenerTest.java
@@ -1,0 +1,91 @@
+package com.edrdog.alertservice;
+
+import com.edrdog.alertservice.dto.Alert;
+import com.edrdog.alertservice.slack.SlackNotifier;
+import com.edrdog.alertservice.webhook.AlertRouter;
+import com.edrdog.alertservice.webhook.AlertRouter.Route;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/** AlertListener: 라우팅 결과에 따른 발송/skip 과 쿨다운 억제·롤백. */
+class AlertListenerTest {
+
+    private static final String WEBHOOK = "https://hooks/abc";
+
+    private AlertRouter router;
+    private SlackNotifier slack;
+    private AlertListener listener;
+
+    @BeforeEach
+    void setUp() {
+        router = mock(AlertRouter.class);
+        slack = mock(SlackNotifier.class);
+        listener = new AlertListener(60_000, router, slack);
+    }
+
+    private Alert alert(long ts) {
+        return new Alert("t1", "host-1", "SUSPICIOUS_PROCESS_CHAIN", "T1059",
+                Alert.SEV_HIGH, Alert.ACTION_KILL, ts, List.of("evidence"));
+    }
+
+    private void routed() {
+        when(router.route(any())).thenReturn(Optional.of(new Route(WEBHOOK, "user:1")));
+    }
+
+    @Test
+    @DisplayName("목적지가 있으면 그 webhook 으로 발송한다")
+    void routed_sends() {
+        routed();
+        when(slack.send(any(), anyString())).thenReturn(true);
+
+        listener.onAlert(alert(1_000));
+
+        verify(slack).send(any(), anyString());
+    }
+
+    @Test
+    @DisplayName("목적지가 없으면 발송하지 않는다")
+    void noRoute_skips() {
+        when(router.route(any())).thenReturn(Optional.empty());
+
+        listener.onAlert(alert(1_000));
+
+        verify(slack, never()).send(any(), anyString());
+    }
+
+    @Test
+    @DisplayName("발송에 성공하면 윈도우 안 같은 alert 는 억제된다")
+    void sendSucceeded_withinWindow_suppressed() {
+        routed();
+        when(slack.send(any(), anyString())).thenReturn(true);
+
+        listener.onAlert(alert(1_000));
+        listener.onAlert(alert(2_000));
+
+        verify(slack, times(1)).send(any(), anyString());
+    }
+
+    @Test
+    @DisplayName("발송에 실패하면 쿨다운을 롤백해 다음 alert 를 막지 않는다")
+    void sendFailed_cooldownRolledBack() {
+        routed();
+        when(slack.send(any(), anyString())).thenReturn(false);
+
+        listener.onAlert(alert(1_000));
+        listener.onAlert(alert(2_000));
+
+        verify(slack, times(2)).send(any(), anyString());
+    }
+}

--- a/alert-service/src/test/java/com/edrdog/alertservice/CooldownTest.java
+++ b/alert-service/src/test/java/com/edrdog/alertservice/CooldownTest.java
@@ -47,4 +47,27 @@ class CooldownTest {
         assertThat(cooldown.allow("t1|host-1|RULE", 1_000)).isTrue();
         assertThat(cooldown.allow("t1|host-1|RULE", 30_000)).isFalse();
     }
+
+    @Test
+    @DisplayName("forget 하면 윈도우 안이어도 다시 통과한다 (발송 실패 롤백용)")
+    void forget_allowsAgainWithinWindow() {
+        Cooldown cooldown = new Cooldown(60_000);
+        assertThat(cooldown.allow("t1|host-1|RULE", 1_000)).isTrue();
+
+        cooldown.forget("t1|host-1|RULE");
+
+        assertThat(cooldown.allow("t1|host-1|RULE", 2_000)).isTrue();
+    }
+
+    @Test
+    @DisplayName("forget 은 다른 키에 영향을 주지 않는다")
+    void forget_otherKeysUntouched() {
+        Cooldown cooldown = new Cooldown(60_000);
+        cooldown.allow("t1|host-1|RULE", 1_000);
+        cooldown.allow("t1|host-2|RULE", 1_000);
+
+        cooldown.forget("t1|host-1|RULE");
+
+        assertThat(cooldown.allow("t1|host-2|RULE", 2_000)).isFalse();
+    }
 }

--- a/alert-service/src/test/java/com/edrdog/alertservice/slack/SlackNotifierTest.java
+++ b/alert-service/src/test/java/com/edrdog/alertservice/slack/SlackNotifierTest.java
@@ -13,6 +13,7 @@ import static org.springframework.http.HttpMethod.POST;
 import static org.springframework.test.web.client.ExpectedCount.once;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withServerError;
 import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
 
 /** SlackNotifier: 메시지 포맷(순수) + 주어진 webhook 으로 POST 검증. */
@@ -57,7 +58,21 @@ class SlackNotifierTest {
                 .andExpect(method(POST))
                 .andRespond(withSuccess());
 
-        notifier.send(alert(Alert.SEV_HIGH, Alert.ACTION_KILL), "https://hooks/abc");
+        assertThat(notifier.send(alert(Alert.SEV_HIGH, Alert.ACTION_KILL), "https://hooks/abc")).isTrue();
+        server.verify();
+    }
+
+    @Test
+    @DisplayName("Slack 이 5xx 를 주면 false 를 돌려준다 (호출자가 쿨다운을 롤백할 수 있게)")
+    void send_returnsFalseOnFailure() {
+        RestClient.Builder builder = RestClient.builder();
+        MockRestServiceServer server = MockRestServiceServer.bindTo(builder).build();
+        SlackNotifier notifier = new SlackNotifier(builder);
+
+        server.expect(once(), requestTo("https://hooks/abc"))
+                .andRespond(withServerError());
+
+        assertThat(notifier.send(alert(Alert.SEV_HIGH, Alert.ACTION_KILL), "https://hooks/abc")).isFalse();
         server.verify();
     }
 }

--- a/collector-service/README.md
+++ b/collector-service/README.md
@@ -68,7 +68,13 @@ OSQUERY_TLS_KEYSTORE_PASSWORD=changeit \
 공용 파일: OS별 플래그 [`osquery/osquery.mac.flags`](osquery/osquery.mac.flags) /
 [`osquery/osquery.win.flags`](osquery/osquery.win.flags).
 `--tls_hostname` 은 **엔드포인트에서 도달 가능한 api-service HTTPS 주소**로 맞출 것
-(같은 머신 데모면 `localhost:8443`, 원격이면 실주소).
+(로컬 `bootRun` 데모면 `localhost:8443`, k8s 배포면 `<서버주소>:30443` — `k8s/README.md` 참고).
+서버 인증서 SAN 이 이 호스트와 다르면 enroll 단계에서 조용히 실패한다.
+
+퍼블리셔별 활성 플래그가 플래그 파일에 이미 들어 있다. 지우면 **에러 없이 이벤트만 0건**이 되므로 주의:
+macOS 는 `--disable_endpointsecurity=false`(프로세스) · `--enable_file_events=true`(FIM) ·
+`--disable_audit=false --audit_allow_config=true --audit_allow_sockets=true`(소켓),
+Windows 는 `--enable_process_etw_events=true`(프로세스) · `--enable_ntfs_event_publisher=true`(FIM).
 
 ### macOS
 
@@ -79,11 +85,14 @@ OSQUERY_TLS_KEYSTORE_PASSWORD=changeit \
 3. **FDA 부여**: 시스템 설정 → 개인정보 보호 및 보안 → 전체 디스크 접근 → osqueryd 바이너리 추가.
    - `.app` 번들이 아니라 그 안의 유닉스 바이너리를 지정
      (`/opt/osquery/lib/osquery.app/Contents/MacOS/osqueryd`, `Cmd+Shift+G`).
-4. **launchd 데몬으로 실행**(포그라운드/대화형은 TCC 가 터미널 앱에 귀속돼 안 됨):
+4. **launchd 데몬으로 실행**(포그라운드/대화형은 TCC 가 터미널 앱에 귀속돼 안 됨).
+   launchd 잡(`io.osquery.agent`)은 flagfile 경로가 `/var/osquery/osquery.flags` 로 박혀 있으므로
+   플래그 파일을 **그 경로에 두고** 띄운다. 다른 경로에 두면 `osqueryctl start` 가 그냥 무시한다.
    ```bash
-   sudo osqueryd --flagfile /path/to/osquery/osquery.mac.flags
-   # 또는 osqueryctl 로 데몬 등록 후 sudo osqueryctl start
+   sudo cp collector-service/osquery/osquery.mac.flags /var/osquery/osquery.flags
+   sudo osqueryctl start     # /var/osquery/io.osquery.agent.plist 를 LaunchDaemons 로 복사 후 load
    ```
+   중지는 `sudo osqueryctl stop`(unload + plist 삭제).
 5. **재부팅**: TCC(FDA) 권한은 살아있는 세션에 즉시 반영되지 않는다. 재부팅 후 exec 이벤트 수집 확인.
 6. 이벤트가 안 잡히면 FDA/EndpointSecurity 권한부터 의심.
 
@@ -92,12 +101,19 @@ OSQUERY_TLS_KEYSTORE_PASSWORD=changeit \
 `process_etw_events`(ETW)로 프로세스 생성을 감시. **관리자 권한**으로 실행.
 network 이벤트는 core osquery 에 실시간 소켓 테이블이 없어 **Zeek 가 담당**한다.
 
+설치 경로는 `C:\Program Files\osquery` 이고 데몬은 PATH 에 없다. 전체 경로로 부른다.
+
 ```powershell
-osqueryd.exe --flagfile C:\ProgramData\osquery\osquery.win.flags
+winget install --id osquery.osquery -e
+& "C:\Program Files\osquery\osqueryd\osqueryd.exe" --flagfile C:\ProgramData\osquery\osquery.win.flags
 ```
 
-`process_etw_events.type` 리터럴은 버전마다 다를 수 있다. 안 잡히면
-`osqueryi.exe` 에서 `SELECT DISTINCT type FROM process_etw_events;` 로 확인 후 서버 `OsqueryConfig` 의 `WHERE` 수정.
+`process_etw_events.type` 리터럴은 버전마다 다를 수 있다. 확인은 **osqueryd 를 멈춘 상태에서**
+`osqueryi.exe --disable_events=false --enable_process_etw_events=true` 로 직접 띄운 뒤
+`SELECT DISTINCT type FROM process_etw_events;` 를 본다.
+osqueryd 가 도는 중에 그냥 `osqueryi` 를 띄우면 별도 프로세스라 osqueryd 의 이벤트 버퍼가 아니라
+자기 자신의 빈 버퍼를 보게 되고(DB 도 잠겨 있음), 항상 0건으로 보인다.
+값이 다르면 서버 `OsqueryConfig` 의 `WHERE` 를 고친다.
 
 ## 수집 API 배선 검증 (FDA 없이)
 

--- a/collector-service/osquery/osquery.mac.flags
+++ b/collector-service/osquery/osquery.mac.flags
@@ -1,14 +1,20 @@
 # EDRdog osquery 엔드포인트 플래그 (macOS). api-service 수집 TLS API 로 붙는다.
 # 수집 쿼리(schedule)는 서버가 /api/osquery/config 로 내려주므로 여기엔 config 파일이 없다.
 #
-# 실행(FDA 때문에 launchd 데몬 권장):
-#   sudo osqueryd --flagfile=osquery.mac.flags
+# 실행: FDA(TCC)는 실행한 프로세스에 붙으므로 터미널 포그라운드로 띄우면 권한이 터미널 앱에 귀속돼 안 된다.
+# launchd 데몬(io.osquery.agent)은 flagfile 경로가 /var/osquery/osquery.flags 로 박혀 있으므로,
+# 이 파일을 그 경로에 복사한 뒤 osqueryctl 로 띄운다:
+#   sudo cp osquery.mac.flags /var/osquery/osquery.flags && sudo osqueryctl start
 # enroll secret 발급: 프론트 로그인 후 POST /api/tenant/enroll-secret → 값 하나를 enroll_secret_path 파일에 저장.
 
 # --- TLS remote 플러그인 ---
+# gflags 는 줄 끝 주석을 잘라내지 않는다. 주석은 반드시 줄 전체로 쓸 것
+# (--tls_hostname=host:8443  # 설명  → 호스트 값에 "# 설명" 까지 들어가 붙지 않는다).
 --enroll_secret_path=/etc/osquery/enroll.secret
---tls_hostname=localhost:8443                        # api-service osquery HTTPS 커넥터 (dev)
---tls_server_certs=/etc/osquery/osquery-server.pem   # scripts/gen-dev-keystore.sh 가 만든 서버 cert 를 핀
+# api-service osquery HTTPS 커넥터. 로컬 bootRun 이면 localhost:8443, k8s 배포면 <서버주소>:30443
+--tls_hostname=localhost:8443
+# scripts/gen-dev-keystore.sh 가 만든 서버 cert 를 핀
+--tls_server_certs=/etc/osquery/osquery-server.pem
 
 --config_plugin=tls
 --config_tls_endpoint=/api/osquery/config
@@ -21,10 +27,23 @@
 --logger_tls_period=10
 --disable_carver=true
 
-# --- evented 테이블 + EndpointSecurity(es_process_events) ---
-# FDA(전체 디스크 접근)가 없으면 EndpointSecurity 는 에러 없이 조용히 빈 결과가 된다. README 참고.
+# --- evented 테이블 ---
+# 서버가 내려주는 macOS 스케줄은 3종류 테이블을 쓴다. 퍼블리셔마다 켜는 플래그가 따로 있고,
+# 안 켜면 osquery 는 에러 없이 조용히 빈 결과를 준다(그래서 "수집은 도는데 이벤트가 0" 이 된다).
 --disable_events=false
+
+# es_process_events (EndpointSecurity) → process_events / script_events 스케줄
+# FDA(전체 디스크 접근)가 없으면 여기까지 맞춰도 조용히 빈 결과가 된다. README 참고.
 --disable_endpointsecurity=false
+
+# file_events (FSEvents) → file_events 스케줄(자동실행 경로 FIM, detector T1547 판정 입력)
+--enable_file_events=true
+
+# socket_events (OpenBSM) → socket_events 스케줄(아웃바운드 연결, detector network 룰 입력)
+# audit_allow_config 는 osquery 가 /etc/security/audit_control 을 런타임에 고쳐 필요한 audit 클래스를 켜게 한다.
+--disable_audit=false
+--audit_allow_config=true
+--audit_allow_sockets=true
 
 --host_identifier=hostname
 --disable_watchdog=true

--- a/collector-service/osquery/osquery.win.flags
+++ b/collector-service/osquery/osquery.win.flags
@@ -1,14 +1,18 @@
 # EDRdog osquery 엔드포인트 플래그 (Windows). api-service 수집 TLS API 로 붙는다.
 # 수집 쿼리(schedule)는 서버가 /api/osquery/config 로 내려주므로 여기엔 config 파일이 없다.
 #
-# 실행(관리자 PowerShell):
-#   osqueryd.exe --flagfile=C:\ProgramData\osquery\osquery.win.flags
+# 실행(관리자 PowerShell). osqueryd.exe 는 PATH 에 없으므로 전체 경로로 부른다:
+#   & "C:\Program Files\osquery\osqueryd\osqueryd.exe" --flagfile=C:\ProgramData\osquery\osquery.win.flags
 # enroll secret 발급: 프론트 로그인 후 POST /api/tenant/enroll-secret → 값을 enroll_secret_path 파일에 저장.
 
 # --- TLS remote 플러그인 ---
+# gflags 는 줄 끝 주석을 잘라내지 않는다. 주석은 반드시 줄 전체로 쓸 것
+# (--tls_hostname=host:8443  # 설명  → 호스트 값에 "# 설명" 까지 들어가 붙지 않는다).
 --enroll_secret_path=C:\ProgramData\osquery\enroll.secret
+# api-service osquery HTTPS 커넥터. 로컬 bootRun 이면 localhost:8443, k8s 배포면 <서버주소>:30443
 --tls_hostname=localhost:8443
---tls_server_certs=C:\ProgramData\osquery\osquery-server.pem   # gen-dev-keystore.sh 산출 PEM 을 핀(dev)
+# gen-dev-keystore.sh 산출 PEM 을 핀(dev)
+--tls_server_certs=C:\ProgramData\osquery\osquery-server.pem
 
 --config_plugin=tls
 --config_tls_endpoint=/api/osquery/config
@@ -21,9 +25,17 @@
 --logger_tls_period=10
 --disable_carver=true
 
-# --- evented 테이블 + ETW(process_etw_events) 로 프로세스 생성 감시 ---
+# --- evented 테이블 ---
+# 퍼블리셔마다 켜는 플래그가 따로 있고, 안 켜면 osquery 는 에러 없이 조용히 빈 결과를 준다.
 # network 이벤트는 core osquery 에 실시간 소켓 테이블이 없어 Zeek 가 담당한다.
 --disable_events=false
+
+# process_etw_events (ETW) → process_etw_events / script_etw_events 스케줄
+# 이 플래그가 없으면 Windows 수집은 전부 0건이다(퍼블리셔가 setUp 에서 바로 빠진다).
+--enable_process_etw_events=true
+
+# file_events (NTFS USN 저널) → file_events 스케줄(시작프로그램 FIM, detector T1547 판정 입력)
+--enable_ntfs_event_publisher=true
 
 --host_identifier=hostname
 --disable_watchdog=true

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -88,6 +88,21 @@ curl -sk https://localhost:8443/api/osquery/enroll -H 'Content-Type: application
   L4(TCP) 통과 프록시를 쓴다.
 - 인증서 SAN 이 `--tls_hostname` 의 호스트와 다르면 역시 enroll 단계에서 실패한다. 주소가 바뀌면 인증서를
   다시 만들고 Secret 을 갱신한 뒤 엔드포인트의 PEM 까지 교체해야 한다.
+### 매니페스트 변경을 배포서버에 반영하기
+
+CD 는 서비스 5개 매니페스트를 apply 하지 않는다(apply 하면 image 가 `:latest` 로 되돌아갔다가
+`set image` 로 다시 `:sha` 가 되면서 롤아웃이 두 번 돈다). 그래서 `k8s/api-service.yaml` 을 고쳤으면
+서버에서 한 번 수동으로 적용한다. 지금 떠 있는 이미지 태그를 지키면서 적용하는 순서:
+
+```bash
+IMG=$(sudo kubectl -n edrdog get deploy/api-service -o jsonpath='{.spec.template.spec.containers[0].image}')
+sudo kubectl -n edrdog apply -f k8s/api-service.yaml
+sudo kubectl -n edrdog set image deployment/api-service api-service="$IMG"
+sudo kubectl -n edrdog rollout status deployment/api-service
+```
+
+Service 는 매니페스트가 서버 실제 상태(NodePort 30084)와 같아 apply 해도 그대로다.
+
 - kind 로컬에서는 `kind-cluster.yaml` 의 `30443 -> hostPort 8443` 매핑을 쓴다.
   **`extraPortMappings` 는 클러스터 생성 시에만 반영**되므로 기존 클러스터라면 다시 만들거나
   `kubectl -n edrdog port-forward svc/api-service-osquery 8443:8443` 로 우회한다.

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -23,6 +23,7 @@ kubectl -n edrdog get pods                            # Running 확인
 | Grafana | `http://localhost:3000` | admin / admin. 첫 화면이 EDRdog Overview |
 | OTLP HTTP | `http://localhost:4318` | 서비스가 메트릭·트레이스를 보내는 곳 |
 | OTLP gRPC | `localhost:4317` | 〃 |
+| osquery 수집 HTTPS | `localhost:8443` (NodePort 30443) | 엔드포인트 osquery 가 붙는 곳. 아래 시크릿을 만들어야 열린다 |
 
 클러스터 내부(파드 간) Kafka 주소: `kafka.edrdog.svc.cluster.local:9094`
 클러스터 내부 OTLP 주소: `http://otel-lgtm:4318` (각 서비스 Deployment 의 `OTEL_EXPORTER_OTLP_ENDPOINT`)
@@ -50,6 +51,46 @@ curl "http://localhost:3000/api/datasources/proxy/uid/loki/loki/api/v1/label/ser
 ```bash
 kind delete cluster --name edrdog    # 클러스터째 삭제 (데이터 emptyDir 라 함께 소멸)
 ```
+
+## osquery 수집 포트 (api-service 8443 / NodePort 30443)
+
+엔드포인트의 osquery TLS logger 는 평문 HTTP 로 붙지 않는다. 그래서 api-service 는 프론트용 8084 와 별도로
+osquery 전용 HTTPS 커넥터를 8443 에 연다. **이 커넥터는 `osquery-tls` Secret 이 있을 때만 켜진다**
+(Secret 이 없으면 값이 안 들어와 `OSQUERY_TLS_ENABLED` 가 기본 false 로 남고, api-service 는 그대로 정상 기동한다).
+
+```bash
+# 1) 서버 인증서 + 키스토어 생성. 인자는 엔드포인트가 실제로 붙을 주소(도메인 또는 공인 IP).
+#    osquery 가 이 인증서를 핀하므로 SAN 이 --tls_hostname 의 호스트와 같아야 한다.
+./scripts/gen-dev-keystore.sh ./dev-tls edrdog.example.com
+
+# 2) Secret 생성 (키스토어 + 스위치 + 비번을 한 Secret 에)
+kubectl -n edrdog create secret generic osquery-tls \
+  --from-file=keystore.p12=./dev-tls/osquery-keystore.p12 \
+  --from-literal=OSQUERY_TLS_ENABLED=true \
+  --from-literal=OSQUERY_TLS_KEYSTORE_PASSWORD=changeit
+
+kubectl -n edrdog rollout restart deploy/api-service
+
+# 3) 확인 (self-signed 라 -k)
+curl -sk https://localhost:8443/api/osquery/enroll -H 'Content-Type: application/json' \
+  -d '{"enroll_secret":"틀린값"}'      # -> {"node_invalid":true} 면 커넥터 정상
+```
+
+엔드포인트에는 `./dev-tls/osquery-server.pem` 을 배포하고 플래그를 맞춘다.
+
+```
+--tls_hostname=edrdog.example.com:30443
+--tls_server_certs=<osquery-server.pem 경로>
+```
+
+- **Caddy 로 프록시하면 안 된다.** osquery 가 서버 인증서를 핀하므로 중간에서 TLS 를 다시 종단하면
+  엔드포인트가 enroll 단계에서 조용히 실패한다. 노출하려면 NodePort 30443 을 보안그룹에서 직접 열거나
+  L4(TCP) 통과 프록시를 쓴다.
+- 인증서 SAN 이 `--tls_hostname` 의 호스트와 다르면 역시 enroll 단계에서 실패한다. 주소가 바뀌면 인증서를
+  다시 만들고 Secret 을 갱신한 뒤 엔드포인트의 PEM 까지 교체해야 한다.
+- kind 로컬에서는 `kind-cluster.yaml` 의 `30443 -> hostPort 8443` 매핑을 쓴다.
+  **`extraPortMappings` 는 클러스터 생성 시에만 반영**되므로 기존 클러스터라면 다시 만들거나
+  `kubectl -n edrdog port-forward svc/api-service-osquery 8443:8443` 로 우회한다.
 
 ## 시크릿 (Infisical)
 

--- a/k8s/api-service.yaml
+++ b/k8s/api-service.yaml
@@ -94,6 +94,10 @@ spec:
               - key: keystore.p12
                 path: keystore.p12
 ---
+# 프론트/외부 API 진입점. NodePort 30084 — 호스트(EC2)에서 도는 Caddy 가 localhost:30084 로 프록시한다.
+# 배포서버가 이미 이 형태로 떠 있는데 여기가 ClusterIP 로 남아 있어서, 이 파일을 apply 하면
+# NodePort 가 벗겨져 사이트가 죽었다(그래서 CD 가 이 매니페스트를 통째로 건너뛰고 있다).
+# 실제 상태에 맞춰 둔다. 포트를 바꾸려면 Caddy 설정도 같이 바꿔야 한다.
 apiVersion: v1
 kind: Service
 metadata:
@@ -102,11 +106,13 @@ metadata:
   labels:
     app: api-service
 spec:
+  type: NodePort
   selector:
     app: api-service
   ports:
     - port: 80
       targetPort: 8084
+      nodePort: 30084
 ---
 # osquery 엔드포인트가 붙는 수집 포트. NodePort 30443 로 직접 노출한다.
 # Caddy 로 프록시하면 안 된다: osquery 가 --tls_server_certs 로 서버 인증서를 핀하기 때문에

--- a/k8s/api-service.yaml
+++ b/k8s/api-service.yaml
@@ -22,6 +22,13 @@ spec:
           ports:
             - containerPort: 8084
             - containerPort: 8443   # osquery 수집 전용 HTTPS 커넥터 (osquery-tls Secret 이 있을 때만 열린다)
+          # Infisical 이 동기화한 edrdog-secrets. EDRDOG_API_KEY(프론트 X-API-Key), INTERNAL_API_KEY
+          # (alert-service 내부 조회), CLICKHOUSE_PASSWORD 등이 여기서 온다. 이게 빠진 채로 apply 하면
+          # 프론트는 401, 알림은 전면 중단, 대시보드는 ClickHouse 인증 실패로 깨진다.
+          # 아래 env 에 같은 이름이 있으면 그쪽이 이긴다(그래서 DB_PASSWORD 는 아래 평문 값이 쓰인다).
+          envFrom:
+            - secretRef:
+                name: edrdog-secrets
           env:
             # --- osquery 수집 HTTPS 커넥터 ---
             # 엔드포인트의 osquery TLS logger 는 평문 HTTP 로 안 붙으므로 이 포트가 없으면 수집 자체가 불가능하다.
@@ -53,11 +60,13 @@ spec:
             - name: EDRDOG_CLICKHOUSE_URL
               value: "http://clickhouse:8123"
             # 프론트 도메인 (배포 시 실제 값으로 교체)
+            # 배포된 프론트(Vercel) + 로컬 dev 서버. 서버 실제 값과 같게 둔다.
             - name: CORS_ALLOWED_ORIGINS
-              value: "http://localhost:5173"
-            # 발표 환경에서만 true (데모 계정 test/1234 + 과거 7일 시드)
+              value: "https://frontend1-ten-gamma.vercel.app,http://localhost:5173"
+            # 발표 환경에서만 true (데모 계정 test/1234 + 과거 7일 시드).
+            # 현재 배포서버가 true 라 그대로 맞춘다. 해커톤이 끝나면 false 로 되돌린다.
             - name: DEMO_SEED
-              value: "false"
+              value: "true"
             # 메트릭/트레이스 OTLP 수집기 (k8s/otel-lgtm.yaml)
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: "http://otel-lgtm:4318"

--- a/k8s/api-service.yaml
+++ b/k8s/api-service.yaml
@@ -21,7 +21,27 @@ spec:
           image: ghcr.io/2026-siheung-bootcamp-team-i/backend/api-service:latest
           ports:
             - containerPort: 8084
+            - containerPort: 8443   # osquery 수집 전용 HTTPS 커넥터 (osquery-tls Secret 이 있을 때만 열린다)
           env:
+            # --- osquery 수집 HTTPS 커넥터 ---
+            # 엔드포인트의 osquery TLS logger 는 평문 HTTP 로 안 붙으므로 이 포트가 없으면 수집 자체가 불가능하다.
+            # 스위치와 비번은 osquery-tls Secret 에서 온다. Secret 이 없으면 값이 안 들어와 커넥터는 꺼진 채(기본 false)
+            # 뜨므로 api-service 는 그대로 정상 기동한다. 생성 절차는 k8s/README.md 참고.
+            - name: OSQUERY_TLS_ENABLED
+              valueFrom:
+                secretKeyRef:
+                  name: osquery-tls
+                  key: OSQUERY_TLS_ENABLED
+                  optional: true
+            - name: OSQUERY_TLS_KEYSTORE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: osquery-tls
+                  key: OSQUERY_TLS_KEYSTORE_PASSWORD
+                  optional: true
+            # 키스토어는 아래 volume 으로 마운트된 파일을 읽는다 (Secret 없으면 이 경로도 비어 있지만 커넥터가 꺼져 있어 무해).
+            - name: OSQUERY_TLS_KEYSTORE
+              value: "/etc/osquery-tls/keystore.p12"
             - name: KAFKA_BOOTSTRAP
               value: "kafka:9094"
             - name: DB_URL
@@ -60,6 +80,19 @@ spec:
             limits:
               cpu: 500m
               memory: 512Mi
+          volumeMounts:
+            - name: osquery-tls
+              mountPath: /etc/osquery-tls
+              readOnly: true
+      volumes:
+        # optional:true 라 Secret 이 없어도 파드는 뜬다(빈 디렉터리로 마운트). 그때는 커넥터도 꺼져 있다.
+        - name: osquery-tls
+          secret:
+            secretName: osquery-tls
+            optional: true
+            items:
+              - key: keystore.p12
+                path: keystore.p12
 ---
 apiVersion: v1
 kind: Service
@@ -74,3 +107,23 @@ spec:
   ports:
     - port: 80
       targetPort: 8084
+---
+# osquery 엔드포인트가 붙는 수집 포트. NodePort 30443 로 직접 노출한다.
+# Caddy 로 프록시하면 안 된다: osquery 가 --tls_server_certs 로 서버 인증서를 핀하기 때문에
+# 중간에서 TLS 를 다시 종단하면 엔드포인트가 등록 단계에서 실패한다(프록시하려면 L4 TCP 통과여야 함).
+# EC2 보안그룹에 30443/TCP 를 열어야 외부 기기가 붙을 수 있다.
+apiVersion: v1
+kind: Service
+metadata:
+  name: api-service-osquery
+  namespace: edrdog
+  labels:
+    app: api-service
+spec:
+  type: NodePort
+  selector:
+    app: api-service
+  ports:
+    - port: 8443
+      targetPort: 8443
+      nodePort: 30443

--- a/k8s/kind-cluster.yaml
+++ b/k8s/kind-cluster.yaml
@@ -31,3 +31,6 @@ nodes:
       - containerPort: 30318   # OTLP HTTP           -> host localhost:4318
         hostPort: 4318
         protocol: TCP
+      - containerPort: 30443   # osquery 수집 HTTPS  -> host localhost:8443
+        hostPort: 8443
+        protocol: TCP

--- a/k8s/responder-service.yaml
+++ b/k8s/responder-service.yaml
@@ -21,23 +21,36 @@ spec:
           image: ghcr.io/2026-siheung-bootcamp-team-i/backend/responder-service:latest
           ports:
             - containerPort: 8082
+          # Infisical 이 동기화한 edrdog-secrets. api/alert/detector 등 다른 서비스와 같은 패턴이다.
+          # 아래 env 에 같은 이름이 있으면 그쪽이 이긴다.
+          envFrom:
+            - secretRef:
+                name: edrdog-secrets
           env:
+            # --- 실제 조치(kill) 실행 ---
+            # 배포서버는 이미 켜져 있고, 이 매니페스트는 그 상태를 그대로 옮긴 것이다.
+            # 끄려면 이 값을 "false" 로 바꾸거나 env 를 지운다(지우면 edrdog-secrets 값이 쓰인다).
+            # 켠 상태에서 FLEET_BASE_URL 이 https 가 아니면 FleetTls 가 기동을 막는다.
+            # Bearer 토큰이 평문으로 나가는 걸 차단하는 의도된 동작이다.
+            - name: RESPONDER_EXECUTE_ENABLED
+              value: "true"
+            - name: FLEET_BASE_URL
+              value: "https://fleet.edrdog.svc.cluster.local:8080"
+            # Fleet 이 자가서명이라 그 인증서를 담은 truststore 로 검증한다(아래 volume).
+            - name: FLEET_TLS_TRUSTSTORE
+              value: "/fleet/fleet-truststore.p12"
+            - name: FLEET_TLS_TRUSTSTORE_PASSWORD
+              value: "changeit"
+            - name: FLEET_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: fleet-creds
+                  key: token
             - name: SPRING_KAFKA_BOOTSTRAP_SERVERS
               value: "kafka:9094"
             # 트레이스 OTLP 수집기 (k8s/otel-lgtm.yaml)
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: "http://otel-lgtm:4318"
-            # 실제 조치(kill) 실행은 기본 OFF(dry-run). 신뢰가 쌓인 뒤 아래를 채워 켠다.
-            # 켤 때 FLEET_BASE_URL 은 https 여야 하며(FleetTls), 자가서명 인증서면 FLEET_TLS_TRUSTSTORE 를 지정한다.
-            # - name: RESPONDER_EXECUTE_ENABLED
-            #   value: "true"
-            # - name: FLEET_BASE_URL
-            #   value: "https://fleet.내부주소"
-            # - name: FLEET_TOKEN
-            #   valueFrom:
-            #     secretKeyRef: { name: fleet, key: token }
-            # - name: FLEET_TLS_TRUSTSTORE
-            #   value: "/etc/fleet/truststore.p12"
           readinessProbe:
             httpGet:
               path: /actuator/health
@@ -57,6 +70,15 @@ spec:
             limits:
               cpu: 500m
               memory: 512Mi
+          volumeMounts:
+            - name: fleet-ts
+              mountPath: /fleet
+              readOnly: true
+      volumes:
+        # Fleet 서버 인증서를 담은 truststore. FLEET_TLS_TRUSTSTORE 가 이 경로를 가리킨다.
+        - name: fleet-ts
+          secret:
+            secretName: fleet-truststore
 ---
 apiVersion: v1
 kind: Service

--- a/scripts/gen-dev-keystore.sh
+++ b/scripts/gen-dev-keystore.sh
@@ -18,8 +18,16 @@ ALIAS="${OSQUERY_TLS_KEY_ALIAS:-osquery}"
 
 mkdir -p "$OUT"
 
+# osquery 는 --tls_hostname 의 호스트를 서버 인증서의 SAN 과 대조한다.
+# 배포 주소가 IP 면 dns: 로 넣어봐야 검증에 실패하므로 IPv4 는 ip: 로 넣는다.
+if [[ "$HOST" =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  SAN="ip:$HOST,ip:127.0.0.1"
+else
+  SAN="dns:$HOST,ip:127.0.0.1"
+fi
+
 keytool -genkeypair -alias "$ALIAS" -keyalg RSA -keysize 2048 -validity 825 \
-  -dname "CN=$HOST" -ext "SAN=dns:$HOST,ip:127.0.0.1" \
+  -dname "CN=$HOST" -ext "SAN=$SAN" \
   -keystore "$OUT/osquery-keystore.p12" -storetype PKCS12 \
   -storepass "$PASS" -keypass "$PASS"
 
@@ -38,5 +46,12 @@ echo "  OSQUERY_TLS_KEYSTORE=$OUT/osquery-keystore.p12 \\"
 echo "  OSQUERY_TLS_KEYSTORE_PASSWORD=$PASS \\"
 echo "  ./gradlew :api-service:bootRun"
 echo
+echo "k8s(api-service) 에 태우려면 Secret 하나 만들면 끝(만들기 전엔 커넥터 OFF):"
+echo "  kubectl -n edrdog create secret generic osquery-tls \\"
+echo "    --from-file=keystore.p12=$OUT/osquery-keystore.p12 \\"
+echo "    --from-literal=OSQUERY_TLS_ENABLED=true \\"
+echo "    --from-literal=OSQUERY_TLS_KEYSTORE_PASSWORD=$PASS"
+echo "  kubectl -n edrdog rollout restart deploy/api-service"
+echo
 echo "osquery 엔드포인트 플래그: collector-service/osquery/osquery.mac.flags · osquery.win.flags"
-echo "  (--tls_server_certs 를 $OUT/osquery-server.pem 로 지정)"
+echo "  (--tls_server_certs 를 $OUT/osquery-server.pem 로 지정, --tls_hostname 은 $HOST:30443)"


### PR DESCRIPTION
## 요약

dev 에 쌓인 변경을 main 으로 올린다. 현재 6개 커밋이 담겨 있고, #86(osquery 수집 배선 수정)이 dev 에 머지되면 이 PR 에 자동으로 포함된다.

## 포함 내용

- **webhook 테스트 전송 API** (#85): `POST /api/me/webhook/test`. 저장된 개인 webhook 으로 실제 발송을 시도한다. 등록이 됐는지 확인할 수 있는 유일한 수단이라 온보딩에서 쓴다.
- **Kafka UI 교체** (#84): Kafdrop → UI for Apache Kafka
- **CI 시크릿 수정** (#82): 빌드에 `MAXMIND_LICENSE_KEY` 주입

## 머지 대기

- #86 osquery 수집 배선 수정 (퍼블리셔 플래그 누락 + 8443/NodePort 30443 노출). dev 머지 후 여기 포함된다.

## 배포 주의

#86 이 포함되면 `k8s/api-service.yaml` 이 바뀌지만, CD 는 이 매니페스트를 apply 하지 않는다(서버 Service 가 NodePort 30084 라 레포의 ClusterIP 를 apply 하면 사이트가 죽는다). 수집 포트를 실제로 열려면 `k8s/README.md` 의 수동 절차가 필요하다.