### PR TITLE
release: CORS preflight 401 수정 (온보딩 enroll secret 발급 복구)

### DIFF
--- a/api-service/src/main/java/com/edrdog/apiservice/security/ApiKeyFilter.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/security/ApiKeyFilter.java
@@ -30,7 +30,11 @@ public class ApiKeyFilter extends OncePerRequestFilter {
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain)
             throws ServletException, IOException {
         String path = request.getRequestURI();
-        if (policy.isExempt(path) || policy.isAuthorized(request.getHeader(HEADER))) {
+        boolean preflight = ApiKeyPolicy.isPreflight(
+                request.getMethod(),
+                request.getHeader("Origin"),
+                request.getHeader("Access-Control-Request-Method"));
+        if (preflight || policy.isExempt(path) || policy.isAuthorized(request.getHeader(HEADER))) {
             chain.doFilter(request, response);
             return;
         }

--- a/api-service/src/main/java/com/edrdog/apiservice/security/ApiKeyPolicy.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/security/ApiKeyPolicy.java
@@ -27,6 +27,16 @@ public class ApiKeyPolicy {
         this.configuredKey = configuredKey;
     }
 
+    /**
+     * CORS preflight 여부. 브라우저는 preflight 에 커스텀 헤더(X-API-Key)를 싣지 않으므로
+     * 여기서 막으면 본 요청이 아예 발사되지 않는다(프론트에는 "서버에 연결하지 못했습니다"로 보인다).
+     * preflight 는 본문 없는 협상 요청이라 통과시켜도 데이터가 새지 않고, 실제 요청은 그대로 검사된다.
+     * 판정은 브라우저가 붙이는 두 헤더의 존재로 한다(단순 OPTIONS 는 preflight 가 아니다).
+     */
+    public static boolean isPreflight(String method, String origin, String requestMethodHeader) {
+        return "OPTIONS".equalsIgnoreCase(method) && origin != null && requestMethodHeader != null;
+    }
+
     /** 헬스체크·Swagger 등 인증 없이 열어두는 경로. */
     public boolean isExempt(String path) {
         return EXEMPT_PREFIXES.stream().anyMatch(path::startsWith);

--- a/api-service/src/test/java/com/edrdog/apiservice/security/ApiKeyPolicyTest.java
+++ b/api-service/src/test/java/com/edrdog/apiservice/security/ApiKeyPolicyTest.java
@@ -65,4 +65,17 @@ class ApiKeyPolicyTest {
         assertFalse(policy.isAuthorized(""));
         assertFalse(policy.isAuthorized("  "));
     }
+
+    @Test
+    void CORS_preflight_는_키_없이도_통과_대상이다() {
+        assertTrue(ApiKeyPolicy.isPreflight("OPTIONS", "http://localhost:5173", "POST"));
+        assertTrue(ApiKeyPolicy.isPreflight("options", "https://edrdog.example", "GET"));
+    }
+
+    @Test
+    void preflight_헤더가_빠진_OPTIONS_는_preflight_가_아니다() {
+        assertFalse(ApiKeyPolicy.isPreflight("OPTIONS", null, "POST"));
+        assertFalse(ApiKeyPolicy.isPreflight("OPTIONS", "http://localhost:5173", null));
+        assertFalse(ApiKeyPolicy.isPreflight("POST", "http://localhost:5173", "POST"));
+    }
 }

--- a/api-service/src/test/java/com/edrdog/apiservice/security/CorsIntegrationTest.java
+++ b/api-service/src/test/java/com/edrdog/apiservice/security/CorsIntegrationTest.java
@@ -59,6 +59,25 @@ class CorsIntegrationTest {
     }
 
     @Test
+    void API키가_필요한_경로도_preflight_는_통과한다() throws Exception {
+        // 브라우저는 preflight 에 X-API-Key 를 싣지 않는다. ApiKeyFilter 가 여기서 401 을 주면
+        // 본 요청이 아예 발사되지 않아 온보딩의 enroll secret 발급이 "서버에 연결하지 못했습니다"로 죽는다.
+        mvc.perform(options("/api/tenant/enroll-secret")
+                        .header("Origin", "http://localhost:5173")
+                        .header("Access-Control-Request-Method", "POST")
+                        .header("Access-Control-Request-Headers", "Authorization,X-API-Key"))
+                .andExpect(status().isOk())
+                .andExpect(header().string("Access-Control-Allow-Origin", "http://localhost:5173"));
+    }
+
+    @Test
+    void preflight_가_아닌_OPTIONS_는_여전히_API키를_요구한다() throws Exception {
+        // Origin/Access-Control-Request-Method 없는 OPTIONS 는 preflight 가 아니므로 그냥 막는다.
+        mvc.perform(options("/api/tenant/enroll-secret"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
     void 허용되지_않은_출처의_preflight_는_거부된다() throws Exception {
         mvc.perform(options("/api/alerts")
                         .header("Origin", "https://evil.example")


### PR DESCRIPTION
#97 하나. ApiKeyFilter 가 CORS preflight 를 401 로 막아 브라우저에서 /api/tenant/* 호출이 아예 나가지 못하던 문제를 고친다. 온보딩 1번 enroll secret 발급과 3번 조직 공용 webhook 이 이것 때문에 화면에서 한 번도 성공한 적이 없었다.