### PR TITLE
release: 룰 오탐 수정 (R2/R3 실행 경로 판정)

### DIFF
--- a/detector-service/src/main/java/com/edrdog/detectorservice/api/Scenarios.java
+++ b/detector-service/src/main/java/com/edrdog/detectorservice/api/Scenarios.java
@@ -58,7 +58,7 @@ public final class Scenarios {
         return List.of(
                 network(host, baseTs, "185.220.101.5", 443, tenantId),
                 process(host, baseTs + 1000, "update32.exe", "explorer.exe",
-                        "C:\\Users\\Public\\update32.exe", tenantId));
+                        "C:\\Users\\victim\\Downloads\\update32.exe", tenantId));
     }
 
     /** 다운로드 경로의 스크립트 실행 (unsigned/의심 스크립트 → MEDIUM). 단일 이벤트 point 룰. */

--- a/detector-service/src/main/java/com/edrdog/detectorservice/rule/Rules.java
+++ b/detector-service/src/main/java/com/edrdog/detectorservice/rule/Rules.java
@@ -98,6 +98,11 @@ public final class Rules {
         if (!isProcess(current) || isBaseline(lower(current.process()))) {
             return Optional.empty();
         }
+        // 받아온 것을 실행했는지가 핵심이다(T1105+T1204). 실행 경로 조건이 없으면
+        // "웹 접속 한 번 + 아무 프로세스 실행"이 전부 CRITICAL 이 되어 실사용에서 오탐만 남는다.
+        if (!pathArgumentHasMarker(current.cmdline(), SCRIPT_TEMP_MARKERS)) {
+            return Optional.empty();
+        }
         Optional<Event> download = prior.stream()
                 .filter(Rules::isNetwork)
                 .filter(e -> DOWNLOAD_PORTS.contains(e.destPort()))
@@ -119,7 +124,7 @@ public final class Rules {
 
     /** R3 T1059: 임시/다운로드 경로에서 실행된 스크립트 (저심각 point 룰). */
     private static Optional<Alert> scriptFromTempPath(Event current) {
-        if (!isScript(current) || !pathHasMarker(current.cmdline(), SCRIPT_TEMP_MARKERS)) {
+        if (!isScript(current) || !pathArgumentHasMarker(current.cmdline(), SCRIPT_TEMP_MARKERS)) {
             return Optional.empty();
         }
         return Optional.of(new Alert(
@@ -171,6 +176,33 @@ public final class Rules {
     private static boolean pathHasMarker(String path, Set<String> markers) {
         String p = lower(path);
         return p != null && markers.stream().anyMatch(p::contains);
+    }
+
+    /** 셸 연산자 — 여기부터는 실행 대상이 아니라 출력/후속 명령이라 판정에서 제외한다. */
+    private static final Set<String> SHELL_OPERATORS = Set.of(">", ">>", ">|", "<", "|", "||", "&&", ";", "&");
+
+    /**
+     * cmdline 에서 "실행 대상으로 보이는 경로 인자"에만 표식이 있는지 본다.
+     *
+     * <p>cmdline 전체를 문자열로 훑으면 실행과 무관한 위치의 경로까지 걸린다. 실제로
+     * {@code ... && pwd -P >| /tmp/x} 처럼 리다이렉션 대상이 임시 경로라는 이유로 알림이 나갔다.
+     * 그래서 셸 연산자가 나오면 거기서 끊고, 앞쪽 인자 중 경로처럼 생긴 토큰만 검사한다.
+     */
+    private static boolean pathArgumentHasMarker(String cmdline, Set<String> markers) {
+        String c = lower(cmdline);
+        if (c == null) {
+            return false;
+        }
+        for (String token : c.split("\\s+")) {
+            if (SHELL_OPERATORS.contains(token)) {
+                return false;   // 연산자 뒤는 실행 대상이 아니다
+            }
+            boolean looksLikePath = token.contains("/") || token.contains("\\");
+            if (looksLikePath && markers.stream().anyMatch(token::contains)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /** null 안전한 집합 포함 검사 (immutable Set 은 contains(null) 시 NPE). */

--- a/detector-service/src/test/java/com/edrdog/detectorservice/kafkastreams/topology/DetectionTopologyTest.java
+++ b/detector-service/src/test/java/com/edrdog/detectorservice/kafkastreams/topology/DetectionTopologyTest.java
@@ -52,6 +52,11 @@ class DetectionTopologyTest {
         return new Event(host, Event.TYPE_PROCESS, ts, proc, parent, proc, null, 0, "tenant-a");
     }
 
+    /** cmdline 을 직접 주는 process 이벤트. R2 는 실행 경로를 본다. */
+    private Event processFrom(String host, String proc, String cmdline, long ts) {
+        return new Event(host, Event.TYPE_PROCESS, ts, proc, "explorer.exe", cmdline, null, 0, "tenant-a");
+    }
+
     private Event network(String host, int destPort, long ts) {
         return new Event(host, Event.TYPE_NETWORK, ts, null, null, null, "203.0.113.9", destPort, "tenant-a");
     }
@@ -73,7 +78,7 @@ class DetectionTopologyTest {
     @DisplayName("network 다운로드 → 실행 시퀀스 → alerts 에 CRITICAL 발행")
     void downloadExecute_emitsAlert() {
         events.pipeInput("k", network("host-2", 443, 1000));
-        events.pipeInput("k", process("host-2", "evil.exe", "cmd.exe", 2000));
+        events.pipeInput("k", processFrom("host-2", "evil.exe", "C:\\Users\\me\\Downloads\\evil.exe", 2000));
 
         assertThat(alerts.getQueueSize()).isEqualTo(1);
         assertThat(alerts.readValue().severity()).isEqualTo(Alert.SEV_CRITICAL);

--- a/detector-service/src/test/java/com/edrdog/detectorservice/rule/RulesTest.java
+++ b/detector-service/src/test/java/com/edrdog/detectorservice/rule/RulesTest.java
@@ -20,6 +20,11 @@ class RulesTest {
         return new Event(HOST, Event.TYPE_PROCESS, ts, proc, parent, proc + " args", null, 0, TENANT);
     }
 
+    /** cmdline 을 직접 주는 process 이벤트. R2 는 실행 경로(cmdline)를 본다. */
+    private Event processFrom(String proc, String cmdline, long ts) {
+        return new Event(HOST, Event.TYPE_PROCESS, ts, proc, "bash", cmdline, null, 0, TENANT);
+    }
+
     private Event network(String destIp, int destPort, long ts) {
         return new Event(HOST, Event.TYPE_NETWORK, ts, null, null, null, destIp, destPort, TENANT);
     }
@@ -74,7 +79,7 @@ class RulesTest {
     @DisplayName("R2: network 다운로드 후 같은 host 에서 process 실행 → DOWNLOAD_AND_EXECUTE(T1105+T1204, CRITICAL, isolate)")
     void r2_downloadThenExecute_alerts() {
         List<Event> buffer = List.of(network("203.0.113.9", 443, 1000));
-        Event current = process("evil.exe", "cmd.exe", 2000);
+        Event current = processFrom("evil.exe", "/tmp/evil.exe --run", 2000);
 
         Optional<Alert> alert = Rules.evaluate(buffer, current);
 
@@ -86,6 +91,28 @@ class RulesTest {
         assertThat(a.action()).isEqualTo(Alert.ACTION_ISOLATE);
         assertThat(a.ts()).isEqualTo(2000);
         assertThat(a.matched()).hasSize(2);
+    }
+
+    @Test
+    @DisplayName("R2 음성: 받아온 뒤라도 임시·다운로드 경로가 아닌 실행은 미판정 (평범한 앱 실행)")
+    void r2_executeFromNormalPath_noAlert() {
+        // 웹 접속 후 정상 앱을 실행하는 건 일상이다. 여기까지 CRITICAL 로 올리면 실사용에서 오탐만 남는다.
+        List<Event> buffer = List.of(network("203.0.113.9", 443, 1000));
+        Event current = processFrom("Slack", "/Applications/Slack.app/Contents/MacOS/Slack", 2000);
+
+        assertThat(Rules.evaluate(buffer, current)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("R2 양성: 다운로드 폴더에서 실행해도 잡는다")
+    void r2_executeFromDownloads_alerts() {
+        List<Event> buffer = List.of(network("203.0.113.9", 80, 1000));
+        Event current = processFrom("setup", "/Users/me/Downloads/setup --silent", 2000);
+
+        Optional<Alert> alert = Rules.evaluate(buffer, current);
+
+        assertThat(alert).isPresent();
+        assertThat(alert.get().ruleId()).isEqualTo("DOWNLOAD_AND_EXECUTE");
     }
 
     @Test
@@ -135,6 +162,28 @@ class RulesTest {
     }
 
     @Test
+    @DisplayName("R3 음성: 리다이렉션 뒤에 /tmp/ 가 나올 뿐이면 미판정 (실제 오탐 사례)")
+    void r3_tempPathOnlyAfterRedirect_noAlert() {
+        // 실제로 Slack 까지 갔던 오탐. 실행된 스크립트는 홈 디렉터리에 있고
+        // /tmp/ 는 출력 리다이렉션 대상일 뿐인데 cmdline 전체 문자열 검사에 걸렸다.
+        Event current = script("zsh",
+                "/bin/zsh -c source /Users/me/.claude/shell-snapshots/snap.sh && pwd -P >| /tmp/claude-cwd", 3000);
+
+        assertThat(Rules.evaluate(List.of(), current)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("R3 양성: 인터프리터가 임시 경로 스크립트를 인자로 실행하면 잡는다")
+    void r3_interpreterRunsTempScript_alerts() {
+        Event current = script("zsh", "/bin/zsh /tmp/evil.sh", 3000);
+
+        Optional<Alert> alert = Rules.evaluate(List.of(), current);
+
+        assertThat(alert).isPresent();
+        assertThat(alert.get().ruleId()).isEqualTo("SCRIPT_FROM_TEMP_PATH");
+    }
+
+    @Test
     @DisplayName("R4: 자동실행(시작프로그램) 경로에 파일 생성 → FILE_IN_AUTORUN_PATH(T1547, MEDIUM, notify)")
     void r4_fileInAutorunPath_alerts() {
         Event current = file("evil.lnk",
@@ -168,7 +217,8 @@ class RulesTest {
                 process("winword.exe", "explorer.exe", 900),
                 network("203.0.113.9", 443, 1000)
         );
-        Event current = process("powershell.exe", "winword.exe", 2000);
+        Event current = new Event(HOST, Event.TYPE_PROCESS, 2000, "powershell.exe", "winword.exe",
+                "C:\\Users\\me\\Downloads\\payload.ps1", null, 0, TENANT);
 
         Optional<Alert> alert = Rules.evaluate(buffer, current);
 


### PR DESCRIPTION
#100 하나. cmdline 문자열 전체를 훑던 판정을 '실행 대상 인자'로 좁혀 R2 CRITICAL 폭주와 R3 MEDIUM 오탐을 없앤다. Zeek 수집(#99)을 켜기 전에 먼저 배포해야 한다.