### PR TITLE
fix: 상관 버퍼가 노이즈로 가득 차 5분 윈도우가 십여 초로 줄던 문제

### DIFF
--- a/detector-service/src/main/java/com/edrdog/detectorservice/kafkastreams/topology/CorrelationProcessor.java
+++ b/detector-service/src/main/java/com/edrdog/detectorservice/kafkastreams/topology/CorrelationProcessor.java
@@ -50,11 +50,14 @@ public class CorrelationProcessor implements Processor<String, Event, String, Al
         Rules.evaluate(buffer.events, current).ifPresent(alert ->
                 ctx.forward(record.withKey(host).withValue(alert)));
 
-        // 현재 이벤트 적재 (상한 초과 시 가장 오래된 것부터 제거)
-        buffer.events.add(current);
-        while (buffer.events.size() > EventBuffer.MAX) {
-            buffer.events.remove(0);
+        // 룰이 선행으로 참조하는 이벤트만 적재한다. 전부 담으면 상한(EventBuffer.MAX)이 금방 차서
+        // 5분 윈도우가 사실상 십여 초로 줄어든다(실기기는 초당 십여 건씩 프로세스 이벤트를 낸다).
+        if (Rules.isCorrelatable(current)) {
+            buffer.events.add(current);
+            while (buffer.events.size() > EventBuffer.MAX) {
+                buffer.events.remove(0);
+            }
+            store.put(host, buffer);
         }
-        store.put(host, buffer);
     }
 }

--- a/detector-service/src/main/java/com/edrdog/detectorservice/rule/Rules.java
+++ b/detector-service/src/main/java/com/edrdog/detectorservice/rule/Rules.java
@@ -63,6 +63,32 @@ public final class Rules {
         return fileInAutorunPath(current);
     }
 
+/**
+     * 선행 이벤트로 버퍼에 남길 가치가 있는지 (순수 판정).
+     *
+     * <p>버퍼는 상태 크기 때문에 상한이 있는데, 실기기는 초당 십여 건씩 프로세스 이벤트를 낸다.
+     * 전부 담으면 상한이 금방 차서 5분 윈도우가 사실상 십여 초로 줄고, 상관 룰이 발화하지 못한다.
+     * 룰이 '선행'으로 실제 참조하는 것만 남긴다. 나머지는 현재 이벤트로 판정될 때 이미 쓰였다.
+     *
+     * <ul>
+     *   <li>network: 다운로드 포트만 (R2)</li>
+     *   <li>process: office 앱(R1 의 부모 후보) 또는 임시·다운로드 경로 실행(R2 역방향)</li>
+     * </ul>
+     */
+    public static boolean isCorrelatable(Event e) {
+        if (e == null) {
+            return false;
+        }
+        if (isNetwork(e)) {
+            return DOWNLOAD_PORTS.contains(e.destPort());
+        }
+        if (isProcess(e)) {
+            return in(OFFICE_APPS, lower(e.process()))
+                    || executableHasMarker(e.cmdline(), SCRIPT_TEMP_MARKERS);
+        }
+        return false;
+    }
+
     /** R1 T1059: 버퍼의 office앱 exec → 그 office앱을 부모로 shell 실행. */
     private static Optional<Alert> suspiciousProcessChain(List<Event> prior, Event current) {
         if (!isProcess(current)) {

--- a/detector-service/src/test/java/com/edrdog/detectorservice/kafkastreams/topology/DetectionTopologyTest.java
+++ b/detector-service/src/test/java/com/edrdog/detectorservice/kafkastreams/topology/DetectionTopologyTest.java
@@ -102,4 +102,19 @@ class DetectionTopologyTest {
 
         assertThat(alerts.isEmpty()).isTrue();
     }
+
+    @Test
+    @DisplayName("무관한 이벤트가 버퍼 상한을 넘게 쏟아져도 상관은 유지된다")
+    void noisyBuffer_keepsCorrelation() {
+        // 실기기(맥북)는 초당 15건씩 프로세스 이벤트를 낸다. 버퍼가 최근 N건만 보관하면
+        // 5분 윈도우가 사실상 십여 초로 줄어 R2 가 거의 발화하지 못한다(실측).
+        events.pipeInput("k", network("host-3", 443, 1000));
+        for (int i = 0; i < 500; i++) {
+            events.pipeInput("k", process("host-3", "noise" + i, "bash", 1000 + i));
+        }
+        events.pipeInput("k", processFrom("host-3", "evil", "/Users/me/Downloads/evil", 200_000));
+
+        assertThat(alerts.getQueueSize()).isEqualTo(1);
+        assertThat(alerts.readValue().ruleId()).isEqualTo("DOWNLOAD_AND_EXECUTE");
+    }
 }


### PR DESCRIPTION
## 실기기에서 R2 가 거의 발화하지 않았다

실행 이벤트도 443 네트워크 이벤트도 서버에 정상 수집되는데 알림만 안 떴다. 확인해보니 데이터는 다 있었다.

```
process: /Users/dhkim/Downloads/edrdog-demo    ← 수집됨
network: 443 이벤트 최근 200건 중 94건          ← 수집됨
alert:   없음
```

## 원인: 버퍼 상한

`EventBuffer.MAX = 200` 인데 이 맥은 **초당 15건**씩 프로세스 이벤트를 낸다(45초에 667건 실측). 버퍼에는 **최근 13초치**만 남는다.

즉 5분 윈도우가 이름뿐이고, 443 이벤트와 실행 이벤트가 그 좁은 틈에 같이 들어와야만 상관이 성립했다. 개발 중에는 이벤트가 적어서 드러나지 않는 종류의 문제다.

## 변경

상한을 올리면 상태 크기와 직렬화 비용이 같이 커진다(이벤트마다 버퍼 전체를 JSON 으로 읽고 쓴다). 대신 **룰이 선행으로 실제 참조하는 이벤트만** 적재한다.

| 타입 | 적재 조건 |
|---|---|
| network | 다운로드 포트(80/443/8080)만 |
| process | office 앱(R1 의 부모 후보) 또는 임시·다운로드 경로 실행(R2 역방향) |
| 그 외 | 적재 안 함 |

버리는 게 아니라 **현재 이벤트로 판정될 때 이미 쓰인다.** R3/R4 같은 단일 이벤트 룰과 정방향 매칭은 그대로 동작한다.

## 테스트

노이즈 500건을 네트워크 이벤트와 실행 이벤트 사이에 끼운 토폴로지 테스트를 추가했다. 수정 전 실패를 확인했다.

```java
events.pipeInput("k", network("host-3", 443, 1000));
for (int i = 0; i < 500; i++) events.pipeInput("k", process("host-3", "noise"+i, "bash", 1000+i));
events.pipeInput("k", processFrom("host-3", "evil", "/Users/me/Downloads/evil", 200_000));
→ DOWNLOAD_AND_EXECUTE 1건
```

detector 전체 통과.