### PR TITLE
fix: api-service 매니페스트를 배포서버 실제 상태에 맞춤 (NodePort 30084 + envFrom)

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -103,8 +103,11 @@ jobs:
           MODULES="detector-service responder-service archiver-service api-service alert-service"
 
           # 모니터링 스택과 Kafka UI 만 매니페스트로 apply 한다.
-          # 서비스 5개 매니페스트는 손대지 않는다. 레포의 api-service Service 는 ClusterIP 인데
-          # 서버는 NodePort 30084 로 떠 있어(Caddy 가 이 포트로 프록시) apply 하면 사이트가 죽는다.
+          # 서비스 5개 매니페스트는 손대지 않는다. apply 하면 image 가 :latest 로 되돌아갔다가
+          # 아래 set image 로 다시 :sha 가 되면서 롤아웃이 두 번 돌기 때문이다.
+          # (레포 api-service Service 가 ClusterIP 라 apply 하면 NodePort 30084 가 벗겨져 사이트가
+          #  죽던 문제는 매니페스트를 실제 상태에 맞추면서 해소됐다. 매니페스트 변경 반영은
+          #  k8s/README.md 의 수동 apply 절차를 따른다.)
           # 서버 브랜치를 건드리지 않으려고 FETCH_HEAD 에서 파일만 꺼내 적용한다.
           if [ -d ~/Backend/.git ]; then
           git -C ~/Backend fetch --quiet origin main

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -88,6 +88,21 @@ curl -sk https://localhost:8443/api/osquery/enroll -H 'Content-Type: application
   L4(TCP) 통과 프록시를 쓴다.
 - 인증서 SAN 이 `--tls_hostname` 의 호스트와 다르면 역시 enroll 단계에서 실패한다. 주소가 바뀌면 인증서를
   다시 만들고 Secret 을 갱신한 뒤 엔드포인트의 PEM 까지 교체해야 한다.
+### 매니페스트 변경을 배포서버에 반영하기
+
+CD 는 서비스 5개 매니페스트를 apply 하지 않는다(apply 하면 image 가 `:latest` 로 되돌아갔다가
+`set image` 로 다시 `:sha` 가 되면서 롤아웃이 두 번 돈다). 그래서 `k8s/api-service.yaml` 을 고쳤으면
+서버에서 한 번 수동으로 적용한다. 지금 떠 있는 이미지 태그를 지키면서 적용하는 순서:
+
+```bash
+IMG=$(sudo kubectl -n edrdog get deploy/api-service -o jsonpath='{.spec.template.spec.containers[0].image}')
+sudo kubectl -n edrdog apply -f k8s/api-service.yaml
+sudo kubectl -n edrdog set image deployment/api-service api-service="$IMG"
+sudo kubectl -n edrdog rollout status deployment/api-service
+```
+
+Service 는 매니페스트가 서버 실제 상태(NodePort 30084)와 같아 apply 해도 그대로다.
+
 - kind 로컬에서는 `kind-cluster.yaml` 의 `30443 -> hostPort 8443` 매핑을 쓴다.
   **`extraPortMappings` 는 클러스터 생성 시에만 반영**되므로 기존 클러스터라면 다시 만들거나
   `kubectl -n edrdog port-forward svc/api-service-osquery 8443:8443` 로 우회한다.

--- a/k8s/api-service.yaml
+++ b/k8s/api-service.yaml
@@ -94,6 +94,10 @@ spec:
               - key: keystore.p12
                 path: keystore.p12
 ---
+# 프론트/외부 API 진입점. NodePort 30084 — 호스트(EC2)에서 도는 Caddy 가 localhost:30084 로 프록시한다.
+# 배포서버가 이미 이 형태로 떠 있는데 여기가 ClusterIP 로 남아 있어서, 이 파일을 apply 하면
+# NodePort 가 벗겨져 사이트가 죽었다(그래서 CD 가 이 매니페스트를 통째로 건너뛰고 있다).
+# 실제 상태에 맞춰 둔다. 포트를 바꾸려면 Caddy 설정도 같이 바꿔야 한다.
 apiVersion: v1
 kind: Service
 metadata:
@@ -102,11 +106,13 @@ metadata:
   labels:
     app: api-service
 spec:
+  type: NodePort
   selector:
     app: api-service
   ports:
     - port: 80
       targetPort: 8084
+      nodePort: 30084
 ---
 # osquery 엔드포인트가 붙는 수집 포트. NodePort 30443 로 직접 노출한다.
 # Caddy 로 프록시하면 안 된다: osquery 가 --tls_server_certs 로 서버 인증서를 핀하기 때문에

--- a/k8s/api-service.yaml
+++ b/k8s/api-service.yaml
@@ -22,6 +22,13 @@ spec:
           ports:
             - containerPort: 8084
             - containerPort: 8443   # osquery 수집 전용 HTTPS 커넥터 (osquery-tls Secret 이 있을 때만 열린다)
