### PR TITLE
fix: Fleet 호스트 조회가 대소문자 때문에 404 나던 문제 (kill 실패)

### DIFF
--- a/responder-service/src/main/java/com/edrdog/responderservice/fleet/FleetClient.java
+++ b/responder-service/src/main/java/com/edrdog/responderservice/fleet/FleetClient.java
@@ -5,6 +5,7 @@ import org.springframework.core.io.ClassPathResource;
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.http.client.JdkClientHttpRequestFactory;
 import org.springframework.stereotype.Component;
+import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestClient;
 
 import javax.net.ssl.SSLContext;
@@ -86,14 +87,22 @@ public class FleetClient {
      * 플랫폼이 필요한 이유는 Fleet 이 Windows 에 PowerShell, 그 외에 sh 를 실행하기 때문이다.
      */
     public FleetHost resolveHost(String identifier) {
-        HostIdentifierResponse res = http.get()
-                .uri("/api/v1/fleet/hosts/identifier/{id}", identifier)
-                .retrieve()
-                .body(HostIdentifierResponse.class);
-        if (res == null || res.host() == null) {
-            throw new IllegalStateException("Fleet 에서 호스트를 찾지 못함: " + identifier);
+        // Fleet 조회는 대소문자를 구분한다. 알림의 host 는 osquery 가 준 원본이라 Fleet 저장값과
+        // 다를 수 있어(macOS 실측: 원본 404, 소문자 200) 후보를 순서대로 시도한다.
+        for (String candidate : HostIdentifiers.candidates(identifier)) {
+            try {
+                HostIdentifierResponse res = http.get()
+                        .uri("/api/v1/fleet/hosts/identifier/{id}", candidate)
+                        .retrieve()
+                        .body(HostIdentifierResponse.class);
+                if (res != null && res.host() != null) {
+                    return new FleetHost(res.host().id(), res.host().platform());
+                }
+            } catch (HttpClientErrorException.NotFound e) {
+                // 다음 후보로 넘어간다. 후보를 다 소진하면 아래에서 실패로 처리한다.
+            }
         }
-        return new FleetHost(res.host().id(), res.host().platform());
+        throw new IllegalStateException("Fleet 에서 호스트를 찾지 못함: " + identifier);
     }
 
     /** 스크립트를 호스트에서 동기 실행하고 결과를 반환. */

--- a/responder-service/src/main/java/com/edrdog/responderservice/fleet/HostIdentifiers.java
+++ b/responder-service/src/main/java/com/edrdog/responderservice/fleet/HostIdentifiers.java
@@ -1,0 +1,28 @@
+package com.edrdog.responderservice.fleet;
+
+import java.util.List;
+
+/**
+ * Fleet 호스트 조회에 쓸 식별자 후보를 만드는 순수 로직.
+ *
+ * <p>Fleet 의 {@code /hosts/identifier/{id}} 조회는 대소문자를 구분한다. 실측으로 확인했다.
+ * 같은 기기인데 {@code gimdonghyeon-ui-MacBookPro.local} 은 404, 소문자는 200이었다.
+ * osquery 는 OS 가 준 hostname 을 그대로 보내고(대문자 포함) Fleet 은 소문자로 저장해서 어긋난다.
+ *
+ * <p>알림의 host 를 그대로 쓰면 조치가 "호스트를 찾지 못함"으로 실패한다. 원본을 먼저 시도하고
+ * 다르면 소문자도 시도한다. Windows 처럼 원본이 맞는 경우를 깨뜨리지 않으려고 순서를 이렇게 둔다.
+ */
+public final class HostIdentifiers {
+
+    private HostIdentifiers() {
+    }
+
+    /** 조회 순서대로의 후보. 같은 값을 두 번 조회하지 않는다. */
+    public static List<String> candidates(String identifier) {
+        if (identifier == null || identifier.isBlank()) {
+            return List.of();
+        }
+        String lower = identifier.toLowerCase();
+        return identifier.equals(lower) ? List.of(identifier) : List.of(identifier, lower);
+    }
+}

--- a/responder-service/src/test/java/com/edrdog/responderservice/fleet/HostIdentifiersTest.java
+++ b/responder-service/src/test/java/com/edrdog/responderservice/fleet/HostIdentifiersTest.java
@@ -1,0 +1,46 @@
+package com.edrdog.responderservice.fleet;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Fleet 호스트 조회에 쓸 식별자 후보 (순수 로직).
+ *
+ * <p>Fleet 의 identifier 조회는 대소문자를 구분한다. 실측: 같은 기기인데
+ * "gimdonghyeon-ui-MacBookPro.local" 은 404, "gimdonghyeon-ui-macbookpro.local" 은 200.
+ * osquery 는 OS 가 준 이름을 그대로 보내고 Fleet 은 소문자로 저장해서 어긋난다.
+ */
+class HostIdentifiersTest {
+
+    @Test
+    @DisplayName("대문자가 섞여 있으면 원본과 소문자를 함께 후보로 낸다")
+    void mixedCase_yieldsBothCandidates() {
+        List<String> c = HostIdentifiers.candidates("gimdonghyeon-ui-MacBookPro.local");
+
+        assertThat(c).containsExactly("gimdonghyeon-ui-MacBookPro.local", "gimdonghyeon-ui-macbookpro.local");
+    }
+
+    @Test
+    @DisplayName("이미 소문자면 후보는 하나뿐 (같은 조회를 두 번 하지 않는다)")
+    void lowerCase_yieldsSingleCandidate() {
+        assertThat(HostIdentifiers.candidates("srv-web-01")).containsExactly("srv-web-01");
+    }
+
+    @Test
+    @DisplayName("Windows 처럼 전부 대문자여도 원본을 먼저 시도한다")
+    void upperCase_triesOriginalFirst() {
+        assertThat(HostIdentifiers.candidates("DESKTOP-KIM"))
+                .containsExactly("DESKTOP-KIM", "desktop-kim");
+    }
+
+    @Test
+    @DisplayName("비어 있으면 후보 없음")
+    void blank_yieldsNothing() {
+        assertThat(HostIdentifiers.candidates(null)).isEmpty();
+        assertThat(HostIdentifiers.candidates("  ")).isEmpty();
+    }
+}


### PR DESCRIPTION
## 실기기에서 발견

맥북을 Fleet 에 등록하고 확인하다 나왔다. 같은 기기인데 조회가 갈린다.

```
GET /api/v1/fleet/hosts/identifier/gimdonghyeon-ui-MacBookPro.local → 404
GET /api/v1/fleet/hosts/identifier/gimdonghyeon-ui-macbookpro.local → 200
```

osquery 는 OS 가 준 hostname 을 그대로 보내고(대문자 포함), Fleet 은 소문자로 저장한다. 알림의 `host` 를 그대로 넘기면 `resolveHost` 가 404 를 받아 **조치가 통째로 실패한다.**

## 변경

- `HostIdentifiers.candidates()`: 원본 → 소문자 순서로 후보 생성 (같으면 하나만)
- `FleetClient.resolveHost` 가 후보를 순서대로 시도하고 404 면 다음으로

원본을 먼저 두는 이유는 Windows 처럼 원본이 맞는 경우를 깨뜨리지 않기 위해서다.

## 테스트

`HostIdentifiersTest` 4건 신규 (혼합 대소문자 / 이미 소문자 / 전부 대문자 / 공백). responder 전체 통과.

## 함께 확인된 것

kill 경로에 이 문제 말고도 두 개가 더 있었고, 둘 다 서버·기기 설정으로 해결했다.

1. **Fleet API 토큰이 401** 이었다. `api@edrdog.local` 계정에 "비밀번호 재설정 필요" 플래그가 걸려 있어 API 가 전부 막혀 있었다. 즉 **kill 은 여태 한 번도 동작한 적이 없다.** 플래그를 지워 해결
2. **fleetd 가 scripts 비활성** 으로 설치돼 있었다. `fleetctl package --enable-scripts` 로 다시 만들어 재설치

지금은 `fleetctl run-script` 로 맥북에서 스크립트가 실제로 실행되는 것까지 확인했다(exit 0, 출력 수신).