### PR TITLE
release: Windows kill 지원 + 엔드포인트 설치 스크립트

### DIFF
--- a/collector-service/scripts/edrdog-install-macos.sh
+++ b/collector-service/scripts/edrdog-install-macos.sh
@@ -1,0 +1,185 @@
+#!/usr/bin/env bash
+#
+# EDRdog 엔드포인트 설치 (macOS). 온보딩 화면이 이 스크립트를 한 줄로 실행시킨다.
+#
+#   curl -fsSL <이 파일 raw URL> | sudo bash -s -- \
+#     --tls-host <수집서버:포트> --enroll-secret <값> [--with-zeek]
+#
+# 하는 일:
+#   1. osquery 설치(없을 때만)
+#   2. 서버 인증서를 수집 포트에서 직접 받아 저장  ← 관리자에게 따로 받을 필요가 없다
+#   3. enroll secret / 플래그 파일 배치
+#   4. launchd 데몬으로 osquery 기동
+#   5. --with-zeek 면 Zeek + 전송기까지 데몬으로 등록 (네트워크 이벤트, 위협 지도용)
+#
+# 못 하는 일:
+#   전체 디스크 접근(FDA) 승인. macOS TCC 라 사람이 시스템 설정에서 직접 켜야 한다.
+#   스크립트가 끝나면서 경로를 출력하니 그것만 하면 된다.
+#
+# 여러 번 실행해도 안전하다(같은 값으로 덮어쓴다).
+set -euo pipefail
+
+TLS_HOST=""
+ENROLL_SECRET=""
+WITH_ZEEK=0
+SHIPPER_URL="https://raw.githubusercontent.com/2026-Siheung-Bootcamp-Team-I/Backend/main/collector-service/zeek/edrdog-zeek-shipper.py"
+
+OSQUERY_BIN="/opt/osquery/lib/osquery.app/Contents/MacOS/osqueryd"
+FLAGS_PATH="/var/osquery/osquery.flags"        # launchd 잡이 읽는 고정 경로
+CONF_DIR="/etc/osquery"
+ZEEK_LOG_DIR="/var/log/edrdog-zeek"
+SHIPPER_PATH="/usr/local/bin/edrdog-zeek-shipper.py"
+
+log()  { printf '\033[1m[edrdog]\033[0m %s\n' "$*"; }
+fail() { printf '\033[1;31m[edrdog] %s\033[0m\n' "$*" >&2; exit 1; }
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --tls-host)      TLS_HOST="${2:-}"; shift 2 ;;
+    --enroll-secret) ENROLL_SECRET="${2:-}"; shift 2 ;;
+    --with-zeek)     WITH_ZEEK=1; shift ;;
+    *) fail "알 수 없는 옵션: $1" ;;
+  esac
+done
+
+[ "$(id -u)" -eq 0 ] || fail "sudo 로 실행해야 한다 (파일 배치와 데몬 등록에 필요)"
+[ -n "$TLS_HOST" ]      || fail "--tls-host 가 필요하다 (예: edrdog.example.com:30443)"
+[ -n "$ENROLL_SECRET" ] || fail "--enroll-secret 이 필요하다 (온보딩 1번에서 발급)"
+
+# brew 는 root 로 못 돌린다. sudo 로 실행됐으니 원래 사용자로 되돌려 호출한다.
+REAL_USER="${SUDO_USER:-$(stat -f '%Su' /dev/console)}"
+run_as_user() { sudo -u "$REAL_USER" -H "$@"; }
+
+# --- 1. osquery ---
+if [ -x "$OSQUERY_BIN" ]; then
+  log "osquery 이미 설치됨"
+else
+  command -v brew >/dev/null || fail "Homebrew 가 필요하다. https://brew.sh 참고"
+  log "osquery 설치 중 (몇 분 걸릴 수 있다)"
+  run_as_user brew install --cask osquery
+  [ -x "$OSQUERY_BIN" ] || fail "osquery 설치 후에도 $OSQUERY_BIN 이 없다"
+fi
+
+# --- 2. 서버 인증서 ---
+# osquery 는 이 인증서를 핀해서 검증한다. 수집 포트에서 직접 받아오므로 따로 전달받을 필요가 없다.
+log "서버 인증서 받는 중 ($TLS_HOST)"
+mkdir -p "$CONF_DIR"
+if ! echo | openssl s_client -connect "$TLS_HOST" -servername "${TLS_HOST%%:*}" 2>/dev/null \
+     | sed -n '/BEGIN CERTIFICATE/,/END CERTIFICATE/p' > "$CONF_DIR/osquery-server.pem"; then
+  fail "수집 서버에 붙지 못했다: $TLS_HOST (주소·방화벽 확인)"
+fi
+[ -s "$CONF_DIR/osquery-server.pem" ] || fail "인증서를 받지 못했다: $TLS_HOST"
+chmod 644 "$CONF_DIR/osquery-server.pem"
+
+# --- 3. enroll secret + 플래그 ---
+printf '%s' "$ENROLL_SECRET" > "$CONF_DIR/enroll.secret"
+chmod 600 "$CONF_DIR/enroll.secret"
+
+mkdir -p "$(dirname "$FLAGS_PATH")"
+# gflags 는 줄 끝 주석을 잘라내지 않는다. 주석은 줄 전체로만 쓴다.
+cat > "$FLAGS_PATH" <<FLAGS
+# EDRdog osquery 플래그 (설치 스크립트가 생성). 수집 쿼리는 서버가 config 로 내려준다.
+--enroll_secret_path=$CONF_DIR/enroll.secret
+--tls_hostname=$TLS_HOST
+--tls_server_certs=$CONF_DIR/osquery-server.pem
+
+--config_plugin=tls
+--config_tls_endpoint=/api/osquery/config
+--config_refresh=60
+--enroll_tls_endpoint=/api/osquery/enroll
+
+--logger_plugin=tls
+--logger_tls_endpoint=/api/osquery/log
+--logger_tls_period=10
+--disable_carver=true
+
+# 퍼블리셔마다 켜는 플래그가 다르다. 빠지면 osquery 가 에러 없이 빈 결과를 준다.
+--disable_events=false
+# 프로세스 생성 (EndpointSecurity). FDA 가 있어야 실제로 채워진다.
+--disable_endpointsecurity=false
+# 파일 변경 (FSEvents)
+--enable_file_events=true
+# 아웃바운드 연결 (OpenBSM). 신형 macOS 에서는 비어 있을 수 있어 네트워크는 Zeek 가 담당한다.
+--disable_audit=false
+--audit_allow_config=true
+--audit_allow_sockets=true
+
+--host_identifier=hostname
+--disable_watchdog=true
+FLAGS
+chmod 644 "$FLAGS_PATH"
+log "설정 배치 완료 ($FLAGS_PATH)"
+
+# --- 4. 기동 ---
+osqueryctl stop >/dev/null 2>&1 || true
+osqueryctl start >/dev/null 2>&1 || fail "osquery 기동 실패. 'sudo osqueryctl status' 로 확인"
+log "osquery 기동됨 (host=$(hostname))"
+
+# --- 5. Zeek (선택) ---
+if [ "$WITH_ZEEK" -eq 1 ]; then
+  ZEEK_BIN="$(command -v zeek || echo /opt/homebrew/bin/zeek)"
+  if [ ! -x "$ZEEK_BIN" ]; then
+    log "Zeek 설치 중"
+    run_as_user brew install zeek
+    ZEEK_BIN="$(command -v zeek || echo /opt/homebrew/bin/zeek)"
+  fi
+  [ -x "$ZEEK_BIN" ] || fail "zeek 를 찾지 못했다"
+
+  IFACE="$(route get default 2>/dev/null | awk '/interface:/{print $2}')"
+  [ -n "$IFACE" ] || fail "기본 네트워크 인터페이스를 찾지 못했다"
+
+  curl -fsSL "$SHIPPER_URL" -o "$SHIPPER_PATH" || fail "전송기 내려받기 실패"
+  chmod 755 "$SHIPPER_PATH"
+  mkdir -p "$ZEEK_LOG_DIR"
+
+  # -C 는 필수. 맥 네트워크 카드가 체크섬을 나중에 채워서, 없으면 Zeek 가 패킷을 전부 버린다.
+  cat > /Library/LaunchDaemons/com.edrdog.zeek.plist <<PLIST
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0"><dict>
+  <key>Label</key><string>com.edrdog.zeek</string>
+  <key>ProgramArguments</key><array>
+    <string>$ZEEK_BIN</string><string>-C</string><string>-i</string><string>$IFACE</string>
+    <string>LogAscii::use_json=T</string><string>local</string>
+  </array>
+  <key>WorkingDirectory</key><string>$ZEEK_LOG_DIR</string>
+  <key>RunAtLoad</key><true/><key>KeepAlive</key><true/>
+</dict></plist>
+PLIST
+
+  cat > /Library/LaunchDaemons/com.edrdog.zeek-shipper.plist <<PLIST
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0"><dict>
+  <key>Label</key><string>com.edrdog.zeek-shipper</string>
+  <key>ProgramArguments</key><array>
+    <string>/usr/bin/python3</string><string>$SHIPPER_PATH</string>
+    <string>--conn-log</string><string>$ZEEK_LOG_DIR/conn.log</string>
+    <string>--tls-host</string><string>$TLS_HOST</string>
+  </array>
+  <key>RunAtLoad</key><true/><key>KeepAlive</key><true/>
+</dict></plist>
+PLIST
+
+  for job in com.edrdog.zeek com.edrdog.zeek-shipper; do
+    launchctl unload "/Library/LaunchDaemons/$job.plist" >/dev/null 2>&1 || true
+    launchctl load -w "/Library/LaunchDaemons/$job.plist" || fail "$job 등록 실패"
+  done
+  log "Zeek + 전송기 데몬 등록됨 (인터페이스 $IFACE, 로그 $ZEEK_LOG_DIR)"
+fi
+
+cat <<DONE
+
+설치가 끝났습니다. 마지막 한 단계는 직접 해야 합니다.
+
+  전체 디스크 접근(FDA) 승인
+  시스템 설정 → 개인정보 보호 및 보안 → 전체 디스크 접근 → "+" → Cmd+Shift+G 로 아래 경로 추가
+
+    $OSQUERY_BIN
+
+  이 권한은 macOS 가 사람 승인만 받도록 막아둔 것이라 자동화할 수 없습니다.
+  승인한 뒤 재부팅하면 프로세스 이벤트가 수집되기 시작합니다.
+
+상태 확인:  sudo osqueryctl status
+제거:       sudo osqueryctl stop && sudo rm -rf $CONF_DIR $FLAGS_PATH
+DONE

