### PR TITLE
fix: R2 가 인자만 임시 경로인 정상 프로세스까지 CRITICAL 로 올리던 문제

### DIFF
--- a/detector-service/src/main/java/com/edrdog/detectorservice/rule/Rules.java
+++ b/detector-service/src/main/java/com/edrdog/detectorservice/rule/Rules.java
@@ -98,9 +98,11 @@ public final class Rules {
         if (!isProcess(current) || isBaseline(lower(current.process()))) {
             return Optional.empty();
         }
-        // 받아온 것을 실행했는지가 핵심이다(T1105+T1204). 실행 경로 조건이 없으면
-        // "웹 접속 한 번 + 아무 프로세스 실행"이 전부 CRITICAL 이 되어 실사용에서 오탐만 남는다.
-        if (!pathArgumentHasMarker(current.cmdline(), SCRIPT_TEMP_MARKERS)) {
+        // 받아온 것을 "실행"했는지가 핵심이다(T1105+T1204). 조건이 없으면 웹 접속 한 번 뒤의
+        // 모든 프로세스 실행이 CRITICAL 이 된다. 인자까지 보면 정상 프로세스가 임시 경로를
+        // 인자로 받는 경우(find /private/tmp/..., mount_apfs ... /private/tmp/PKInstallSandbox/...)
+        // 까지 걸리므로, 실행된 파일 자체(argv[0])만 본다.
+        if (!executableHasMarker(current.cmdline(), SCRIPT_TEMP_MARKERS)) {
             return Optional.empty();
         }
         Optional<Event> download = prior.stream()
@@ -180,6 +182,23 @@ public final class Rules {
 
     /** 셸 연산자 — 여기부터는 실행 대상이 아니라 출력/후속 명령이라 판정에서 제외한다. */
     private static final Set<String> SHELL_OPERATORS = Set.of(">", ">>", ">|", "<", "|", "||", "&&", ";", "&");
+
+    /**
+     * 실행된 파일 자체(argv[0])의 경로에 표식이 있는지 본다.
+     *
+     * <p>인자까지 보면 정상 프로세스가 임시 경로를 인자로 받는 것만으로 걸린다. 실제로
+     * {@code find /private/tmp/...} 와 {@code mount_apfs ... /private/tmp/PKInstallSandbox/...} 가
+     * CRITICAL 로 올라갔다. macOS 는 설치·업데이트 과정에서 /private/tmp 를 상시 쓴다.
+     * "받아온 파일을 실행"이 R2 의 의미이므로 실행 파일 경로만 판단 근거로 쓴다.
+     */
+    private static boolean executableHasMarker(String cmdline, Set<String> markers) {
+        String c = lower(cmdline);
+        if (c == null || c.isBlank()) {
+            return false;
+        }
+        String argv0 = c.trim().split("\\s+")[0];
+        return markers.stream().anyMatch(argv0::contains);
+    }
 
     /**
      * cmdline 에서 "실행 대상으로 보이는 경로 인자"에만 표식이 있는지 본다.

--- a/detector-service/src/test/java/com/edrdog/detectorservice/rule/RulesTest.java
+++ b/detector-service/src/test/java/com/edrdog/detectorservice/rule/RulesTest.java
@@ -116,6 +116,19 @@ class RulesTest {
     }
 
     @Test
+    @DisplayName("R2 음성: 인자만 임시 경로인 정상 프로세스는 미판정 (실제 오탐 사례)")
+    void r2_tempPathOnlyInArgument_noAlert() {
+        // 실제로 Slack 까지 갔던 오탐 2건. 실행된 파일은 /usr/bin/find, /sbin/mount_apfs 이고
+        // 임시 경로는 인자일 뿐이다. macOS 는 설치·업데이트 과정에서 /private/tmp 를 상시 사용한다.
+        List<Event> buffer = List.of(network("203.0.113.9", 443, 1000));
+
+        assertThat(Rules.evaluate(buffer,
+                processFrom("find", "find /private/tmp/scratch -name *.py", 2000))).isEmpty();
+        assertThat(Rules.evaluate(buffer,
+                processFrom("mount_apfs", "/sbin/mount_apfs -o nobrowse /dev/disk1 /private/tmp/PKInstallSandbox/Root", 2100))).isEmpty();
+    }
+
+    @Test
     @DisplayName("R2 음성: network 이벤트의 포트가 다운로드 포트가 아니면 미판정")
     void r2_nonDownloadPort_noAlert() {
         List<Event> buffer = List.of(network("203.0.113.9", 22, 1000));


### PR DESCRIPTION
## Zeek 를 켜자마자 드러났다

network 이벤트가 들어오기 시작하니 R2 의 네트워크 조건이 상시 만족된다. 그래서 프로세스 쪽 조건이 조금만 헐거워도 바로 터진다. 실제로 Slack 까지 간 2건이다.

```
network 160.79.104.10:443  +  process find (parent bash)
network 172.217.118.4:443  +  process mount_apfs (parent com.apple.MobileSoftwareUpdate.CleanupPreparePathService)
```

둘 다 macOS 가 정상적으로 쓰는 프로세스다.

## 원인

직전 수정(#100)은 cmdline 의 **인자** 중 임시 경로가 있으면 걸리게 했다. 그런데 정상 프로세스가 임시 경로를 **인자로** 받는 경우가 흔하다.

```
find /private/tmp/scratch -name *.py
/sbin/mount_apfs -o nobrowse /dev/disk1 /private/tmp/PKInstallSandbox/Root
```

실행된 파일 자체는 `/usr/bin/find`, `/sbin/mount_apfs` 다. macOS 는 설치·업데이트 과정에서 `/private/tmp` 를 상시 쓴다.

## 변경

R2 의 의미는 "받아온 파일을 **실행**"이므로 실행된 파일 자체(argv[0])만 본다.

| 룰 | 판단 근거 | 예 |
|---|---|---|
| R2 | argv[0] (실행 파일) | `/tmp/evil.sh --run` → 잡음, `find /private/tmp/x` → 안 잡음 |
| R3 | 인자 (스크립트 경로) | `zsh /tmp/evil.sh` → 잡음, `... >| /tmp/out` → 안 잡음 |

R3 는 인터프리터가 인자로 받은 스크립트를 봐야 하므로 기존 판정을 유지한다. 두 룰이 서로 다른 위치를 보게 되어 `/tmp/evil.sh` 직접 실행은 R2, `zsh /tmp/evil.sh` 는 R3 가 담당한다.

## 테스트

실제 오탐 2건을 그대로 재현하는 케이스를 추가하고 수정 전 실패를 확인했다.

```java
processFrom("find", "find /private/tmp/scratch -name *.py", 2000)                     → 미판정
processFrom("mount_apfs", "/sbin/mount_apfs ... /private/tmp/PKInstallSandbox/Root")  → 미판정
```

기존 R2 양성 케이스(`/tmp/evil.exe --run`, `/Users/me/Downloads/setup --silent`)는 argv[0] 에 표식이 있어 그대로 통과한다. RulesTest 16건, detector 전체 39건 통과.

## 배경

이 오탐은 #100 배포 후에도 남아 있던 것이고, Zeek(#99)를 켜기 전까지는 network 이벤트가 없어 드러나지 않았다. 실기기에 붙여 보지 않았으면 발표 중에 터졌을 문제다.