### PR TITLE
release: 상관 버퍼 노이즈 필터

### DIFF
--- a/detector-service/src/main/java/com/edrdog/detectorservice/kafkastreams/topology/CorrelationProcessor.java
+++ b/detector-service/src/main/java/com/edrdog/detectorservice/kafkastreams/topology/CorrelationProcessor.java
@@ -50,11 +50,14 @@ public class CorrelationProcessor implements Processor<String, Event, String, Al
         Rules.evaluate(buffer.events, current).ifPresent(alert ->
                 ctx.forward(record.withKey(host).withValue(alert)));
 
-        // 현재 이벤트 적재 (상한 초과 시 가장 오래된 것부터 제거)
-        buffer.events.add(current);
-        while (buffer.events.size() > EventBuffer.MAX) {
-            buffer.events.remove(0);
+        // 룰이 선행으로 참조하는 이벤트만 적재한다. 전부 담으면 상한(EventBuffer.MAX)이 금방 차서
+        // 5분 윈도우가 사실상 십여 초로 줄어든다(실기기는 초당 십여 건씩 프로세스 이벤트를 낸다).
+        if (Rules.isCorrelatable(current)) {
+            buffer.events.add(current);
+            while (buffer.events.size() > EventBuffer.MAX) {
+                buffer.events.remove(0);
+            }
+            store.put(host, buffer);
         }
-        store.put(host, buffer);
     }
 }

--- a/detector-service/src/main/java/com/edrdog/detectorservice/rule/Rules.java
+++ b/detector-service/src/main/java/com/edrdog/detectorservice/rule/Rules.java
@@ -63,6 +63,32 @@ public final class Rules {
         return fileInAutorunPath(current);
     }
 
+/**
+     * 선행 이벤트로 버퍼에 남길 가치가 있는지 (순수 판정).
+     *
+     * <p>버퍼는 상태 크기 때문에 상한이 있는데, 실기기는 초당 십여 건씩 프로세스 이벤트를 낸다.
+     * 전부 담으면 상한이 금방 차서 5분 윈도우가 사실상 십여 초로 줄고, 상관 룰이 발화하지 못한다.
+     * 룰이 '선행'으로 실제 참조하는 것만 남긴다. 나머지는 현재 이벤트로 판정될 때 이미 쓰였다.
+     *
+     * <ul>
+     *   <li>network: 다운로드 포트만 (R2)</li>
+     *   <li>process: office 앱(R1 의 부모 후보) 또는 임시·다운로드 경로 실행(R2 역방향)</li>
+     * </ul>
+     */
+    public static boolean isCorrelatable(Event e) {
+        if (e == null) {
+            return false;
+        }
+        if (isNetwork(e)) {
+            return DOWNLOAD_PORTS.contains(e.destPort());
+        }
+        if (isProcess(e)) {
+            return in(OFFICE_APPS, lower(e.process()))
+                    || executableHasMarker(e.cmdline(), SCRIPT_TEMP_MARKERS);
+        }
+        return false;
+    }
+
     /** R1 T1059: 버퍼의 office앱 exec → 그 office앱을 부모로 shell 실행. */
     private static Optional<Alert> suspiciousProcessChain(List<Event> prior, Event current) {
         if (!isProcess(current)) {

--- a/detector-service/src/test/java/com/edrdog/detectorservice/kafkastreams/topology/DetectionTopologyTest.java
+++ b/detector-service/src/test/java/com/edrdog/detectorservice/kafkastreams/topology/DetectionTopologyTest.java
@@ -102,4 +102,19 @@ class DetectionTopologyTest {
 
         assertThat(alerts.isEmpty()).isTrue();
     }
+
+    @Test
+    @DisplayName("무관한 이벤트가 버퍼 상한을 넘게 쏟아져도 상관은 유지된다")
+    void noisyBuffer_keepsCorrelation() {
+        // 실기기(맥북)는 초당 15건씩 프로세스 이벤트를 낸다. 버퍼가 최근 N건만 보관하면
+        // 5분 윈도우가 사실상 십여 초로 줄어 R2 가 거의 발화하지 못한다(실측).
+        events.pipeInput("k", network("host-3", 443, 1000));
+        for (int i = 0; i < 500; i++) {
+            events.pipeInput("k", process("host-3", "noise" + i, "bash", 1000 + i));
+        }
+        events.pipeInput("k", processFrom("host-3", "evil", "/Users/me/Downloads/evil", 200_000));
+
+        assertThat(alerts.getQueueSize()).isEqualTo(1);
+        assertThat(alerts.readValue().ruleId()).isEqualTo("DOWNLOAD_AND_EXECUTE");
+    }
 }


### PR DESCRIPTION
#116 하나. 실기기의 이벤트 양(초당 15건) 때문에 상관 버퍼가 13초치만 남아 R2 가 거의 발화하지 못했다. 룰이 선행으로 참조하는 이벤트만 적재한다.