### PR TITLE
fix: collector-service 에 spring-boot-starter-web 추가 (HTTP 서버가 안 떠서 재시작 반복)

### DIFF
--- a/collector-service/build.gradle
+++ b/collector-service/build.gradle
@@ -1,5 +1,8 @@
 // Collector — osquery/Zeek 원시 result-log(events-raw) 를 소비해 detector 스키마(Event)로 정규화 후 events 로 재발행
 dependencies {
+    // 루트 build.gradle 이 actuator 를 넣지만 web 이 없으면 HTTP 서버 자체가 안 떠서
+    // /actuator/health 가 서빙되지 않는다(k8s probe 가 계속 실패해 컨테이너가 재시작된다).
+    implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.kafka:spring-kafka'
     implementation 'com.fasterxml.jackson.core:jackson-databind'        // 원시 osquery JSON 파싱 + Event JSON 직렬화
 }


### PR DESCRIPTION
## 문제

#91 로 collector 를 배포하자마자 컨테이너가 계속 재시작됐다.

```
Liveness probe failed: Get "http://10.42.0.95:8082/actuator/health": connection refused
Container collector-service failed liveness probe, will be restarted
```

이미지 pull 은 정상이고 앱도 뜨는데 8082 에 아무도 리슨하지 않는다.

## 원인

루트 `build.gradle` 이 `spring-boot-starter-actuator` 를 모든 모듈에 넣지만, `collector-service` 에는 **`spring-boot-starter-web` 이 없다**. 웹 서버가 없으니 actuator 엔드포인트가 HTTP 로 서빙되지 않고, k8s probe 가 영원히 실패해 컨테이너가 죽었다 살기를 반복한다. 그때마다 Kafka 소비도 끊긴다.

`collector-service/src/main/resources/application.yml` 은 이미 `server.port: 8082` 와 `management.endpoints` 를 갖고 있어 웹 서버를 전제로 쓰여 있었다. 같은 소비 전용 서비스인 `archiver-service` 도 web 을 갖고 있다(ClickHouse RestClient 용).

## 변경

`collector-service/build.gradle` 에 한 줄 추가.

## 임시 조치

머지·재배포 전까지 서버에서는 probe 를 떼어 돌리고 있다.

```bash
kubectl -n edrdog patch deploy collector-service --type=json \
  -p '[{"op":"remove","path":"/spec/template/spec/containers/0/livenessProbe"},
       {"op":"remove","path":"/spec/template/spec/containers/0/readinessProbe"}]'
```

새 이미지 배포 후 `kubectl apply -f k8s/collector-service.yaml` 로 probe 를 되돌리면 된다.

## 검증

`./gradlew :collector-service:build` 통과. 실제 health 응답은 배포 후 확인.