### PR TITLE
release: enroll secret 자동 발급 + CI fail-fast 해제

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -48,6 +48,9 @@ jobs:
       contents: read
       packages: write
     strategy:
+      # 한 모듈이 실패해도 나머지는 계속 빌드한다. Docker Hub 에서 베이스 이미지를 받다가
+      # 네트워크 타임아웃이 나면(실제로 발생했다) fail-fast 가 멀쩡한 모듈까지 취소시킨다.
+      fail-fast: false
       matrix:
         module: [detector-service, responder-service, archiver-service, api-service, alert-service, collector-service]
     steps:

--- a/api-service/src/main/java/com/edrdog/apiservice/tenant/TenantService.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/tenant/TenantService.java
@@ -53,11 +53,22 @@ public class TenantService {
         return secret;
     }
 
-    /** 현재 enroll secret 조회. tenant 없음 404, 미발급이면 빈 Optional. */
-    @Transactional(readOnly = true)
+    /**
+     * 현재 enroll secret 조회. 없으면 그 자리에서 발급한다. tenant 없음 404.
+     *
+     * <p>tenant 당 하나 있으면 되는 값인데 사용자가 버튼을 눌러야 생기는 구조였다. 그러면 온보딩의
+     * 설치 명령이 빈 채로 보이고, 사용자는 왜 눌러야 하는지 알 수 없다. 조회 시점에 만들어 준다.
+     * 이미 있으면 그대로 돌려준다(호출할 때마다 바뀌면 이미 배포한 기기의 안내가 어긋난다).
+     * 값을 갈아치우는 건 명시적인 재발급(rotateEnrollSecret)만 한다.
+     */
+    @Transactional
     public Optional<String> getEnrollSecret(Long tenantId) {
         Tenant tenant = tenants.findById(tenantId)
                 .orElseThrow(() -> AuthException.notFound("tenant 를 찾을 수 없습니다"));
-        return Optional.ofNullable(tenant.getEnrollSecret());
+        if (tenant.getEnrollSecret() == null) {
+            tenant.updateEnrollSecret(OsqueryTokens.newToken());
+            tenants.save(tenant);
+        }
+        return Optional.of(tenant.getEnrollSecret());
     }
 }

--- a/api-service/src/test/java/com/edrdog/apiservice/tenant/TenantServiceTest.java
+++ b/api-service/src/test/java/com/edrdog/apiservice/tenant/TenantServiceTest.java
@@ -89,4 +89,39 @@ class TenantServiceTest {
         AuthException e = assertThrows(AuthException.class, () -> service.getWebhook(99L));
         assertEquals(AuthException.Kind.NOT_FOUND, e.getKind());
     }
+
+    // --- enroll secret ---
+
+    @Test
+    void getEnrollSecret_미발급이면_그자리에서_발급한다() {
+        // 사용자가 버튼을 눌러야 secret 이 생기면 설치 명령이 빈 채로 보인다.
+        // tenant 당 하나 있으면 되는 값이라 조회 시점에 만들어 준다.
+        Tenant tenant = newTenant();
+        when(tenants.findById(1L)).thenReturn(Optional.of(tenant));
+
+        String secret = service.getEnrollSecret(1L).orElseThrow();
+
+        assertFalse(secret.isBlank());
+        assertEquals(secret, tenant.getEnrollSecret());
+        verify(tenants).save(tenant);
+    }
+
+    @Test
+    void getEnrollSecret_이미있으면_그대로_돌려준다() {
+        // 조회할 때마다 값이 바뀌면 이미 배포한 기기의 설치 안내가 어긋난다.
+        Tenant tenant = newTenant();
+        tenant.updateEnrollSecret("fixed-secret");
+        when(tenants.findById(1L)).thenReturn(Optional.of(tenant));
+
+        assertEquals("fixed-secret", service.getEnrollSecret(1L).orElseThrow());
+        assertEquals("fixed-secret", service.getEnrollSecret(1L).orElseThrow());
+    }
+
+    @Test
+    void getEnrollSecret_tenant없으면_404예외() {
+        when(tenants.findById(9L)).thenReturn(Optional.empty());
+
+        AuthException e = assertThrows(AuthException.class, () -> service.getEnrollSecret(9L));
+        assertEquals(AuthException.Kind.NOT_FOUND, e.getKind());
+    }
 }


### PR DESCRIPTION
#107 하나. enroll secret 을 조회 시점에 발급해 온보딩에서 '발급' 단계를 없앤다. Docker Hub 타임아웃으로 배포가 통째로 멈추던 문제도 fail-fast 해제로 막는다.