### PR TITLE
fix: R2 를 이벤트 시각 순서로 판정 (늦게 도착한 네트워크 이벤트)

### DIFF
--- a/detector-service/src/main/java/com/edrdog/detectorservice/rule/Rules.java
+++ b/detector-service/src/main/java/com/edrdog/detectorservice/rule/Rules.java
@@ -93,8 +93,34 @@ public final class Rules {
                 actTarget(current)));
     }
 
-    /** R2 T1105+T1204: 버퍼의 network 다운로드 → 이후 process 실행. */
+    /**
+     * R2 T1105+T1204: network 다운로드 → 이후 process 실행.
+     *
+     * <p>판정은 <b>이벤트 시각</b> 순서로 한다. 도착 순서로만 보면 이 조합을 거의 놓친다.
+     * 네트워크 이벤트는 Zeek 가 연결 종료 후에 기록하고 전송기가 묶어 보내서 항상 늦게 도착하는데,
+     * 실행 이벤트는 osquery 가 바로 올린다. 실기기에서 R2 가 한 번도 발화하지 않은 원인이었다.
+     * 그래서 어느 쪽이 나중에 도착하든, 시각상 다운로드가 먼저면 판정한다.
+     */
     private static Optional<Alert> downloadAndExecute(List<Event> prior, Event current) {
+        // 네트워크가 늦게 도착한 경우: 버퍼에서 그 뒤에 실행된 프로세스를 찾는다.
+        if (isNetwork(current) && DOWNLOAD_PORTS.contains(current.destPort())) {
+            return prior.stream()
+                    .filter(Rules::isProcess)
+                    .filter(e -> !isBaseline(lower(e.process())))
+                    .filter(e -> executableHasMarker(e.cmdline(), SCRIPT_TEMP_MARKERS))
+                    .filter(e -> e.ts() >= current.ts())   // 시각상 다운로드가 먼저여야 한다
+                    .findFirst()
+                    .map(exec -> new Alert(
+                            exec.host(),
+                            "DOWNLOAD_AND_EXECUTE",
+                            "T1105+T1204",
+                            Alert.SEV_CRITICAL,
+                            Alert.actionFor(Alert.SEV_CRITICAL),
+                            exec.ts(),
+                            List.of(summary(current), summary(exec)),
+                            exec.tenantId(),
+                            actTarget(exec)));
+        }
         if (!isProcess(current) || isBaseline(lower(current.process()))) {
             return Optional.empty();
         }
@@ -108,6 +134,7 @@ public final class Rules {
         Optional<Event> download = prior.stream()
                 .filter(Rules::isNetwork)
                 .filter(e -> DOWNLOAD_PORTS.contains(e.destPort()))
+                .filter(e -> e.ts() <= current.ts())   // 시각상 다운로드가 먼저여야 한다
                 .findFirst();
         if (download.isEmpty()) {
             return Optional.empty();

--- a/detector-service/src/test/java/com/edrdog/detectorservice/rule/RulesTest.java
+++ b/detector-service/src/test/java/com/edrdog/detectorservice/rule/RulesTest.java
@@ -239,4 +239,29 @@ class RulesTest {
         assertThat(alert.get().severity()).isEqualTo(Alert.SEV_CRITICAL);
         assertThat(alert.get().ruleId()).isEqualTo("DOWNLOAD_AND_EXECUTE");
     }
+
+    @Test
+    @DisplayName("R2: 네트워크 이벤트가 늦게 도착해도 이벤트 시각 순서가 맞으면 판정한다")
+    void r2_lateArrivingNetwork_stillAlerts() {
+        // Zeek 는 연결이 끝난 뒤에 기록하고 전송기가 묶어 보내므로 네트워크 이벤트는 항상 늦게 도착한다.
+        // 도착 순서만 보면 이 조합을 영영 놓친다(실측: 실기기에서 R2 가 한 번도 발화하지 않았다).
+        List<Event> buffer = List.of(processFrom("evil", "/Users/me/Downloads/evil", 2000));
+        Event lateNetwork = network("203.0.113.9", 443, 1000);   // 이벤트 시각은 실행보다 앞선다
+
+        Optional<Alert> alert = Rules.evaluate(buffer, lateNetwork);
+
+        assertThat(alert).isPresent();
+        assertThat(alert.get().ruleId()).isEqualTo("DOWNLOAD_AND_EXECUTE");
+        assertThat(alert.get().severity()).isEqualTo(Alert.SEV_CRITICAL);
+    }
+
+    @Test
+    @DisplayName("R2 음성: 실행이 네트워크보다 먼저 일어났으면(시각 기준) 판정하지 않는다")
+    void r2_executeBeforeDownload_noAlert() {
+        // 순서를 보장하지 않으면 '받기 전에 실행한 것'까지 다운로드-실행으로 오인한다.
+        List<Event> buffer = List.of(processFrom("evil", "/Users/me/Downloads/evil", 1000));
+        Event laterNetwork = network("203.0.113.9", 443, 2000);
+
+        assertThat(Rules.evaluate(buffer, laterNetwork)).isEmpty();
+    }
 }


### PR DESCRIPTION
## 실기기에서 R2 가 한 번도 발화하지 않았다

다운로드 경로에 바이너리를 만들어 실행하고 웹 접속도 발생시켰는데 CRITICAL 이 안 떴다. 조건은 다 갖췄는데도 안 나온다.

## 원인: 도착 순서

`CorrelationProcessor` 는 윈도우 계산에만 `ts` 를 쓰고, 판정은 **먼저 도착한 이벤트**만 선행으로 본다.

```java
buffer.events.removeIf(prev -> current.ts() - prev.ts() > windowMs);  // 윈도우만 ts
Rules.evaluate(buffer.events, current);                               // 판정은 도착 순서
```

그런데 두 이벤트의 도착 순서가 **구조적으로 뒤집혀 있다.**

| 이벤트 | 발행 시점 |
|---|---|
| 네트워크(Zeek) | 연결 종료 후 약 5초 뒤 기록 → 전송기가 10초 주기로 묶어 발행 |
| 프로세스(osquery) | exec 즉시 발행 |

시각상 다운로드가 먼저여도 **도착은 항상 늦다.** 그래서 실행 이벤트를 판정할 때 네트워크가 버퍼에 없다. 이대로면 R2 는 실사용에서 사실상 죽은 룰이다.

## 변경

- 네트워크 이벤트가 도착했을 때도 버퍼에서 **그 뒤에 실행된** 프로세스를 찾아 판정한다
- 양방향 모두 **이벤트 시각 순서**(다운로드 `ts` <= 실행 `ts`)를 확인한다. 순서를 안 보면 "받기 전에 실행한 것"까지 다운로드-실행으로 오인한다

같은 쌍이 두 번 발화하지는 않는다. 각 이벤트는 한 번만 처리되고, 정상 순서로 도착하면 프로세스 이벤트 시점에만 매칭된다.

## 테스트

- 늦게 도착한 네트워크로 판정 (수정 전 실패 확인)
- 시각 역순(실행이 먼저)은 미판정

RulesTest 18건, detector 전체 통과.