### PR TITLE
release: CI artifact 에 collector jar 추가 (이미지 빌드 복구)

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -37,6 +37,7 @@ jobs:
             archiver-service/build/libs/*.jar
             api-service/build/libs/*.jar
             alert-service/build/libs/*.jar
+            collector-service/build/libs/*.jar
 
   # 이미지 빌드 + GHCR 푸시 (main 푸시에만, 모듈별 matrix)
   image:


### PR DESCRIPTION
#93 하나. collector-service jar 이 CI artifact 에 빠져 이미지 빌드가 실패하고 deploy 까지 멈춰 있던 것을 복구한다.