### PR TITLE
fix: Slack 발송 실패가 쿨다운 창을 태워 다음 알림까지 막던 문제

### DIFF
--- a/alert-service/src/main/java/com/edrdog/alertservice/AlertListener.java
+++ b/alert-service/src/main/java/com/edrdog/alertservice/AlertListener.java
@@ -50,7 +50,11 @@ public class AlertListener {
         }
         String key = route.get().cooldownId() + "|" + alert.host() + "|" + alert.ruleId();
         if (cooldown.allow(key, alert.ts())) {
-            slack.send(alert, route.get().webhookUrl());
+            // 발송이 실패하면 기록을 되돌린다. 안 그러면 실패한 발송이 쿨다운 창을 태워
+            // 같은 alert 의 재발생분까지 조용히 막힌다.
+            if (!slack.send(alert, route.get().webhookUrl())) {
+                cooldown.forget(key);
+            }
         }
     }
 }

--- a/alert-service/src/main/java/com/edrdog/alertservice/Cooldown.java
+++ b/alert-service/src/main/java/com/edrdog/alertservice/Cooldown.java
@@ -26,4 +26,13 @@ public class Cooldown {
         lastSent.put(key, nowMs);
         return true;
     }
+
+    /**
+     * 기록을 지워 다음 요청이 다시 통과하게 한다.
+     * allow 는 발송 전에 호출되므로, 발송이 실패했는데 기록이 남으면 그 실패가 쿨다운 창을 태워
+     * 같은 alert 의 재발생분까지 막는다. 실패 시 롤백해 그 상황을 없앤다.
+     */
+    public void forget(String key) {
+        lastSent.remove(key);
+    }
 }

--- a/alert-service/src/main/java/com/edrdog/alertservice/slack/SlackNotifier.java
+++ b/alert-service/src/main/java/com/edrdog/alertservice/slack/SlackNotifier.java
@@ -25,8 +25,12 @@ public class SlackNotifier {
         this.client = builder.build();
     }
 
-    /** alert 를 주어진 webhook URL 로 전송. 실패는 경고 로그만 남기고 삼킨다. */
-    public void send(Alert alert, String webhookUrl) {
+    /**
+     * alert 를 주어진 webhook URL 로 전송하고 성공 여부를 돌려준다.
+     * 예외를 밖으로 던지지는 않는다(한 건 실패로 컨슈머를 멈추지 않는다). 대신 false 를 돌려줘
+     * 호출자가 쿨다운을 롤백할 수 있게 한다.
+     */
+    public boolean send(Alert alert, String webhookUrl) {
         try {
             client.post()
                     .uri(webhookUrl)
@@ -34,9 +38,11 @@ public class SlackNotifier {
                     .body(Map.of("text", format(alert)))
                     .retrieve()
                     .toBodilessEntity();
+            return true;
         } catch (Exception e) {
             log.warn("Slack 발송 실패 (tenant={}, host={}, rule={}): {}",
                     alert.tenantId(), alert.host(), alert.ruleId(), e.getMessage());
+            return false;
         }
     }
 

--- a/alert-service/src/test/java/com/edrdog/alertservice/AlertListenerTest.java
+++ b/alert-service/src/test/java/com/edrdog/alertservice/AlertListenerTest.java
@@ -1,0 +1,91 @@
+package com.edrdog.alertservice;
+
+import com.edrdog.alertservice.dto.Alert;
+import com.edrdog.alertservice.slack.SlackNotifier;
+import com.edrdog.alertservice.webhook.AlertRouter;
+import com.edrdog.alertservice.webhook.AlertRouter.Route;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/** AlertListener: 라우팅 결과에 따른 발송/skip 과 쿨다운 억제·롤백. */
+class AlertListenerTest {
+
+    private static final String WEBHOOK = "https://hooks/abc";
+
+    private AlertRouter router;
+    private SlackNotifier slack;
+    private AlertListener listener;
+
+    @BeforeEach
+    void setUp() {
+        router = mock(AlertRouter.class);
+        slack = mock(SlackNotifier.class);
+        listener = new AlertListener(60_000, router, slack);
+    }
+
+    private Alert alert(long ts) {
+        return new Alert("t1", "host-1", "SUSPICIOUS_PROCESS_CHAIN", "T1059",
+                Alert.SEV_HIGH, Alert.ACTION_KILL, ts, List.of("evidence"));
+    }
+
+    private void routed() {
+        when(router.route(any())).thenReturn(Optional.of(new Route(WEBHOOK, "user:1")));
+    }
+
+    @Test
+    @DisplayName("목적지가 있으면 그 webhook 으로 발송한다")
+    void routed_sends() {
+        routed();
+        when(slack.send(any(), anyString())).thenReturn(true);
+
+        listener.onAlert(alert(1_000));
+
+        verify(slack).send(any(), anyString());
+    }
+
+    @Test
+    @DisplayName("목적지가 없으면 발송하지 않는다")
+    void noRoute_skips() {
+        when(router.route(any())).thenReturn(Optional.empty());
+
+        listener.onAlert(alert(1_000));
+
+        verify(slack, never()).send(any(), anyString());
+    }
+
+    @Test
+    @DisplayName("발송에 성공하면 윈도우 안 같은 alert 는 억제된다")
+    void sendSucceeded_withinWindow_suppressed() {
+        routed();
+        when(slack.send(any(), anyString())).thenReturn(true);
+
+        listener.onAlert(alert(1_000));
+        listener.onAlert(alert(2_000));
+
+        verify(slack, times(1)).send(any(), anyString());
+    }
+
+    @Test
+    @DisplayName("발송에 실패하면 쿨다운을 롤백해 다음 alert 를 막지 않는다")
+    void sendFailed_cooldownRolledBack() {
+        routed();
+        when(slack.send(any(), anyString())).thenReturn(false);
+
+        listener.onAlert(alert(1_000));
+        listener.onAlert(alert(2_000));
+
+        verify(slack, times(2)).send(any(), anyString());
+    }
+}

--- a/alert-service/src/test/java/com/edrdog/alertservice/CooldownTest.java
+++ b/alert-service/src/test/java/com/edrdog/alertservice/CooldownTest.java
@@ -47,4 +47,27 @@ class CooldownTest {
         assertThat(cooldown.allow("t1|host-1|RULE", 1_000)).isTrue();
         assertThat(cooldown.allow("t1|host-1|RULE", 30_000)).isFalse();
     }
+
+    @Test
+    @DisplayName("forget 하면 윈도우 안이어도 다시 통과한다 (발송 실패 롤백용)")
+    void forget_allowsAgainWithinWindow() {
+        Cooldown cooldown = new Cooldown(60_000);
+        assertThat(cooldown.allow("t1|host-1|RULE", 1_000)).isTrue();
+
+        cooldown.forget("t1|host-1|RULE");
+
+        assertThat(cooldown.allow("t1|host-1|RULE", 2_000)).isTrue();
+    }
+
+    @Test
+    @DisplayName("forget 은 다른 키에 영향을 주지 않는다")
+    void forget_otherKeysUntouched() {
+        Cooldown cooldown = new Cooldown(60_000);
+        cooldown.allow("t1|host-1|RULE", 1_000);
+        cooldown.allow("t1|host-2|RULE", 1_000);
+
+        cooldown.forget("t1|host-1|RULE");
+
+        assertThat(cooldown.allow("t1|host-2|RULE", 2_000)).isFalse();
+    }
 }

--- a/alert-service/src/test/java/com/edrdog/alertservice/slack/SlackNotifierTest.java
+++ b/alert-service/src/test/java/com/edrdog/alertservice/slack/SlackNotifierTest.java
@@ -13,6 +13,7 @@ import static org.springframework.http.HttpMethod.POST;
 import static org.springframework.test.web.client.ExpectedCount.once;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withServerError;
 import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
 
 /** SlackNotifier: 메시지 포맷(순수) + 주어진 webhook 으로 POST 검증. */
@@ -57,7 +58,21 @@ class SlackNotifierTest {
                 .andExpect(method(POST))
                 .andRespond(withSuccess());
 
-        notifier.send(alert(Alert.SEV_HIGH, Alert.ACTION_KILL), "https://hooks/abc");
+        assertThat(notifier.send(alert(Alert.SEV_HIGH, Alert.ACTION_KILL), "https://hooks/abc")).isTrue();
+        server.verify();
+    }
+
+    @Test
+    @DisplayName("Slack 이 5xx 를 주면 false 를 돌려준다 (호출자가 쿨다운을 롤백할 수 있게)")
+    void send_returnsFalseOnFailure() {
+        RestClient.Builder builder = RestClient.builder();
+        MockRestServiceServer server = MockRestServiceServer.bindTo(builder).build();
+        SlackNotifier notifier = new SlackNotifier(builder);
+
+        server.expect(once(), requestTo("https://hooks/abc"))
+                .andRespond(withServerError());
+
+        assertThat(notifier.send(alert(Alert.SEV_HIGH, Alert.ACTION_KILL), "https://hooks/abc")).isFalse();
         server.verify();
     }
 }


