### PR TITLE
release: collector-service 배포 (끊겨 있던 수집 경로 연결)

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -48,7 +48,7 @@ jobs:
       packages: write
     strategy:
       matrix:
-        module: [detector-service, responder-service, archiver-service, api-service, alert-service]
+        module: [detector-service, responder-service, archiver-service, api-service, alert-service, collector-service]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4
@@ -100,7 +100,7 @@ jobs:
             -i ~/.ssh/deploy_key "$SSH_USER@$SSH_HOST" \
             "REPO='$REPO_LC' SHA='$SHA' NS=edrdog bash -s" <<'REMOTE'
           set -euo pipefail
-          MODULES="detector-service responder-service archiver-service api-service alert-service"
+          MODULES="detector-service responder-service archiver-service api-service alert-service collector-service"
 
           # 모니터링 스택과 Kafka UI 만 매니페스트로 apply 한다.
           # 서비스 5개 매니페스트는 손대지 않는다. apply 하면 image 가 :latest 로 되돌아갔다가
@@ -126,10 +126,22 @@ jobs:
           echo "~/Backend 클론이 없어 모니터링 매니페스트 apply 를 건너뛴다" >&2
           fi
 
+          # Deployment 가 아직 없는 모듈(새로 추가된 서비스)은 건너뛴다.
+          # set -e 라 없는 deployment 에 set image 를 하면 나머지 배포까지 통째로 죽는다.
+          # 새 서비스는 서버에서 k8s/<모듈>.yaml 을 한 번 apply 한 뒤부터 이 루프가 관리한다.
+          DEPLOYED=""
           for m in $MODULES; do
+          if sudo kubectl -n "$NS" get deploy "$m" >/dev/null 2>&1; then
+          DEPLOYED="$DEPLOYED $m"
+          else
+          echo "deployment/$m 없음 → 건너뜀. k8s/$m.yaml 을 서버에서 먼저 apply 할 것" >&2
+          fi
+          done
+
+          for m in $DEPLOYED; do
           sudo kubectl -n "$NS" set image "deployment/$m" "$m=ghcr.io/$REPO/$m:$SHA"
           done
-          for m in $MODULES; do
+          for m in $DEPLOYED; do
           sudo kubectl -n "$NS" rollout status "deployment/$m" --timeout=120s
           done
           REMOTE

--- a/collector-service/Dockerfile
+++ b/collector-service/Dockerfile
@@ -1,0 +1,6 @@
+FROM eclipse-temurin:21-jre
+WORKDIR /app
+# CI가 build/libs 에 boot jar 하나만 남겨 전달 (plain jar 는 제거됨)
+COPY build/libs/*.jar app.jar
+EXPOSE 8082
+ENTRYPOINT ["java", "-jar", "/app/app.jar"]

--- a/k8s/collector-service.yaml
+++ b/k8s/collector-service.yaml
@@ -1,0 +1,69 @@
+# events-raw(osquery/Zeek 원시 result-log)를 소비해 detector 스키마로 정규화한 뒤 events 로 재발행한다.
+# 이게 없으면 api-service 가 발행한 원시 로그를 아무도 소비하지 않아 events 가 비고,
+# detector/archiver 가 events 만 보므로 탐지도 대시보드도 조용해진다(수집 경로가 끊긴다).
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: collector-service
+  namespace: edrdog
+  labels:
+    app: collector-service
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: collector-service
+  template:
+    metadata:
+      labels:
+        app: collector-service
+    spec:
+      containers:
+        - name: collector-service
+          # 배포 시 CI 가 kubectl set image 로 실제 태그(:<sha>) 주입
+          image: ghcr.io/2026-siheung-bootcamp-team-i/backend/collector-service:latest
+          ports:
+            - containerPort: 8082
+          # 다른 서비스와 같은 패턴 (Infisical 동기화 Secret)
+          envFrom:
+            - secretRef:
+                name: edrdog-secrets
+          env:
+            - name: SPRING_KAFKA_BOOTSTRAP_SERVERS
+              value: "kafka:9094"
+            # 트레이스 OTLP 수집기 (k8s/otel-lgtm.yaml)
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: "http://otel-lgtm:4318"
+          readinessProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8082
+            initialDelaySeconds: 15
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8082
+            initialDelaySeconds: 30
+            periodSeconds: 20
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: collector-service
+  namespace: edrdog
+  labels:
+    app: collector-service
+spec:
+  selector:
+    app: collector-service
+  ports:
+    - port: 80
+      targetPort: 8082


### PR DESCRIPTION
## 요약

#91 하나. `collector-service` 를 실제로 배포 가능하게 만든다.

`events-raw` → `events` 정규화를 담당하는 유일한 서비스인데 Dockerfile·k8s 매니페스트·CI matrix 가 전부 없어 배포된 적이 없었다. 그래서 osquery 를 붙여도 원시 로그가 `events-raw` 에 쌓이기만 하고 탐지·대시보드·알림이 전부 조용했다.

CD 배포 루프에 존재 가드도 함께 넣었다. Deployment 가 없는 모듈에 `set image` 를 하면 `set -e` 때문에 나머지 서비스 배포까지 죽는데, 이 머지가 정확히 그 상황을 만든다.

## 머지 후 필수 작업

CI 빌드가 끝난 뒤 서버에서 한 번만 실행한다.

```bash
cd ~/Backend && git fetch origin && git checkout origin/main -- k8s/
sudo kubectl -n edrdog apply -f k8s/collector-service.yaml
sudo kubectl -n edrdog rollout status deploy/collector-service
```

빌드 전에 apply 하면 `:latest` 를 못 찾아 ImagePullBackOff 가 난다.