--- a/collector-service/scripts/edrdog-install-windows.ps1
+++ b/collector-service/scripts/edrdog-install-windows.ps1
@@ -1,0 +1,143 @@
+<#
+.SYNOPSIS
+  EDRdog 엔드포인트 설치 (Windows). 온보딩 화면이 이 스크립트를 2줄로 실행시킨다.
+
+.DESCRIPTION
+  하는 일:
+    1. osquery 설치(없을 때만, winget)
+    2. 서버 인증서를 수집 포트에서 직접 받아 저장  ← 관리자에게 따로 받을 필요가 없다
+    3. enroll secret / 플래그 파일 배치
+    4. osqueryd 를 Windows 서비스로 등록하고 시작
+
+  macOS 와 달리 FDA 같은 사람 승인 단계가 없다. 관리자 권한 PowerShell 이면 끝까지 자동이다.
+
+  ⚠ 이 스크립트는 아직 실제 Windows 기기에서 검증되지 않았다. 실패하면 온보딩 화면의
+  "수동으로 설치하기" 절차를 쓰면 된다.
+
+.PARAMETER TlsHost
+  수집 서버 주소 host:port (예: edrdog.example.com:30443)
+
+.PARAMETER EnrollSecret
+  온보딩 1번에서 발급한 값
+
+.EXAMPLE
+  irm <이 파일 raw URL> -OutFile edrdog-install.ps1
+  .\edrdog-install.ps1 -TlsHost edrdog.example.com:30443 -EnrollSecret abc123
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)][string]$TlsHost,
+    [Parameter(Mandatory = $true)][string]$EnrollSecret
+)
+
+$ErrorActionPreference = 'Stop'
+
+$ConfDir     = 'C:\ProgramData\osquery'
+$FlagsPath   = Join-Path $ConfDir 'osquery.flags'
+$CertPath    = Join-Path $ConfDir 'osquery-server.pem'
+$SecretPath  = Join-Path $ConfDir 'enroll.secret'
+$OsqueryExe  = 'C:\Program Files\osquery\osqueryd\osqueryd.exe'
+
+function Log  { param($m) Write-Host "[edrdog] $m" -ForegroundColor Cyan }
+function Fail { param($m) Write-Host "[edrdog] $m" -ForegroundColor Red; exit 1 }
+
+# 관리자 권한 확인. 서비스 등록과 ProgramData 쓰기에 필요하다.
+$isAdmin = ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()
+           ).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+if (-not $isAdmin) { Fail '관리자 권한 PowerShell 에서 실행해야 한다' }
+
+# --- 1. osquery ---
+if (Test-Path $OsqueryExe) {
+    Log 'osquery 이미 설치됨'
+} else {
+    if (-not (Get-Command winget -ErrorAction SilentlyContinue)) {
+        Fail 'winget 이 없다. https://osquery.io/downloads 에서 직접 설치할 것'
+    }
+    Log 'osquery 설치 중 (몇 분 걸릴 수 있다)'
+    winget install --id osquery.osquery -e --accept-source-agreements --accept-package-agreements | Out-Null
+    if (-not (Test-Path $OsqueryExe)) { Fail "설치 후에도 $OsqueryExe 가 없다" }
+}
+
+New-Item -ItemType Directory -Force -Path $ConfDir | Out-Null
+
+# --- 2. 서버 인증서 ---
+# osquery 는 이 인증서를 핀해서 검증한다. 수집 포트에서 직접 받아오므로 따로 전달받을 필요가 없다.
+Log "서버 인증서 받는 중 ($TlsHost)"
+$hostName, $port = $TlsHost.Split(':')
+if (-not $port) { $port = 443 }
+try {
+    $tcp = [System.Net.Sockets.TcpClient]::new($hostName, [int]$port)
+    # 인증서를 '받아오는' 단계라 검증하지 않는다. 이후 osquery 가 이 파일로 핀 검증을 한다.
+    # 콜백은 델리게이트 타입으로 명시 캐스팅한다(스크립트블록 암묵 변환은 PowerShell 버전에 따라 실패한다).
+    $noValidation = [System.Net.Security.RemoteCertificateValidationCallback] { param($s, $c, $ch, $e) $true }
+    $ssl = [System.Net.Security.SslStream]::new($tcp.GetStream(), $false, $noValidation)
+    $ssl.AuthenticateAsClient($hostName)
+    $raw = $ssl.RemoteCertificate.Export([System.Security.Cryptography.X509Certificates.X509ContentType]::Cert)
+    $b64 = [Convert]::ToBase64String($raw, [Base64FormattingOptions]::InsertLineBreaks)
+    "-----BEGIN CERTIFICATE-----`n$b64`n-----END CERTIFICATE-----" |
+        Set-Content -Path $CertPath -Encoding ascii
+} catch {
+    Fail "수집 서버에 붙지 못했다: $TlsHost (주소·방화벽 확인) — $_"
+} finally {
+    if ($ssl) { $ssl.Dispose() }
+    if ($tcp) { $tcp.Dispose() }
+}
+
+# --- 3. enroll secret + 플래그 ---
+# 개행이 붙으면 secret 이 달라진다. NoNewline 필수.
+[System.IO.File]::WriteAllText($SecretPath, $EnrollSecret)
+
+# gflags 는 줄 끝 주석을 잘라내지 않는다. 주석은 줄 전체로만 쓴다.
+@"
+# EDRdog osquery 플래그 (설치 스크립트가 생성). 수집 쿼리는 서버가 config 로 내려준다.
+--enroll_secret_path=$SecretPath
+--tls_hostname=$TlsHost
+--tls_server_certs=$CertPath
+
+--config_plugin=tls
+--config_tls_endpoint=/api/osquery/config
+--config_refresh=60
+--enroll_tls_endpoint=/api/osquery/enroll
+
+--logger_plugin=tls
+--logger_tls_endpoint=/api/osquery/log
+--logger_tls_period=10
+--disable_carver=true
+
+# 퍼블리셔마다 켜는 플래그가 다르다. 빠지면 osquery 가 에러 없이 빈 결과를 준다.
+--disable_events=false
+# 프로세스 생성 (ETW). 이 플래그가 없으면 Windows 수집은 전부 0건이다.
+--enable_process_etw_events=true
+# 파일 변경 (NTFS USN 저널)
+--enable_ntfs_event_publisher=true
+
+--host_identifier=hostname
+--disable_watchdog=true
+"@ | Set-Content -Path $FlagsPath -Encoding ascii
+
+Log "설정 배치 완료 ($FlagsPath)"
+
+# --- 4. 서비스 등록 ---
+# 이미 있으면 지우고 다시 만든다(플래그 경로가 바뀌었을 수 있다).
+if (Get-Service osqueryd -ErrorAction SilentlyContinue) {
+    Stop-Service osqueryd -Force -ErrorAction SilentlyContinue
+    sc.exe delete osqueryd | Out-Null
+    Start-Sleep -Seconds 2
+}
+sc.exe create osqueryd binPath= "`"$OsqueryExe`" --flagfile=`"$FlagsPath`"" start= auto DisplayName= "osquery daemon (EDRdog)" | Out-Null
+Start-Service osqueryd
+Start-Sleep -Seconds 3
+
+$svc = Get-Service osqueryd
+if ($svc.Status -ne 'Running') { Fail "서비스가 시작되지 않았다 (상태: $($svc.Status))" }
+
+Write-Host ''
+Log "설치 완료. osqueryd 서비스 실행 중 (host=$env:COMPUTERNAME)"
+Write-Host @"
+
+수집이 시작되면 온보딩 4번 기기 상태에 이 기기가 나타납니다.
+프로세스 감시가 ETW 라 별도 권한 승인은 필요 없습니다.
+
+상태 확인:  Get-Service osqueryd
+제거:       Stop-Service osqueryd; sc.exe delete osqueryd; Remove-Item -Recurse $ConfDir
+"@