### PR DESCRIPTION
## 문제

`AlertListener` 가 발송 **전에** 쿨다운 시각을 기록한다.

```java
if (cooldown.allow(key, alert.ts())) {   // 여기서 이미 기록됨
    slack.send(alert, route.get().webhookUrl());   // 실패해도 기록은 남음
}
```

그래서 Slack 이 5xx 를 주거나 연결이 끊겨 발송이 실패해도, 같은 `tenant+host+rule` 의 다음 alert 가 60초 동안 조용히 억제된다. 발송은 실패했는데 억제만 정상 동작하는 셈이라 알림이 두 번 사라진다.

온보딩 화면의 연동 점검 중 나온 건이다.

## 변경

- `SlackNotifier.send` 가 성공 여부를 `boolean` 으로 돌려준다. 예외를 밖으로 던지지 않는 건 그대로 (한 건 실패로 컨슈머를 멈추지 않는다)
- `Cooldown.forget(key)` 추가
- `AlertListener` 가 발송 실패 시 롤백

## 테스트

TDD 로 진행했다 (테스트 먼저 → 컴파일 에러로 실패 확인 → 구현 → 통과).

- `CooldownTest` +2: forget 후 윈도우 안 재통과, forget 이 다른 키에 영향 없음
- `SlackNotifierTest` +2: 성공 시 true, 5xx 시 false
- `AlertListenerTest` **신규 4건**: 발송 / 목적지 없음 skip / 성공 후 억제 / **실패 후 롤백**. alert-service 에 리스너 단위 테스트가 아예 없었다

`./gradlew :alert-service:test` 통과 (Cooldown 7, SlackNotifier 4, AlertListener 4).

## 범위 밖

Slack 발송 실패 자체가 유실이라는 점은 그대로다 (재시도·DLQ 없음). alert 는 ClickHouse 에 남아 대시보드에서는 보인다. 재시도 횟수·백오프·DLQ 는 정책 결정이 필요해 따로 다루는 게 맞다고 판단했다.