### PR TITLE
feat: Zeek 로 네트워크 이벤트 수집 (위협 지도 실데이터)

### DIFF
--- a/collector-service/zeek/README.md
+++ b/collector-service/zeek/README.md
@@ -1,0 +1,76 @@
+# Zeek — 네트워크 이벤트 수집
+
+osquery 는 macOS/Windows 어느 쪽도 실시간 네트워크 이벤트를 제대로 주지 못한다.
+
+- **macOS**: `socket_events` 가 OpenBSM 기반인데 애플이 사실상 걷어냈다. 플래그(`--disable_audit=false`,
+  `--audit_allow_sockets=true`)를 다 켜도 이벤트가 0건이다 (macOS 26 에서 실측).
+- **Windows**: core osquery 에 실시간 소켓 테이블 자체가 없다. 그래서 서버가 내려주는 Windows 스케줄에는
+  네트워크 쿼리가 아예 없다.
+
+그래서 네트워크만 Zeek 가 담당한다. 프로세스·파일 이벤트는 그대로 osquery 가 맡는다.
+
+## 서버는 손대지 않는다
+
+collector 의 `RawEventMapper` 는 쿼리명에 `socket` 이 들어가면 network 로 분류하고
+`columns.remote_address` / `remote_port` 를 `destIp` / `destPort` 로 읽는다. 그래서 Zeek `conn.log` 한 줄을
+osquery result-log 모양으로 바꿔 **기존 수집 API 로 넣으면** 그대로 흘러간다. 새 엔드포인트도 새 서비스도 없다.
+
+```
+Zeek conn.log ──▶ edrdog-zeek-shipper.py ──▶ /api/osquery/log ──▶ events-raw ──▶ collector ──▶ events
+                                              (osquery 와 같은 enroll secret / node_key / 서버 cert)
+```
+
+`--host_identifier` 를 osquery 와 같은 값(hostname)으로 두므로 대시보드에서 **한 기기로 합쳐진다.**
+
+## 실행 (macOS)
+
+전제: 이 기기에 osquery 가 이미 EDRdog 로 붙어 있어야 한다(`/etc/osquery/enroll.secret`,
+`/etc/osquery/osquery-server.pem`). 온보딩 2번을 먼저 끝낼 것.
+
+```bash
+brew install zeek
+
+# 1) 캡처 (로그는 실행한 디렉터리에 생긴다)
+mkdir -p ~/zeek-logs && cd ~/zeek-logs
+sudo zeek -C -i en0 LogAscii::use_json=T local
+
+# 2) 다른 터미널에서 shipper
+sudo ./edrdog-zeek-shipper.py \
+  --conn-log ~/zeek-logs/conn.log \
+  --tls-host <수집서버>:30443
+```
+
+- **`-C` 는 필수다.** en0 가 체크섬 오프로딩(TSO)을 쓰기 때문에 없으면 Zeek 가 체크섬 오류로 패킷을 전부 버린다.
+- 인터페이스는 `route get default` 로 확인한다(보통 `en0`).
+- `sudo` 가 필요한 이유는 두 가지다: BPF 디바이스(`/dev/bpf*`)가 root 전용, enroll secret 파일이 0600.
+- `zeekctl` 없이 직접 띄우면 로그 로테이션이 걸리지 않아 `conn.log` 가 계속 append 된다. shipper 는
+  그래도 로테이션·재생성을 감지해 다시 연다.
+
+## 확인
+
+Zeek 는 **연결이 끝난 뒤** conn.log 에 쓴다. TCP 정상 종료면 약 5초 뒤다(`tcp_close_delay`).
+진행 중인 연결은 안 찍히므로, curl 몇 번 치고 10~20초 기다린 뒤에 본다.
+
+```bash
+tail -f ~/zeek-logs/conn.log        # 줄이 쌓이는지
+```
+
+서버 쪽은 위협 지도(`GET /api/events/geo`)에 국가별 건수가 늘어나면 끝까지 도달한 것이다.
+지도는 **사설 IP 를 제외**하므로(`PrivateIp.isPublic`) 외부로 나가는 연결이 있어야 보인다.
+
+## 테스트
+
+변환 로직(순수)만 단위 테스트가 있다. 이 부분이 어긋나면 이벤트가 조용히 버려지거나 network 가 아닌
+타입으로 분류되므로, 필드 이름을 바꿀 때는 여기부터 고친다.
+
+```bash
+python3 -m unittest discover collector-service/zeek
+```
+
+## 한계 (지금 상태)
+
+- **프로세스 상관 없음**: Zeek 는 어떤 프로세스가 낸 연결인지 모른다. 그래서 network 이벤트의
+  `process` 는 비어 있다. 프로세스 기준 판정은 osquery 이벤트가 담당한다.
+- **수동 실행**: launchd 등록이 없다. 터미널을 닫으면 캡처도 멈춘다. 상시 수집이 필요하면
+  Zeek 와 shipper 둘 다 데몬으로 올려야 한다.
+- **Windows 미지원**: 같은 방식(Zeek + shipper)으로 붙일 수는 있으나 아직 안 만들었다.