--- a/responder-service/src/main/java/com/edrdog/responderservice/fleet/FleetClient.java
+++ b/responder-service/src/main/java/com/edrdog/responderservice/fleet/FleetClient.java
@@ -81,8 +81,11 @@ public class FleetClient {
                 : new FileSystemResource(location).getInputStream();
     }
 
-    /** 호스트 식별자(hostname/uuid)를 Fleet 내부 host id 로 변환. */
-    public int resolveHostId(String identifier) {
+    /**
+     * 호스트 식별자(hostname/uuid)로 Fleet 내부 id 와 플랫폼을 조회한다.
+     * 플랫폼이 필요한 이유는 Fleet 이 Windows 에 PowerShell, 그 외에 sh 를 실행하기 때문이다.
+     */
+    public FleetHost resolveHost(String identifier) {
         HostIdentifierResponse res = http.get()
                 .uri("/api/v1/fleet/hosts/identifier/{id}", identifier)
                 .retrieve()
@@ -90,7 +93,7 @@ public class FleetClient {
         if (res == null || res.host() == null) {
             throw new IllegalStateException("Fleet 에서 호스트를 찾지 못함: " + identifier);
         }
-        return res.host().id();
+        return new FleetHost(res.host().id(), res.host().platform());
     }
 
     /** 스크립트를 호스트에서 동기 실행하고 결과를 반환. */
@@ -102,9 +105,9 @@ public class FleetClient {
                 .body(FleetScriptResult.class);
     }
 
-    /** GET hosts/identifier 응답의 필요한 부분만. */
+    /** GET hosts/identifier 응답의 필요한 부분만. 나머지 필드는 무시된다. */
     private record HostIdentifierResponse(Host host) {
-        private record Host(int id) {
+        private record Host(int id, String platform) {
         }
     }
 }

--- a/responder-service/src/main/java/com/edrdog/responderservice/fleet/FleetHost.java
+++ b/responder-service/src/main/java/com/edrdog/responderservice/fleet/FleetHost.java
@@ -1,0 +1,11 @@
+package com.edrdog.responderservice.fleet;
+
+/**
+ * Fleet 호스트 조회 결과 중 조치에 필요한 것만.
+ *
+ * @param id       Fleet 내부 host id (스크립트 실행 대상 지정에 쓴다)
+ * @param platform Fleet 이 보고하는 플랫폼(windows / darwin / ubuntu ...).
+ *                 Fleet 은 Windows 에 PowerShell, 그 외에 sh 를 실행하므로 스크립트를 이 값으로 고른다.
+ */
+public record FleetHost(int id, String platform) {
+}

--- a/responder-service/src/main/java/com/edrdog/responderservice/response/KillScript.java
+++ b/responder-service/src/main/java/com/edrdog/responderservice/response/KillScript.java
@@ -35,7 +35,55 @@ public final class KillScript {
         return "'" + s.replace("'", "'\\''") + "'";
     }
 
-    /** target(프로세스명 또는 경로) → 정확 일치 kill 스크립트. */
+    /**
+     * 대상 호스트 플랫폼에 맞는 kill 스크립트.
+     *
+     * <p>Fleet 은 Windows 호스트에 PowerShell(.ps1)을, 그 외에는 sh 를 실행한다.
+     * POSIX 스크립트를 Windows 로 보내면 ps/awk/kill 이 없어 그냥 실패한다.
+     *
+     * @param platform Fleet 이 알려주는 호스트 플랫폼(windows / darwin / ubuntu ...). null 이면 POSIX.
+     */
+    public static String build(String target, String platform) {
+        return isWindows(platform) ? buildWindows(target) : build(target);
+    }
+
+    private static boolean isWindows(String platform) {
+        return platform != null && platform.toLowerCase().contains("windows");
+    }
+
+    /** PowerShell 작은따옴표 이스케이프: ' → '' (PowerShell 규칙은 sh 와 다르다). */
+    private static String psSingleQuote(String s) {
+        return "'" + s.replace("'", "''") + "'";
+    }
+
+    /**
+     * Windows: 프로세스명 정확 일치로 종료.
+     *
+     * <p>{@code Get-Process -Name} 은 확장자 없는 이름을 받으므로 .exe 를 뗀다.
+     * 이름 비교는 PowerShell 이 대소문자를 구분하지 않는데, Windows 파일명 규칙 자체가 그래서 의도한 동작이다.
+     */
+    private static String buildWindows(String target) {
+        String base = basename(target);
+        if (base.toLowerCase().endsWith(".exe")) {
+            base = base.substring(0, base.length() - 4);
+        }
+        String name = psSingleQuote(base);
+        return """
+                # EDRdog responder: 대상 프로세스명과 일치하는 실행 프로세스를 종료 (trigger=response)
+                $name = %s
+                $procs = Get-Process -Name $name -ErrorAction SilentlyContinue
+                if (-not $procs) {
+                  Write-Output "EDRDOG_RESULT=NO_MATCH name=$name"
+                  exit 0
+                }
+                $ids = ($procs | ForEach-Object { $_.Id }) -join ' '
+                Write-Output "EDRDOG_RESULT=MATCH name=$name pids=$ids"
+                $procs | Stop-Process -Force -ErrorAction SilentlyContinue
+                Write-Output "EDRDOG_RESULT=KILLED name=$name pids=$ids"
+                """.formatted(name);
+    }
+
+    /** target(프로세스명 또는 경로) → 정확 일치 kill 스크립트 (POSIX sh). */
     public static String build(String target) {
         String name = shSingleQuote(basename(target));
         return """

--- a/responder-service/src/main/java/com/edrdog/responderservice/response/ResponseExecutor.java
+++ b/responder-service/src/main/java/com/edrdog/responderservice/response/ResponseExecutor.java
@@ -1,6 +1,7 @@
 package com.edrdog.responderservice.response;
 
 import com.edrdog.responderservice.fleet.FleetClient;
+import com.edrdog.responderservice.fleet.FleetHost;
 import com.edrdog.responderservice.fleet.FleetScriptResult;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -44,8 +45,11 @@ public class ResponseExecutor {
             return new ExecuteResult(host, target, "COOLDOWN", null);
         }
         try {
-            int hostId = fleet.resolveHostId(host);
-            FleetScriptResult result = fleet.runScriptSync(hostId, KillScript.build(target));
+            // 플랫폼을 같이 받아온다. Fleet 은 Windows 에 PowerShell, 그 외에 sh 를 실행하므로
+            // POSIX 스크립트를 Windows 로 보내면 ps/awk/kill 이 없어 그냥 실패한다.
+            FleetHost fleetHost = fleet.resolveHost(host);
+            FleetScriptResult result =
+                    fleet.runScriptSync(fleetHost.id(), KillScript.build(target, fleetHost.platform()));
             KillOutcome outcome = KillOutcome.interpret(result);
             log.info("[EXECUTE] trigger=response host={} target={} outcome={} execId={}",
                     host, target, outcome, result.executionId());

--- a/responder-service/src/test/java/com/edrdog/responderservice/response/KillScriptTest.java
+++ b/responder-service/src/test/java/com/edrdog/responderservice/response/KillScriptTest.java
@@ -53,4 +53,44 @@ class KillScriptTest {
         assertThat(script).doesNotContain("comm=");
         assertThat(script).doesNotContain("$2==n");
     }
+
+    // --- Windows (PowerShell) ---
+
+    @Test
+    @DisplayName("Windows 는 PowerShell 스크립트를 만든다 (ps/awk/kill 은 Windows 에 없다)")
+    void windows_buildsPowerShell() {
+        String script = KillScript.build("evil.exe", "windows");
+
+        assertThat(script).contains("Get-Process");
+        assertThat(script).contains("Stop-Process");
+        assertThat(script).doesNotContain("#!/bin/sh");
+        assertThat(script).doesNotContain("ps -Ao");
+        assertThat(script).contains("EDRDOG_RESULT=NO_MATCH");
+        assertThat(script).contains("EDRDOG_RESULT=KILLED");
+    }
+
+    @Test
+    @DisplayName("Windows 는 .exe 를 떼고 프로세스명으로 매칭한다 (Get-Process -Name 규칙)")
+    void windows_stripsExeSuffix() {
+        String script = KillScript.build("C:\\Users\\victim\\Downloads\\evil.exe", "windows");
+
+        assertThat(script).contains("'evil'");
+        assertThat(script).doesNotContain("'evil.exe'");
+    }
+
+    @Test
+    @DisplayName("Windows 도 작은따옴표를 이스케이프해 인젝션을 막는다")
+    void windows_escapesQuotes() {
+        String script = KillScript.build("ev'il.exe", "windows");
+
+        assertThat(script).contains("'ev''il'");
+    }
+
+    @Test
+    @DisplayName("platform 이 windows 가 아니면 기존 POSIX sh 를 그대로 쓴다")
+    void nonWindows_keepsPosix() {
+        assertThat(KillScript.build("curl", "darwin")).startsWith("#!/bin/sh");
+        assertThat(KillScript.build("curl", "ubuntu")).startsWith("#!/bin/sh");
+        assertThat(KillScript.build("curl", null)).startsWith("#!/bin/sh");
+    }
 }

--- a/responder-service/src/test/java/com/edrdog/responderservice/response/ResponseExecutorTest.java
+++ b/responder-service/src/test/java/com/edrdog/responderservice/response/ResponseExecutorTest.java
@@ -1,9 +1,11 @@
 package com.edrdog.responderservice.response;
 
 import com.edrdog.responderservice.fleet.FleetClient;
+import com.edrdog.responderservice.fleet.FleetHost;
 import com.edrdog.responderservice.fleet.FleetScriptResult;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -33,7 +35,7 @@ class ResponseExecutorTest {
     @Test
     @DisplayName("스위치 ON 이면 Fleet 실행 후 결과 상태를 반환")
     void enabled_runsAndReturnsOutcome() {
-        when(fleet.resolveHostId("host-1")).thenReturn(42);
+        when(fleet.resolveHost("host-1")).thenReturn(new FleetHost(42, "darwin"));
         when(fleet.runScriptSync(eq(42), anyString())).thenReturn(killed());
         ResponseExecutor executor = new ResponseExecutor(fleet, true, 60_000);
 
@@ -46,7 +48,7 @@ class ResponseExecutorTest {
     @Test
     @DisplayName("같은 호스트가 쿨다운 안에 다시 오면 COOLDOWN, Fleet 은 한 번만 호출")
     void cooldown_suppressesSecondCall() {
-        when(fleet.resolveHostId(anyString())).thenReturn(42);
+        when(fleet.resolveHost(anyString())).thenReturn(new FleetHost(42, "darwin"));
         when(fleet.runScriptSync(anyInt(), anyString())).thenReturn(killed());
         ResponseExecutor executor = new ResponseExecutor(fleet, true, 60_000);
 
@@ -60,11 +62,40 @@ class ResponseExecutorTest {
     @Test
     @DisplayName("Fleet 호출이 실패하면 FAILED")
     void fleetError_returnsFailed() {
-        when(fleet.resolveHostId(anyString())).thenThrow(new IllegalStateException("호스트 없음"));
+        when(fleet.resolveHost(anyString())).thenThrow(new IllegalStateException("호스트 없음"));
         ResponseExecutor executor = new ResponseExecutor(fleet, true, 60_000);
 
         ExecuteResult result = executor.killProcess("host-1", "powershell.exe");
 
         assertThat(result.status()).isEqualTo("FAILED");
+    }
+
+    @Test
+    @DisplayName("Windows 호스트에는 PowerShell 스크립트를 보낸다 (POSIX sh 는 Windows 에서 실패한다)")
+    void windowsHost_sendsPowerShell() {
+        when(fleet.resolveHost("win-1")).thenReturn(new FleetHost(7, "windows"));
+        when(fleet.runScriptSync(eq(7), anyString())).thenReturn(killed());
+        ResponseExecutor executor = new ResponseExecutor(fleet, true, 60_000);
+
+        executor.killProcess("win-1", "evil.exe");
+
+        ArgumentCaptor<String> script = ArgumentCaptor.forClass(String.class);
+        verify(fleet).runScriptSync(eq(7), script.capture());
+        assertThat(script.getValue()).contains("Stop-Process");
+        assertThat(script.getValue()).doesNotContain("#!/bin/sh");
+    }
+
+    @Test
+    @DisplayName("macOS 호스트에는 POSIX sh 를 보낸다")
+    void macHost_sendsPosix() {
+        when(fleet.resolveHost("mac-1")).thenReturn(new FleetHost(8, "darwin"));
+        when(fleet.runScriptSync(eq(8), anyString())).thenReturn(killed());
+        ResponseExecutor executor = new ResponseExecutor(fleet, true, 60_000);
+
+        executor.killProcess("mac-1", "curl");
+
+        ArgumentCaptor<String> script = ArgumentCaptor.forClass(String.class);
+        verify(fleet).runScriptSync(eq(8), script.capture());
+        assertThat(script.getValue()).startsWith("#!/bin/sh");
     }
 }


### PR DESCRIPTION
#105 하나. Windows kill 조치(PowerShell)를 구현하고, 온보딩 명령을 한 줄로 줄이는 설치 스크립트(macOS/Windows)를 추가한다. 프론트는 Frontend#61 에서 이 스크립트를 가리킨다.