### PR TITLE
fix: CORS preflight 가 ApiKeyFilter 에 막혀 브라우저에서 /api/tenant/* 를 못 부르던 문제

### DIFF
--- a/api-service/src/main/java/com/edrdog/apiservice/security/ApiKeyFilter.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/security/ApiKeyFilter.java
@@ -30,7 +30,11 @@ public class ApiKeyFilter extends OncePerRequestFilter {
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain)
             throws ServletException, IOException {
         String path = request.getRequestURI();
-        if (policy.isExempt(path) || policy.isAuthorized(request.getHeader(HEADER))) {
+        boolean preflight = ApiKeyPolicy.isPreflight(
+                request.getMethod(),
+                request.getHeader("Origin"),
+                request.getHeader("Access-Control-Request-Method"));
+        if (preflight || policy.isExempt(path) || policy.isAuthorized(request.getHeader(HEADER))) {
             chain.doFilter(request, response);
             return;
         }

--- a/api-service/src/main/java/com/edrdog/apiservice/security/ApiKeyPolicy.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/security/ApiKeyPolicy.java
@@ -27,6 +27,16 @@ public class ApiKeyPolicy {
         this.configuredKey = configuredKey;
     }
 
+    /**
+     * CORS preflight 여부. 브라우저는 preflight 에 커스텀 헤더(X-API-Key)를 싣지 않으므로
+     * 여기서 막으면 본 요청이 아예 발사되지 않는다(프론트에는 "서버에 연결하지 못했습니다"로 보인다).
+     * preflight 는 본문 없는 협상 요청이라 통과시켜도 데이터가 새지 않고, 실제 요청은 그대로 검사된다.
+     * 판정은 브라우저가 붙이는 두 헤더의 존재로 한다(단순 OPTIONS 는 preflight 가 아니다).
+     */
+    public static boolean isPreflight(String method, String origin, String requestMethodHeader) {
+        return "OPTIONS".equalsIgnoreCase(method) && origin != null && requestMethodHeader != null;
+    }
+
     /** 헬스체크·Swagger 등 인증 없이 열어두는 경로. */
     public boolean isExempt(String path) {
         return EXEMPT_PREFIXES.stream().anyMatch(path::startsWith);

--- a/api-service/src/test/java/com/edrdog/apiservice/security/ApiKeyPolicyTest.java
+++ b/api-service/src/test/java/com/edrdog/apiservice/security/ApiKeyPolicyTest.java
@@ -65,4 +65,17 @@ class ApiKeyPolicyTest {
         assertFalse(policy.isAuthorized(""));
         assertFalse(policy.isAuthorized("  "));
     }
+
+    @Test
+    void CORS_preflight_는_키_없이도_통과_대상이다() {
+        assertTrue(ApiKeyPolicy.isPreflight("OPTIONS", "http://localhost:5173", "POST"));
+        assertTrue(ApiKeyPolicy.isPreflight("options", "https://edrdog.example", "GET"));
+    }
+
+    @Test
+    void preflight_헤더가_빠진_OPTIONS_는_preflight_가_아니다() {
+        assertFalse(ApiKeyPolicy.isPreflight("OPTIONS", null, "POST"));
+        assertFalse(ApiKeyPolicy.isPreflight("OPTIONS", "http://localhost:5173", null));
+        assertFalse(ApiKeyPolicy.isPreflight("POST", "http://localhost:5173", "POST"));
+    }
 }

--- a/api-service/src/test/java/com/edrdog/apiservice/security/CorsIntegrationTest.java
+++ b/api-service/src/test/java/com/edrdog/apiservice/security/CorsIntegrationTest.java
@@ -59,6 +59,25 @@ class CorsIntegrationTest {
     }
 
     @Test
+    void API키가_필요한_경로도_preflight_는_통과한다() throws Exception {
+        // 브라우저는 preflight 에 X-API-Key 를 싣지 않는다. ApiKeyFilter 가 여기서 401 을 주면
+        // 본 요청이 아예 발사되지 않아 온보딩의 enroll secret 발급이 "서버에 연결하지 못했습니다"로 죽는다.
+        mvc.perform(options("/api/tenant/enroll-secret")
+                        .header("Origin", "http://localhost:5173")
+                        .header("Access-Control-Request-Method", "POST")
+                        .header("Access-Control-Request-Headers", "Authorization,X-API-Key"))
+                .andExpect(status().isOk())
+                .andExpect(header().string("Access-Control-Allow-Origin", "http://localhost:5173"));
+    }
+
+    @Test
+    void preflight_가_아닌_OPTIONS_는_여전히_API키를_요구한다() throws Exception {
+        // Origin/Access-Control-Request-Method 없는 OPTIONS 는 preflight 가 아니므로 그냥 막는다.
+        mvc.perform(options("/api/tenant/enroll-secret"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
     void 허용되지_않은_출처의_preflight_는_거부된다() throws Exception {
         mvc.perform(options("/api/alerts")
                         .header("Origin", "https://evil.example")


### PR DESCRIPTION
## 증상

온보딩 1번 **enroll secret 발급이 "서버에 연결하지 못했습니다"** 로 실패한다. 401 이 아니라 요청 자체가 나가지 않는다. 3번 조직 공용 webhook 저장도 같다.

## 원인

브라우저는 CORS preflight(OPTIONS)에 커스텀 헤더를 싣지 않는다. `X-API-Key` 가 없으니 `ApiKeyFilter` 가 401 을 주고, 브라우저는 preflight 실패로 보고 본 요청을 아예 발사하지 않는다.

```
$ curl -i -X OPTIONS https://<api>/api/tenant/enroll-secret \
    -H 'Origin: https://<frontend>' -H 'Access-Control-Request-Method: POST'
HTTP/2 401
{"error":"유효한 X-API-Key 가 필요합니다"}
```

**API 키 값과 무관하다.** 프론트에 올바른 키를 넣어도 고쳐지지 않는다.

영향 범위는 API 키를 요구하는 경로뿐이다. `/api/me`, `/api/hosts`, `/api/auth` 등은 `ApiKeyPolicy` 면제라 preflight 가 통과해 지금까지 정상이었다. 그래서 **로그인·기기 등록·개인 webhook 은 되는데 enroll secret 발급과 조직 공용 webhook 만 안 되는** 증상이 나온다.

즉 온보딩의 첫 단계인 enroll secret 발급은 배포 이후 한 번도 화면에서 성공한 적이 없다.

## 변경

- `ApiKeyPolicy.isPreflight(method, origin, acrm)` 순수 판정 추가
- `ApiKeyFilter` 가 preflight 면 통과. preflight 는 본문 없는 협상 요청이라 데이터가 새지 않고, 실제 요청은 그대로 검사된다
- `Origin` / `Access-Control-Request-Method` 가 없는 단순 OPTIONS 는 preflight 가 아니므로 계속 막는다

## 테스트

기존 `CorsIntegrationTest` 는 `/api/alerts`(**면제 경로**)만 검증해서 이 버그를 놓쳤다. API 키가 필요한 경로로 케이스를 추가했다.

- `API키가_필요한_경로도_preflight_는_통과한다` (수정 전 실패 확인)
- `preflight_가_아닌_OPTIONS_는_여전히_API키를_요구한다`
- `ApiKeyPolicyTest` 에 순수 판정 2건

`./gradlew :api-service:test` 통과 (ApiKeyPolicyTest 10, CorsIntegrationTest 7).