### PR TITLE
fix: CRITICAL 권고를 격리에서 프로세스 종료로 (격리는 구현이 없다)

### DIFF
--- a/detector-service/src/main/java/com/edrdog/detectorservice/dto/Alert.java
+++ b/detector-service/src/main/java/com/edrdog/detectorservice/dto/Alert.java
@@ -34,11 +34,16 @@ public record Alert(
     public static final String ACTION_KILL = "kill";
     public static final String ACTION_ISOLATE = "isolate";
 
-    /** severity → 권고 대응 매핑. CRITICAL 은 격리, HIGH 는 프로세스 종료, MEDIUM 등 그 외는 알림. */
+    /**
+     * severity → 권고 대응 매핑. CRITICAL/HIGH 는 프로세스 종료, 그 외는 알림.
+     *
+     * <p>CRITICAL 을 격리로 권고했었는데 격리는 구현이 없다. responder 가 할 수 있는 건 종료뿐이다.
+     * 권고와 실제 조치가 다르면 사용자가 격리된 줄 알고 넘어간다. 있는 기능으로 권고를 맞춘다.
+     * 격리를 실제로 붙이면(방화벽 차단 등) 그때 CRITICAL 을 되돌린다.
+     */
     public static String actionFor(String severity) {
         return switch (severity) {
-            case SEV_CRITICAL -> ACTION_ISOLATE;
-            case SEV_HIGH -> ACTION_KILL;
+            case SEV_CRITICAL, SEV_HIGH -> ACTION_KILL;
             default -> ACTION_NOTIFY;
         };
     }

--- a/detector-service/src/test/java/com/edrdog/detectorservice/api/ScenariosTest.java
+++ b/detector-service/src/test/java/com/edrdog/detectorservice/api/ScenariosTest.java
@@ -50,7 +50,7 @@ class ScenariosTest {
         assertThat(alert).isPresent();
         assertThat(alert.get().ruleId()).isEqualTo("DOWNLOAD_AND_EXECUTE");
         assertThat(alert.get().severity()).isEqualTo(Alert.SEV_CRITICAL);
-        assertThat(alert.get().action()).isEqualTo(Alert.ACTION_ISOLATE);
+        assertThat(alert.get().action()).isEqualTo(Alert.ACTION_KILL);
     }
 
     @Test

--- a/detector-service/src/test/java/com/edrdog/detectorservice/rule/RulesTest.java
+++ b/detector-service/src/test/java/com/edrdog/detectorservice/rule/RulesTest.java
@@ -76,7 +76,7 @@ class RulesTest {
     }
 
     @Test
-    @DisplayName("R2: network 다운로드 후 같은 host 에서 process 실행 → DOWNLOAD_AND_EXECUTE(T1105+T1204, CRITICAL, isolate)")
+    @DisplayName("R2: network 다운로드 후 같은 host 에서 process 실행 → DOWNLOAD_AND_EXECUTE(T1105+T1204, CRITICAL, kill)")
     void r2_downloadThenExecute_alerts() {
         List<Event> buffer = List.of(network("203.0.113.9", 443, 1000));
         Event current = processFrom("evil.exe", "/tmp/evil.exe --run", 2000);
@@ -88,7 +88,7 @@ class RulesTest {
         assertThat(a.ruleId()).isEqualTo("DOWNLOAD_AND_EXECUTE");
         assertThat(a.mitre()).isEqualTo("T1105+T1204");
         assertThat(a.severity()).isEqualTo(Alert.SEV_CRITICAL);
-        assertThat(a.action()).isEqualTo(Alert.ACTION_ISOLATE);
+        assertThat(a.action()).isEqualTo(Alert.ACTION_KILL);
         assertThat(a.ts()).isEqualTo(2000);
         assertThat(a.matched()).hasSize(2);
     }
@@ -263,5 +263,15 @@ class RulesTest {
         Event laterNetwork = network("203.0.113.9", 443, 2000);
 
         assertThat(Rules.evaluate(buffer, laterNetwork)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("CRITICAL 권고는 kill 이다 (격리는 구현이 없어 권고하지 않는다)")
+    void criticalRecommendsKill() {
+        // 권고와 실제 조치가 다르면 사용자가 격리된 줄 알고 넘어간다.
+        // responder 가 할 수 있는 건 프로세스 종료뿐이라 권고도 거기에 맞춘다.
+        assertThat(Alert.actionFor(Alert.SEV_CRITICAL)).isEqualTo(Alert.ACTION_KILL);
+        assertThat(Alert.actionFor(Alert.SEV_HIGH)).isEqualTo(Alert.ACTION_KILL);
+        assertThat(Alert.actionFor(Alert.SEV_MEDIUM)).isEqualTo(Alert.ACTION_NOTIFY);
     }
 }


### PR DESCRIPTION
## 문제

CRITICAL 알림이 `action=isolate` 로 나간다. **격리는 어디에도 구현돼 있지 않다.** responder 가 할 수 있는 건 프로세스 종료뿐이다.

권고와 실제 조치가 다르면 사용자가 격리된 줄 알고 넘어간다. 실기기에서 실제로 뜨는 알림이 CRITICAL 인데 그 알림에서 조치 버튼이 안 보이던 것도 이 매핑 때문이었다(버튼은 kill 권고에만 붙는다).

## 변경

```java
case SEV_CRITICAL, SEV_HIGH -> ACTION_KILL;
default -> ACTION_NOTIFY;
```

`ACTION_ISOLATE` 상수는 남긴다. 격리를 실제로 붙이면 그때 CRITICAL 을 되돌린다.

## 왜 격리를 지금 구현하지 않았나

macOS 에서 `pfctl` 로 아웃바운드를 끊으면 그 기기가 **Fleet 서버와도 끊긴다.** 원격으로 되돌릴 수단이 사라져서 시연용 개인 기기에 걸기엔 위험하다. 제대로 하려면 관리 채널만 예외로 두는 규칙과 자동 해제 타이머가 필요하다.

## 테스트

`actionFor` 매핑 1건 신규, 기존 R2 기대값 갱신. detector / alert / responder 전체 통과.

(#113 은 리베이스 충돌로 브랜치가 꼬여 닫고 이 PR 로 다시 올렸다. 내용은 동일하다.)