+          # Infisical 이 동기화한 edrdog-secrets. EDRDOG_API_KEY(프론트 X-API-Key), INTERNAL_API_KEY
+          # (alert-service 내부 조회), CLICKHOUSE_PASSWORD 등이 여기서 온다. 이게 빠진 채로 apply 하면
+          # 프론트는 401, 알림은 전면 중단, 대시보드는 ClickHouse 인증 실패로 깨진다.
+          # 아래 env 에 같은 이름이 있으면 그쪽이 이긴다(그래서 DB_PASSWORD 는 아래 평문 값이 쓰인다).
+          envFrom:
+            - secretRef:
+                name: edrdog-secrets
           env:
             # --- osquery 수집 HTTPS 커넥터 ---
             # 엔드포인트의 osquery TLS logger 는 평문 HTTP 로 안 붙으므로 이 포트가 없으면 수집 자체가 불가능하다.
@@ -53,11 +60,13 @@ spec:
             - name: EDRDOG_CLICKHOUSE_URL
               value: "http://clickhouse:8123"
             # 프론트 도메인 (배포 시 실제 값으로 교체)
+            # 배포된 프론트(Vercel) + 로컬 dev 서버. 서버 실제 값과 같게 둔다.
             - name: CORS_ALLOWED_ORIGINS
-              value: "http://localhost:5173"
-            # 발표 환경에서만 true (데모 계정 test/1234 + 과거 7일 시드)
+              value: "https://frontend1-ten-gamma.vercel.app,http://localhost:5173"
+            # 발표 환경에서만 true (데모 계정 test/1234 + 과거 7일 시드).
+            # 현재 배포서버가 true 라 그대로 맞춘다. 해커톤이 끝나면 false 로 되돌린다.
             - name: DEMO_SEED
-              value: "false"
+              value: "true"
             # 메트릭/트레이스 OTLP 수집기 (k8s/otel-lgtm.yaml)
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: "http://otel-lgtm:4318"


### PR DESCRIPTION
## 문제

레포의 `k8s/api-service.yaml` 이 서버 실제 상태와 두 군데 어긋나 있고, 그대로 apply 하면 **사이트가 죽는다**. 그래서 CD 도 이 파일을 건너뛰고 있었고, 결과적으로 "고쳐도 배포에 반영할 수 없는 파일"이 돼 있었다. #86 에서 추가한 수집 포트(8443/30443)도 같은 이유로 서버에 넣을 방법이 없다.

## 어긋난 지점 (kubectl 실측)

**1. Service 타입**

서버는 `NodePort 30084` 이고 호스트 Caddy 가 그 포트로 프록시한다. 레포는 ClusterIP 라 apply 하면 NodePort 가 벗겨진다.

**2. `envFrom: edrdog-secrets` 누락**

서버는 Infisical 이 동기화한 `edrdog-secrets` 를 `envFrom` 으로 받는다. 레포에는 없다. 이 상태로 apply 하면 한 번에 끊긴다.

| 잃는 값 | 결과 |
|---|---|
| `EDRDOG_API_KEY` | 프론트 X-API-Key 불일치 → `/api/tenant/*` 401 |
| `INTERNAL_API_KEY` | api 만 기본값으로 떨어지고 alert-service 는 Infisical 값을 계속 쓴다 → 내부 조회 401 → **탐지 알림 전면 중단** |
| `CLICKHOUSE_PASSWORD` | 기기 목록·대시보드 조회 실패 |

`INTERNAL_API_KEY` 쪽이 특히 조용히 죽는다. 알림이 안 오는데 로그에는 조회 실패만 찍힌다.

## 변경

- Service: `type: NodePort`, `nodePort: 30084`
- Deployment: `envFrom: edrdog-secrets` 추가
- `CORS_ALLOWED_ORIGINS`: 배포 프론트(Vercel) 주소 포함, 서버 값과 동일하게
- `DEMO_SEED`: 서버가 `true` 라 맞춤. **해커톤 끝나면 false 로 되돌릴 것**
- `cicd.yml` 낡은 주석 정정. CD 는 여전히 서비스 매니페스트를 apply 하지 않는다(이유가 바뀌었다: apply 하면 image 가 `:latest` 로 되돌아갔다가 `set image` 로 다시 `:sha` 가 되면서 롤아웃이 두 번 돈다)
- `k8s/README.md` 에 이미지 태그를 지키면서 수동 apply 하는 절차 추가

`DB_PASSWORD` 는 서버도 평문 `edrdog` 를 명시 env 로 갖고 있어(명시 env 가 envFrom 을 이긴다) 그대로 뒀다.

## 검증

`kubectl apply --dry-run=client` 통과. env/envFrom/Service 는 서버의 `kubectl get deploy api-service -o jsonpath` 및 `get svc` 출력과 1:1로 맞췄다.

## 왜 지금 급한가

이 PR 이 머지돼야 #86 의 수집 포트를 서버에 넣을 수 있다. 현재 서버에는 `osquery-tls` Secret 까지 만들어 뒀고, 이 매니페스트 apply 만 남은 상태다.

같은 종류의 드리프트가 responder 에도 있었고 #88 에서 처리했다.