### PR TITLE
feat: collector-service 를 실제로 배포한다 (수집 경로가 끊겨 있었다)

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -48,7 +48,7 @@ jobs:
       packages: write
     strategy:
       matrix:
-        module: [detector-service, responder-service, archiver-service, api-service, alert-service]
+        module: [detector-service, responder-service, archiver-service, api-service, alert-service, collector-service]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4
@@ -100,7 +100,7 @@ jobs:
             -i ~/.ssh/deploy_key "$SSH_USER@$SSH_HOST" \
             "REPO='$REPO_LC' SHA='$SHA' NS=edrdog bash -s" <<'REMOTE'
           set -euo pipefail
-          MODULES="detector-service responder-service archiver-service api-service alert-service"
+          MODULES="detector-service responder-service archiver-service api-service alert-service collector-service"
 
           # 모니터링 스택과 Kafka UI 만 매니페스트로 apply 한다.
           # 서비스 5개 매니페스트는 손대지 않는다. apply 하면 image 가 :latest 로 되돌아갔다가
@@ -126,10 +126,22 @@ jobs:
           echo "~/Backend 클론이 없어 모니터링 매니페스트 apply 를 건너뛴다" >&2
           fi
 
+          # Deployment 가 아직 없는 모듈(새로 추가된 서비스)은 건너뛴다.
+          # set -e 라 없는 deployment 에 set image 를 하면 나머지 배포까지 통째로 죽는다.
+          # 새 서비스는 서버에서 k8s/<모듈>.yaml 을 한 번 apply 한 뒤부터 이 루프가 관리한다.
+          DEPLOYED=""
           for m in $MODULES; do
+          if sudo kubectl -n "$NS" get deploy "$m" >/dev/null 2>&1; then
+          DEPLOYED="$DEPLOYED $m"
+          else
+          echo "deployment/$m 없음 → 건너뜀. k8s/$m.yaml 을 서버에서 먼저 apply 할 것" >&2
+          fi
+          done
+
+          for m in $DEPLOYED; do
           sudo kubectl -n "$NS" set image "deployment/$m" "$m=ghcr.io/$REPO/$m:$SHA"
           done
-          for m in $MODULES; do
+          for m in $DEPLOYED; do
           sudo kubectl -n "$NS" rollout status "deployment/$m" --timeout=120s
           done
           REMOTE

--- a/collector-service/Dockerfile
+++ b/collector-service/Dockerfile
@@ -1,0 +1,6 @@
+FROM eclipse-temurin:21-jre
+WORKDIR /app
+# CI가 build/libs 에 boot jar 하나만 남겨 전달 (plain jar 는 제거됨)
+COPY build/libs/*.jar app.jar
+EXPOSE 8082
+ENTRYPOINT ["java", "-jar", "/app/app.jar"]

--- a/k8s/collector-service.yaml
+++ b/k8s/collector-service.yaml
@@ -1,0 +1,69 @@
+# events-raw(osquery/Zeek 원시 result-log)를 소비해 detector 스키마로 정규화한 뒤 events 로 재발행한다.
+# 이게 없으면 api-service 가 발행한 원시 로그를 아무도 소비하지 않아 events 가 비고,
+# detector/archiver 가 events 만 보므로 탐지도 대시보드도 조용해진다(수집 경로가 끊긴다).
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: collector-service
+  namespace: edrdog
+  labels:
+    app: collector-service
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: collector-service
+  template:
+    metadata:
+      labels:
+        app: collector-service
+    spec:
+      containers:
+        - name: collector-service
+          # 배포 시 CI 가 kubectl set image 로 실제 태그(:<sha>) 주입
+          image: ghcr.io/2026-siheung-bootcamp-team-i/backend/collector-service:latest
+          ports:
+            - containerPort: 8082
+          # 다른 서비스와 같은 패턴 (Infisical 동기화 Secret)
+          envFrom:
+            - secretRef:
+                name: edrdog-secrets
+          env:
+            - name: SPRING_KAFKA_BOOTSTRAP_SERVERS
+              value: "kafka:9094"
+            # 트레이스 OTLP 수집기 (k8s/otel-lgtm.yaml)
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: "http://otel-lgtm:4318"
+          readinessProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8082
+            initialDelaySeconds: 15
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8082
+            initialDelaySeconds: 30
+            periodSeconds: 20
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: collector-service
+  namespace: edrdog
+  labels:
+    app: collector-service
+spec:
+  selector:
+    app: collector-service
+  ports:
+    - port: 80
+      targetPort: 8082


### PR DESCRIPTION
## 문제

**`collector-service` 가 배포되어 있지 않다.** 배포서버 실측에서 발견했다.

```
$ sudo kubectl -n edrdog logs deploy/collector-service
error: deployments.apps "collector-service" not found in namespace "edrdog"
```

레포를 확인하니 Gradle 모듈로만 존재했다.

| | 상태 |
|---|---|
| `settings.gradle` | 있음 |
| `Dockerfile` | **없음** |
| `k8s/` 매니페스트 | **없음** |
| CI 빌드 matrix | **없음** (5개만 빌드) |
| CD `MODULES` | **없음** |
| 서버 배포 | **없음** |

## 왜 치명적인가

collector 는 `events-raw` 를 소비해 detector 스키마로 정규화한 뒤 `events` 로 재발행하는 **유일한** 서비스다.

```
osquery → api-service → [events-raw] → ???  ✗  → [events] → detector / archiver
                                     collector 없음
```

detector 와 archiver 는 `events` 만 본다. 그래서 osquery 를 붙여도 원시 로그가 `events-raw` 에 쌓이기만 하고 끝난다. **탐지도, 대시보드 기기 목록도, 알림도 영원히 조용하다.** 온보딩 안내를 100% 따라 해도 화면에 아무것도 안 나타난다.

지금 대시보드에 보이는 데이터는 전부 `DEMO_SEED=true` 로 들어간 시드다.

## 변경

- `collector-service/Dockerfile` (다른 모듈과 동일 패턴, 8082)
- `k8s/collector-service.yaml` (archiver 매니페스트와 같은 구조 + `envFrom: edrdog-secrets`)
- CI 빌드 matrix 와 CD `MODULES` 에 `collector-service` 추가
- **CD 배포 루프에 존재 가드 추가**: Deployment 가 없는 모듈에 `set image` 를 하면 `set -e` 때문에 나머지 서비스 배포까지 통째로 죽는다. 이 PR 이 머지되는 순간 정확히 그 상황이 발생하므로 같이 넣었다

## 배포 순서 (중요)

첫 배포는 서버에서 매니페스트를 한 번 apply 해야 한다.

```bash
cd ~/Backend && git fetch origin && git checkout origin/main -- k8s/
sudo kubectl -n edrdog apply -f k8s/collector-service.yaml
sudo kubectl -n edrdog rollout status deploy/collector-service
```

이미지가 GHCR 에 올라온 뒤여야 하므로 **main 머지 후 CI 빌드가 끝나고** 실행한다. 그 전에 apply 하면 `:latest` 태그를 못 찾아 ImagePullBackOff 가 난다.

## 검증

`kubectl apply --dry-run=client -f k8s/collector-service.yaml` 통과. 실제 동작은 배포 후 `events-raw` → `events` 흐름으로 확인해야 한다(이 PR 시점에는 미검증).