### PR TITLE
fix: R2/R3 오탐 — 실행 대상이 아닌 경로 문자열까지 탐지에 걸리던 문제

### DIFF
--- a/detector-service/src/main/java/com/edrdog/detectorservice/api/Scenarios.java
+++ b/detector-service/src/main/java/com/edrdog/detectorservice/api/Scenarios.java
@@ -58,7 +58,7 @@ public final class Scenarios {
         return List.of(
                 network(host, baseTs, "185.220.101.5", 443, tenantId),
                 process(host, baseTs + 1000, "update32.exe", "explorer.exe",
-                        "C:\\Users\\Public\\update32.exe", tenantId));
+                        "C:\\Users\\victim\\Downloads\\update32.exe", tenantId));
     }
 
     /** 다운로드 경로의 스크립트 실행 (unsigned/의심 스크립트 → MEDIUM). 단일 이벤트 point 룰. */

--- a/detector-service/src/main/java/com/edrdog/detectorservice/rule/Rules.java
+++ b/detector-service/src/main/java/com/edrdog/detectorservice/rule/Rules.java
@@ -98,6 +98,11 @@ public final class Rules {
         if (!isProcess(current) || isBaseline(lower(current.process()))) {
             return Optional.empty();
         }
+        // 받아온 것을 실행했는지가 핵심이다(T1105+T1204). 실행 경로 조건이 없으면
+        // "웹 접속 한 번 + 아무 프로세스 실행"이 전부 CRITICAL 이 되어 실사용에서 오탐만 남는다.
+        if (!pathArgumentHasMarker(current.cmdline(), SCRIPT_TEMP_MARKERS)) {
+            return Optional.empty();
+        }
         Optional<Event> download = prior.stream()
                 .filter(Rules::isNetwork)
                 .filter(e -> DOWNLOAD_PORTS.contains(e.destPort()))
@@ -119,7 +124,7 @@ public final class Rules {
 
     /** R3 T1059: 임시/다운로드 경로에서 실행된 스크립트 (저심각 point 룰). */
     private static Optional<Alert> scriptFromTempPath(Event current) {
-        if (!isScript(current) || !pathHasMarker(current.cmdline(), SCRIPT_TEMP_MARKERS)) {
+        if (!isScript(current) || !pathArgumentHasMarker(current.cmdline(), SCRIPT_TEMP_MARKERS)) {
             return Optional.empty();
         }
         return Optional.of(new Alert(
@@ -171,6 +176,33 @@ public final class Rules {
     private static boolean pathHasMarker(String path, Set<String> markers) {
         String p = lower(path);
         return p != null && markers.stream().anyMatch(p::contains);
+    }
+
+    /** 셸 연산자 — 여기부터는 실행 대상이 아니라 출력/후속 명령이라 판정에서 제외한다. */
+    private static final Set<String> SHELL_OPERATORS = Set.of(">", ">>", ">|", "<", "|", "||", "&&", ";", "&");
+
+    /**
+     * cmdline 에서 "실행 대상으로 보이는 경로 인자"에만 표식이 있는지 본다.
+     *
+     * <p>cmdline 전체를 문자열로 훑으면 실행과 무관한 위치의 경로까지 걸린다. 실제로
+     * {@code ... && pwd -P >| /tmp/x} 처럼 리다이렉션 대상이 임시 경로라는 이유로 알림이 나갔다.
+     * 그래서 셸 연산자가 나오면 거기서 끊고, 앞쪽 인자 중 경로처럼 생긴 토큰만 검사한다.
+     */
+    private static boolean pathArgumentHasMarker(String cmdline, Set<String> markers) {
+        String c = lower(cmdline);
+        if (c == null) {
+            return false;
+        }
+        for (String token : c.split("\\s+")) {
+            if (SHELL_OPERATORS.contains(token)) {
+                return false;   // 연산자 뒤는 실행 대상이 아니다
+            }
+            boolean looksLikePath = token.contains("/") || token.contains("\\");
+            if (looksLikePath && markers.stream().anyMatch(token::contains)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /** null 안전한 집합 포함 검사 (immutable Set 은 contains(null) 시 NPE). */

--- a/detector-service/src/test/java/com/edrdog/detectorservice/kafkastreams/topology/DetectionTopologyTest.java
+++ b/detector-service/src/test/java/com/edrdog/detectorservice/kafkastreams/topology/DetectionTopologyTest.java
@@ -52,6 +52,11 @@ class DetectionTopologyTest {
         return new Event(host, Event.TYPE_PROCESS, ts, proc, parent, proc, null, 0, "tenant-a");
     }
 
+    /** cmdline 을 직접 주는 process 이벤트. R2 는 실행 경로를 본다. */
+    private Event processFrom(String host, String proc, String cmdline, long ts) {
+        return new Event(host, Event.TYPE_PROCESS, ts, proc, "explorer.exe", cmdline, null, 0, "tenant-a");
+    }
+
     private Event network(String host, int destPort, long ts) {
         return new Event(host, Event.TYPE_NETWORK, ts, null, null, null, "203.0.113.9", destPort, "tenant-a");
     }
@@ -73,7 +78,7 @@ class DetectionTopologyTest {
     @DisplayName("network 다운로드 → 실행 시퀀스 → alerts 에 CRITICAL 발행")
     void downloadExecute_emitsAlert() {
         events.pipeInput("k", network("host-2", 443, 1000));
-        events.pipeInput("k", process("host-2", "evil.exe", "cmd.exe", 2000));
+        events.pipeInput("k", processFrom("host-2", "evil.exe", "C:\\Users\\me\\Downloads\\evil.exe", 2000));
 
         assertThat(alerts.getQueueSize()).isEqualTo(1);
         assertThat(alerts.readValue().severity()).isEqualTo(Alert.SEV_CRITICAL);

--- a/detector-service/src/test/java/com/edrdog/detectorservice/rule/RulesTest.java
+++ b/detector-service/src/test/java/com/edrdog/detectorservice/rule/RulesTest.java
@@ -20,6 +20,11 @@ class RulesTest {
         return new Event(HOST, Event.TYPE_PROCESS, ts, proc, parent, proc + " args", null, 0, TENANT);
     }
 
+    /** cmdline 을 직접 주는 process 이벤트. R2 는 실행 경로(cmdline)를 본다. */
+    private Event processFrom(String proc, String cmdline, long ts) {
+        return new Event(HOST, Event.TYPE_PROCESS, ts, proc, "bash", cmdline, null, 0, TENANT);
+    }
+
     private Event network(String destIp, int destPort, long ts) {
         return new Event(HOST, Event.TYPE_NETWORK, ts, null, null, null, destIp, destPort, TENANT);
     }
@@ -74,7 +79,7 @@ class RulesTest {
     @DisplayName("R2: network 다운로드 후 같은 host 에서 process 실행 → DOWNLOAD_AND_EXECUTE(T1105+T1204, CRITICAL, isolate)")
     void r2_downloadThenExecute_alerts() {
         List<Event> buffer = List.of(network("203.0.113.9", 443, 1000));
-        Event current = process("evil.exe", "cmd.exe", 2000);
+        Event current = processFrom("evil.exe", "/tmp/evil.exe --run", 2000);
 
         Optional<Alert> alert = Rules.evaluate(buffer, current);
 
@@ -86,6 +91,28 @@ class RulesTest {
         assertThat(a.action()).isEqualTo(Alert.ACTION_ISOLATE);
         assertThat(a.ts()).isEqualTo(2000);
         assertThat(a.matched()).hasSize(2);
+    }
+
+    @Test
+    @DisplayName("R2 음성: 받아온 뒤라도 임시·다운로드 경로가 아닌 실행은 미판정 (평범한 앱 실행)")
+    void r2_executeFromNormalPath_noAlert() {
+        // 웹 접속 후 정상 앱을 실행하는 건 일상이다. 여기까지 CRITICAL 로 올리면 실사용에서 오탐만 남는다.
+        List<Event> buffer = List.of(network("203.0.113.9", 443, 1000));
+        Event current = processFrom("Slack", "/Applications/Slack.app/Contents/MacOS/Slack", 2000);
+
+        assertThat(Rules.evaluate(buffer, current)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("R2 양성: 다운로드 폴더에서 실행해도 잡는다")
+    void r2_executeFromDownloads_alerts() {
+        List<Event> buffer = List.of(network("203.0.113.9", 80, 1000));
+        Event current = processFrom("setup", "/Users/me/Downloads/setup --silent", 2000);
+
+        Optional<Alert> alert = Rules.evaluate(buffer, current);
+
+        assertThat(alert).isPresent();
+        assertThat(alert.get().ruleId()).isEqualTo("DOWNLOAD_AND_EXECUTE");
     }
 
     @Test
@@ -135,6 +162,28 @@ class RulesTest {
     }
 
     @Test
+    @DisplayName("R3 음성: 리다이렉션 뒤에 /tmp/ 가 나올 뿐이면 미판정 (실제 오탐 사례)")
+    void r3_tempPathOnlyAfterRedirect_noAlert() {
+        // 실제로 Slack 까지 갔던 오탐. 실행된 스크립트는 홈 디렉터리에 있고
+        // /tmp/ 는 출력 리다이렉션 대상일 뿐인데 cmdline 전체 문자열 검사에 걸렸다.
+        Event current = script("zsh",
+                "/bin/zsh -c source /Users/me/.claude/shell-snapshots/snap.sh && pwd -P >| /tmp/claude-cwd", 3000);
+
+        assertThat(Rules.evaluate(List.of(), current)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("R3 양성: 인터프리터가 임시 경로 스크립트를 인자로 실행하면 잡는다")
+    void r3_interpreterRunsTempScript_alerts() {
+        Event current = script("zsh", "/bin/zsh /tmp/evil.sh", 3000);
+
+        Optional<Alert> alert = Rules.evaluate(List.of(), current);
+
+        assertThat(alert).isPresent();
+        assertThat(alert.get().ruleId()).isEqualTo("SCRIPT_FROM_TEMP_PATH");
+    }
+
+    @Test
     @DisplayName("R4: 자동실행(시작프로그램) 경로에 파일 생성 → FILE_IN_AUTORUN_PATH(T1547, MEDIUM, notify)")
     void r4_fileInAutorunPath_alerts() {
         Event current = file("evil.lnk",
@@ -168,7 +217,8 @@ class RulesTest {
                 process("winword.exe", "explorer.exe", 900),
                 network("203.0.113.9", 443, 1000)
         );
-        Event current = process("powershell.exe", "winword.exe", 2000);
+        Event current = new Event(HOST, Event.TYPE_PROCESS, 2000, "powershell.exe", "winword.exe",
+                "C:\\Users\\me\\Downloads\\payload.ps1", null, 0, TENANT);
 
         Optional<Alert> alert = Rules.evaluate(buffer, current);
 


### PR DESCRIPTION
## 실기기를 붙이자마자 드러난 오탐

맥북에 osquery 를 연결한 직후 Slack 으로 이 알림이 왔다.

```
[MEDIUM] host=gimdonghyeon-ui-MacBookPro.local rule=SCRIPT_FROM_TEMP_PATH mitre=T1059
matched: /bin/zsh -c source ~/.claude/shell-snapshots/snap.sh && pwd -P >| /tmp/claude-cwd
```

실행된 스크립트는 홈 디렉터리에 있고, `/tmp/` 는 **출력 리다이렉션 대상**일 뿐이다. R3 가 cmdline 문자열 전체를 훑기 때문에 걸렸다.

## R2 는 더 심각하다

```java
// 변경 전
if (!isProcess(current) || isBaseline(process)) return empty;
prior 에 destPort ∈ {80,443,8080} network 이벤트가 있으면 → CRITICAL
```

실행 대상에 **아무 조건이 없다.** 웹 접속 한 번 뒤에 앱을 하나만 켜도 CRITICAL 이다. `BASELINE_SAFE` 는 `onedrive.exe`, `teams.exe` 등 **윈도우 프로세스 5개**뿐이라 macOS 에서는 아무것도 안 걸러진다.

지금 조용한 건 룰이 정교해서가 아니라 **network 이벤트 자체가 없어서**다(#99 에서 Zeek 를 붙이면 바로 폭주한다).

## 변경

`pathArgumentHasMarker()` 추가. 셸 연산자(`>`, `>|`, `|`, `&&`, `;` 등)가 나오면 거기서 끊고, 앞쪽 인자 중 **경로처럼 생긴 토큰만** 검사한다.

| 룰 | 변경 |
|---|---|
| R2 `DOWNLOAD_AND_EXECUTE` | 실행 경로가 임시·다운로드 경로일 것을 조건에 추가. "받아온 것을 실행"이 T1105+T1204 의 핵심이다 |
| R3 `SCRIPT_FROM_TEMP_PATH` | 같은 판정으로 교체. 리다이렉션·후속 명령의 경로는 제외 |
| R4 `FILE_IN_AUTORUN_PATH` | 그대로. 파일 생성 경로 자체가 판정 대상이라 이 문제가 없다 |

데모 시나리오도 실제 의미에 맞췄다: `C:\Users\Public\update32.exe` → `C:\Users\victim\Downloads\update32.exe`.

## 효과

- 정상 사용(웹 서핑 + 앱 실행)에서 CRITICAL 이 안 뜬다
- 데모 시나리오(`curl` 로 받아 `/tmp` 에서 실행)는 그대로 CRITICAL
- MEDIUM 오탐의 원인(개발 도구 명령줄)이 사라져 severity 필터 없이도 조용해진다

## 테스트

TDD 로 진행했다. 신규 4건이 수정 전 정확히 실패하는 것을 확인했다.

- R2 음성: 웹 접속 후 `/Applications/Slack.app/...` 실행 → 미판정
- R2 양성: `/Users/me/Downloads/setup --silent` → CRITICAL
- R3 음성: 리다이렉션 뒤 `/tmp/` → 미판정 (실제 오탐 사례 그대로)
- R3 양성: `/bin/zsh /tmp/evil.sh` → MEDIUM

`./gradlew :detector-service:test` 통과 (RulesTest 15, 전체 39).

## 남은 한계

토큰 분리가 공백 기준이라 따옴표로 감싼 복잡한 셸 명령은 완벽히 파싱하지 못한다. 실행 파일의 실제 경로를 osquery `processes` 테이블에서 받아 판정하는 게 정공법이지만, 그건 수집 스키마 변경이라 이 PR 범위 밖이다.