--- a/collector-service/zeek/edrdog-zeek-shipper.py
+++ b/collector-service/zeek/edrdog-zeek-shipper.py
@@ -1,0 +1,233 @@
+#!/usr/bin/env python3
+"""
+Zeek conn.log 을 EDRdog 수집 API 로 흘려보내는 shipper.
+
+osquery 는 macOS/Windows 모두 실시간 소켓 이벤트를 제대로 주지 못한다
+(macOS socket_events 는 OpenBSM 기반이라 신형 macOS 에서 비고, Windows 는 테이블 자체가 없다).
+그래서 네트워크 이벤트만 Zeek 가 담당한다.
+
+서버는 손대지 않는다. collector 의 RawEventMapper 가 쿼리명에 socket 이 들어가면 network 로 분류하고
+columns.remote_address / remote_port 를 destIp / destPort 로 읽으므로, conn.log 한 줄을
+osquery result-log 모양으로 바꿔 기존 /api/osquery/log 로 넣으면 그대로 흘러간다.
+
+  Zeek conn.log ──▶ (이 스크립트) ──▶ /api/osquery/log ──▶ events-raw ──▶ collector ──▶ events
+
+인증도 osquery 와 같다. enroll_secret 으로 한 번 enroll 해 node_key 를 받아 캐시하고,
+node_key 가 무효해지면(서버 재설치 등) 자동으로 다시 enroll 한다.
+
+사용:
+  sudo -E ./edrdog-zeek-shipper.py --conn-log /var/log/zeek/conn.log
+
+환경변수(기본값은 osquery 플래그와 같은 경로를 쓴다):
+  EDR_TLS_HOST      수집 서버 host:port      (기본 값 없음, --tls-host 로도 지정)
+  EDR_CERT          서버 cert(PEM) 경로       (기본 /etc/osquery/osquery-server.pem)
+  EDR_SECRET        enroll secret 파일 경로   (기본 /etc/osquery/enroll.secret)
+  EDR_STATE         node_key 캐시 경로        (기본 /var/osquery/zeek-node-key)
+"""
+
+import argparse
+import json
+import os
+import socket
+import ssl
+import sys
+import time
+import urllib.error
+import urllib.request
+
+DEFAULT_CERT = "/etc/osquery/osquery-server.pem"
+DEFAULT_SECRET = "/etc/osquery/enroll.secret"
+DEFAULT_STATE = "/var/osquery/zeek-node-key"
+
+# 한 번에 보낼 최대 건수와 최대 대기 시간. osquery 의 logger_tls_period(10초) 와 맞춘다.
+BATCH_MAX = 100
+BATCH_SECONDS = 10
+
+
+def log(msg):
+    print(f"[edrdog-zeek] {msg}", flush=True)
+
+
+class Client:
+    """수집 API 클라이언트. 서버 cert 를 핀해서 검증한다(osquery --tls_server_certs 와 같은 방식)."""
+
+    def __init__(self, tls_host, cert_path, secret_path, state_path, host_identifier):
+        self.base = f"https://{tls_host}"
+        self.secret_path = secret_path
+        self.state_path = state_path
+        self.host_identifier = host_identifier
+        self.ctx = ssl.create_default_context(cafile=cert_path)
+        self.node_key = self._load_state()
+
+    def _load_state(self):
+        try:
+            with open(self.state_path) as f:
+                return f.read().strip() or None
+        except OSError:
+            return None
+
+    def _save_state(self, node_key):
+        try:
+            with open(self.state_path, "w") as f:
+                f.write(node_key)
+            os.chmod(self.state_path, 0o600)
+        except OSError as e:
+            log(f"node_key 캐시 실패(계속 진행): {e}")
+
+    def _post(self, path, payload):
+        req = urllib.request.Request(
+            self.base + path,
+            data=json.dumps(payload).encode(),
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        with urllib.request.urlopen(req, context=self.ctx, timeout=15) as res:
+            return json.loads(res.read().decode() or "{}")
+
+    def enroll(self):
+        with open(self.secret_path) as f:
+            secret = f.read().strip()
+        res = self._post(
+            "/api/osquery/enroll",
+            {
+                "enroll_secret": secret,
+                "host_identifier": self.host_identifier,
+                # 서버는 platform 으로 수집 스케줄을 고르는데, 네트워크는 스케줄과 무관하다.
+                # osquery 노드와 같은 host 로 붙으므로 기존 노드를 그대로 재사용한다.
+                "platform_type": "darwin",
+            },
+        )
+        key = res.get("node_key")
+        if not key:
+            raise RuntimeError(f"enroll 실패(enroll secret 확인 필요): {res}")
+        self.node_key = key
+        self._save_state(key)
+        log(f"enroll 완료 (host={self.host_identifier})")
+        return key
+
+    def send(self, records):
+        """result-log 배치 발행. node_key 가 무효면 한 번 재-enroll 후 재시도."""
+        if not self.node_key:
+            self.enroll()
+        payload = {"node_key": self.node_key, "log_type": "result", "data": records}
+        res = self._post("/api/osquery/log", payload)
+        if res.get("node_invalid"):
+            log("node_key 무효 → 재-enroll")
+            self.enroll()
+            payload["node_key"] = self.node_key
+            res = self._post("/api/osquery/log", payload)
+        return not res.get("node_invalid", False)
+
+
+def to_record(conn, host_identifier):
+    """
+    Zeek conn.log 한 줄(JSON) → osquery result-log 레코드.
+
+    쿼리명을 socket_events 로 둬야 collector 의 classify 가 network 로 분류한다.
+    목적지만 채운다. Zeek 는 어떤 프로세스가 낸 연결인지 모르므로 path/cmdline 은 비운다
+    (프로세스 상관은 osquery 프로세스 이벤트 쪽이 담당).
+    """
+    dest_ip = conn.get("id.resp_h")
+    dest_port = conn.get("id.resp_p")
+    ts = conn.get("ts")
+    if not dest_ip or ts is None:
+        return None
+    return {
+        "name": "socket_events",
+        "hostIdentifier": host_identifier,
+        "unixTime": str(int(float(ts))),
+        "action": "added",
+        "columns": {
+            "remote_address": str(dest_ip),
+            "remote_port": str(dest_port) if dest_port is not None else "0",
+            # 참고용. collector 는 network 이벤트에서 cmdline 을 그대로 싣는다.
+            "cmdline": f"zeek proto={conn.get('proto', '')} bytes={conn.get('orig_bytes', 0)}",
+            "time": str(int(float(ts))),
+        },
+    }
+
+
+def tail(path):
+    """파일 끝부터 따라 읽는다. 로테이션(재생성/truncate)되면 다시 연다."""
+    while not os.path.exists(path):
+        log(f"conn.log 대기 중: {path}")
+        time.sleep(3)
+    f = open(path)
+    f.seek(0, os.SEEK_END)
+    inode = os.fstat(f.fileno()).st_ino
+    while True:
+        line = f.readline()
+        if line:
+            yield line
+            continue
+        time.sleep(0.5)
+        try:
+            if os.stat(path).st_ino != inode or os.stat(path).st_size < f.tell():
+                log("conn.log 로테이션 감지 → 다시 연다")
+                f.close()
+                f = open(path)
+                inode = os.fstat(f.fileno()).st_ino
+        except FileNotFoundError:
+            log("conn.log 사라짐 → 재생성 대기")
+            f.close()
+            while not os.path.exists(path):
+                time.sleep(3)
+            f = open(path)
+            inode = os.fstat(f.fileno()).st_ino
+
+
+def main():
+    p = argparse.ArgumentParser(description="Zeek conn.log → EDRdog 수집 API")
+    p.add_argument("--conn-log", required=True, help="Zeek conn.log 경로 (JSON 라인 형식)")
+    p.add_argument("--tls-host", default=os.environ.get("EDR_TLS_HOST"), help="수집 서버 host:port")
+    p.add_argument("--cert", default=os.environ.get("EDR_CERT", DEFAULT_CERT))
+    p.add_argument("--secret", default=os.environ.get("EDR_SECRET", DEFAULT_SECRET))
+    p.add_argument("--state", default=os.environ.get("EDR_STATE", DEFAULT_STATE))
+    p.add_argument("--host-identifier", default=socket.gethostname(),
+                   help="osquery --host_identifier=hostname 과 같은 값이어야 한 기기로 합쳐진다")
+    args = p.parse_args()
+
+    if not args.tls_host:
+        p.error("--tls-host 또는 EDR_TLS_HOST 가 필요하다 (예: edrdog.example.com:30443)")
+
+    client = Client(args.tls_host, args.cert, args.secret, args.state, args.host_identifier)
+    log(f"시작: {args.conn_log} → {args.tls_host} (host={args.host_identifier})")
+
+    batch = []
+    last_flush = time.time()
+    for line in tail(args.conn_log):
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue   # TSV 헤더 등 JSON 이 아닌 줄은 건너뛴다
+        try:
+            rec = to_record(json.loads(line), args.host_identifier)
+        except json.JSONDecodeError:
+            continue
+        if rec:
+            batch.append(rec)
+
+        due = len(batch) >= BATCH_MAX or (batch and time.time() - last_flush >= BATCH_SECONDS)
+        if not due:
+            continue
+        try:
+            client.send(batch)
+            log(f"발행 {len(batch)}건")
+            batch = []
+            last_flush = time.time()
+        except (urllib.error.URLError, ssl.SSLError, OSError) as e:
+            # 서버가 잠깐 죽어도 배치를 버리지 않고 다음 주기에 다시 시도한다.
+            log(f"발행 실패(다음 주기 재시도): {e}")
+            last_flush = time.time()
+            if len(batch) > BATCH_MAX * 10:
+                log("버퍼가 너무 커져 오래된 것부터 버린다")
+                batch = batch[-BATCH_MAX:]
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except KeyboardInterrupt:
+        pass
+    except Exception as e:   # noqa: BLE001 - 최상위에서 원인만 찍고 종료
+        log(f"중단: {e}")
+        sys.exit(1)

--- a/collector-service/zeek/test_shipper.py
+++ b/collector-service/zeek/test_shipper.py
@@ -1,0 +1,70 @@
+"""
+shipper 의 순수 변환 로직 테스트.
+
+  python3 -m unittest discover collector-service/zeek
+
+collector 의 RawEventMapper 가 읽는 필드와 1:1로 맞는지 확인한다.
+여기가 어긋나면 이벤트가 조용히 버려지거나 network 가 아닌 타입으로 분류된다.
+"""
+
+import importlib.util
+import pathlib
+import unittest
+
+_spec = importlib.util.spec_from_file_location(
+    "shipper", pathlib.Path(__file__).with_name("edrdog-zeek-shipper.py")
+)
+shipper = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(shipper)
+
+
+def conn(**over):
+    base = {
+        "ts": 1785006412.123456,
+        "uid": "CAcJw21BbVedgFnYH3",
+        "id.orig_h": "192.168.0.10",
+        "id.orig_p": 54321,
+        "id.resp_h": "93.184.216.34",
+        "id.resp_p": 443,
+        "proto": "tcp",
+        "orig_bytes": 517,
+    }
+    base.update(over)
+    return base
+
+
+class ToRecordTest(unittest.TestCase):
+
+    def test_쿼리명이_socket_events_라서_network_로_분류된다(self):
+        rec = shipper.to_record(conn(), "mac-001")
+        # RawEventMapper.classify 는 이름에 socket 이 들어가면 network 로 본다
+        self.assertIn("socket", rec["name"])
+
+    def test_목적지_주소와_포트가_columns_에_들어간다(self):
+        rec = shipper.to_record(conn(), "mac-001")
+        self.assertEqual(rec["columns"]["remote_address"], "93.184.216.34")
+        self.assertEqual(rec["columns"]["remote_port"], "443")
+
+    def test_host_와_시간이_루트에_들어간다(self):
+        rec = shipper.to_record(conn(), "mac-001")
+        self.assertEqual(rec["hostIdentifier"], "mac-001")
+        # unixTime 은 초 단위 문자열. collector 가 ×1000 해서 밀리초로 만든다.
+        self.assertEqual(rec["unixTime"], "1785006412")
+
+    def test_action_이_added_라야_스킵되지_않는다(self):
+        # RawEventMapper 는 action=removed 를 버린다
+        self.assertEqual(shipper.to_record(conn(), "mac-001")["action"], "added")
+
+    def test_목적지가_없으면_버린다(self):
+        self.assertIsNone(shipper.to_record(conn(**{"id.resp_h": None}), "mac-001"))
+
+    def test_시간이_없으면_버린다(self):
+        self.assertIsNone(shipper.to_record(conn(ts=None), "mac-001"))
+
+    def test_포트가_없어도_0_으로_보낸다(self):
+        rec = shipper.to_record(conn(**{"id.resp_p": None}), "mac-001")
+        self.assertEqual(rec["columns"]["remote_port"], "0")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 문제

위협 지도가 `DEMO_SEED` 데이터로만 차 있다. 네트워크 이벤트를 만들 주체가 없다.

**실측으로 확인했다.** 맥북에서 실제 외부 연결 3건(example.com, cloudflare.com, github.com)을 발생시키고 100초간 `GET /api/events/geo` 를 지켜봤는데 수치가 5건에서 전혀 움직이지 않았다. 그 5건은 시드다.

| 플랫폼 | 이유 |
|---|---|
| macOS | `socket_events` 가 OpenBSM 기반인데 애플이 사실상 걷어냈다. `--disable_audit=false`, `--audit_allow_sockets=true` 를 다 켜도 0건 |
| Windows | core osquery 에 실시간 소켓 테이블이 없다. 서버 스케줄에 네트워크 쿼리 자체가 없다 |

문서 여러 곳(`collector-service/README.md`, `OsqueryConfig` 주석)에 "네트워크는 Zeek 담당"이라고 적혀 있지만 **구현이 없었다.** 이름만 있고 코드가 없는 상태였다.

## 접근: 서버를 손대지 않는다

collector 의 `RawEventMapper` 는 쿼리명에 `socket` 이 들어가면 network 로 분류하고 `columns.remote_address` / `remote_port` 를 `destIp` / `destPort` 로 읽는다. 그래서 Zeek `conn.log` 한 줄을 osquery result-log 모양으로 바꿔 **기존 수집 API** 로 넣으면 그대로 흘러간다.

```
Zeek conn.log ──▶ shipper ──▶ /api/osquery/log ──▶ events-raw ──▶ collector ──▶ events ──▶ 위협 지도
```

새 엔드포인트도, 새 서비스도, 서버 배포 변경도 없다. 인증도 osquery 와 같은 enroll secret / node_key / 서버 cert 를 쓴다.

`--host_identifier` 를 osquery 와 같은 hostname 으로 두므로 대시보드에서 **한 기기로 합쳐진다.**

## 변경

- `collector-service/zeek/edrdog-zeek-shipper.py` — stdlib 만 사용. conn.log tail → 변환 → 배치 발행. node_key 무효 시 자동 재-enroll, 로그 로테이션·재생성 감지, 서버 일시 장애 시 배치 보존 후 재시도
- `collector-service/zeek/test_shipper.py` — 변환 로직 단위 테스트 7건. 필드가 어긋나면 이벤트가 조용히 버려지므로 여기서 잡는다
- `collector-service/zeek/README.md` — 실행 방법과 한계

## macOS 실행 요점

```bash
brew install zeek
mkdir -p ~/zeek-logs && cd ~/zeek-logs
sudo zeek -C -i en0 LogAscii::use_json=T local
sudo ./edrdog-zeek-shipper.py --conn-log ~/zeek-logs/conn.log --tls-host <서버>:30443
```

- `sudo` 필수: BPF 디바이스가 root 전용, enroll secret 이 0600
- **`-C` 필수**: en0 가 체크섬 오프로딩(TSO)을 써서 없으면 Zeek 가 패킷을 전부 버린다. macOS 에서 흔한 함정
- `zeekctl` 없이 띄우면 로테이션이 안 걸려 conn.log 가 계속 append 된다
- Zeek 는 **연결이 끝난 뒤** 쓴다(TCP 정상 종료 기준 약 5초). 진행 중 연결은 안 찍힌다

## 테스트

`python3 -m unittest discover collector-service/zeek` 통과 (7건).

실제 종단 확인(맥에서 Zeek 띄워 지도에 실데이터가 뜨는지)은 sudo 가 필요해 사람이 실행해야 한다. 이 PR 시점에는 미검증이며, 확인되면 코멘트로 남긴다.

## 한계

- Zeek 는 어떤 프로세스가 낸 연결인지 모른다. network 이벤트의 `process` 는 비어 있고, 프로세스 기준 판정은 osquery 이벤트가 담당한다
- launchd 등록이 없어 터미널을 닫으면 캡처가 멈춘다. 상시 수집하려면 데몬화가 필요하다
- Windows 는 같은 방식으로 붙일 수 있으나 아직 안 만들었다