### PR TITLE
fix: responder 매니페스트를 배포서버 실제 상태에 맞춤 (kill 이미 켜져 있음)

### DIFF
--- a/k8s/responder-service.yaml
+++ b/k8s/responder-service.yaml
@@ -21,23 +21,36 @@ spec:
           image: ghcr.io/2026-siheung-bootcamp-team-i/backend/responder-service:latest
           ports:
             - containerPort: 8082
+          # Infisical 이 동기화한 edrdog-secrets. api/alert/detector 등 다른 서비스와 같은 패턴이다.
+          # 아래 env 에 같은 이름이 있으면 그쪽이 이긴다.
+          envFrom:
+            - secretRef:
+                name: edrdog-secrets
           env:
+            # --- 실제 조치(kill) 실행 ---
+            # 배포서버는 이미 켜져 있고, 이 매니페스트는 그 상태를 그대로 옮긴 것이다.
+            # 끄려면 이 값을 "false" 로 바꾸거나 env 를 지운다(지우면 edrdog-secrets 값이 쓰인다).
+            # 켠 상태에서 FLEET_BASE_URL 이 https 가 아니면 FleetTls 가 기동을 막는다.
+            # Bearer 토큰이 평문으로 나가는 걸 차단하는 의도된 동작이다.
+            - name: RESPONDER_EXECUTE_ENABLED
+              value: "true"
+            - name: FLEET_BASE_URL
+              value: "https://fleet.edrdog.svc.cluster.local:8080"
+            # Fleet 이 자가서명이라 그 인증서를 담은 truststore 로 검증한다(아래 volume).
+            - name: FLEET_TLS_TRUSTSTORE
+              value: "/fleet/fleet-truststore.p12"
+            - name: FLEET_TLS_TRUSTSTORE_PASSWORD
+              value: "changeit"
+            - name: FLEET_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: fleet-creds
+                  key: token
             - name: SPRING_KAFKA_BOOTSTRAP_SERVERS
               value: "kafka:9094"
             # 트레이스 OTLP 수집기 (k8s/otel-lgtm.yaml)
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: "http://otel-lgtm:4318"
-            # 실제 조치(kill) 실행은 기본 OFF(dry-run). 신뢰가 쌓인 뒤 아래를 채워 켠다.
-            # 켤 때 FLEET_BASE_URL 은 https 여야 하며(FleetTls), 자가서명 인증서면 FLEET_TLS_TRUSTSTORE 를 지정한다.
-            # - name: RESPONDER_EXECUTE_ENABLED
-            #   value: "true"
-            # - name: FLEET_BASE_URL
-            #   value: "https://fleet.내부주소"
-            # - name: FLEET_TOKEN
-            #   valueFrom:
-            #     secretKeyRef: { name: fleet, key: token }
-            # - name: FLEET_TLS_TRUSTSTORE
-            #   value: "/etc/fleet/truststore.p12"
           readinessProbe:
             httpGet:
               path: /actuator/health
@@ -57,6 +70,15 @@ spec:
             limits:
               cpu: 500m
               memory: 512Mi
+          volumeMounts:
+            - name: fleet-ts
+              mountPath: /fleet
+              readOnly: true
+      volumes:
+        # Fleet 서버 인증서를 담은 truststore. FLEET_TLS_TRUSTSTORE 가 이 경로를 가리킨다.
+        - name: fleet-ts
+          secret:
+            secretName: fleet-truststore
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
## 정정

원래 이 PR 은 "kill 스위치가 꺼져 있으니 켤 수 있게 배선하자"였다. **틀렸다.** 배포서버는 이미 켜져 있다 (kubectl 실측).

```
RESPONDER_EXECUTE_ENABLED=true
FLEET_BASE_URL=https://fleet.edrdog.svc.cluster.local:8080
FLEET_TOKEN from secret fleet-creds, key token
FLEET_TLS_TRUSTSTORE=/fleet/fleet-truststore.p12
```

Fleet 서버도 클러스터 안에 떠 있다 (`fleet`, `fleet-mysql`, `fleet-redis`, `fleet-nodeport` 30880).

## 진짜 문제

레포 매니페스트에는 그 env 가 전부 **주석 처리**돼 있다. 그래서 `k8s/responder-service.yaml` 을 apply 하면 동작 중인 kill 이 꺼진다. `api-service` Service 드리프트(#89)와 같은 종류의 문제다.

앞선 버전(force-push 전)은 `fleet-api` 라는 **새 Secret** 을 전제로 env 를 전부 바꿔치기했는데, 그 Secret 이 존재하지 않아 apply 하면 `RESPONDER_EXECUTE_ENABLED` 가 사라지고 kill 이 꺼진다. 머지했으면 조치 기능이 죽었을 것이다.

## 변경

서버 실측값을 그대로 옮긴다.

| 항목 | 값 |
|---|---|
| `envFrom` | `edrdog-secrets` (Infisical 동기화. api/alert 등과 같은 패턴) |
| `RESPONDER_EXECUTE_ENABLED` | `"true"` |
| `FLEET_BASE_URL` | `https://fleet.edrdog.svc.cluster.local:8080` |
| `FLEET_TOKEN` | secretKeyRef `fleet-creds` / `token` |
| `FLEET_TLS_TRUSTSTORE` | `/fleet/fleet-truststore.p12` |
| volume | secret `fleet-truststore` → `/fleet` (name: `fleet-ts`) |

Fleet 이 자가서명이라 시스템 신뢰저장소로는 검증이 안 돼 truststore 가 필요하다.

## 검증

`kubectl apply --dry-run=client -f k8s/responder-service.yaml` 통과. env/volume 구조는 서버의 `kubectl get deploy responder-service -o jsonpath` 출력과 1:1로 맞췄다.

## 남은 드리프트

같은 문제가 `api-service` 에도 있다. 서버는 `envFrom: edrdog-secrets` 로 DB 비번·API 키·내부 키를 받는데 레포에는 그 `envFrom` 이 없고 `DB_PASSWORD=edrdog` 같은 평문 env 가 박혀 있다. #89 에서 같이 처리한다.