### PR TITLE
fix: GeoLite2 다운로드 429 로 배포가 막히던 문제 (캐시 + 재시도)

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -17,6 +17,14 @@ jobs:
           distribution: temurin
           java-version: '21'
       - uses: gradle/actions/setup-gradle@v4
+      # GeoLite2 mmdb 캐시. MaxMind 는 짧은 시간에 여러 번 받으면 429 를 준다(실제로 배포가 막혔다).
+      # DB 는 주 단위로 갱신되므로 주차 키로 캐시하면 하루에 몇 번을 빌드해도 한 번만 받는다.
+      - name: GeoLite2 캐시
+        uses: actions/cache@v4
+        with:
+          path: api-service/build/geoip
+          key: geolite2-${{ hashFiles('api-service/build.gradle') }}-week
+          restore-keys: geolite2-
       - name: Build + test
         # GeoLite2 mmdb 는 빌드 시점에 받아 jar 에 번들된다. 이 키가 없으면 다운로드를 건너뛰고
         # 빌드는 그대로 성공하지만, 런타임에 GET /api/events/geo 가 항상 빈 배열을 준다(위협 지도가 빈다).

--- a/api-service/build.gradle
+++ b/api-service/build.gradle
@@ -34,8 +34,23 @@ tasks.register('downloadGeoLite2') {
         def tarFile = new File(outDir, 'GeoLite2-Country.tar.gz')
         def url = "https://download.maxmind.com/app/geoip_download?edition_id=GeoLite2-Country&license_key=${key}&suffix=tar.gz"
         logger.lifecycle('[geoip] GeoLite2-Country 다운로드 중...')
-        tarFile.withOutputStream { os ->
-            new URI(url).toURL().openStream().withCloseable { input -> os << input }
+        // MaxMind 는 짧은 시간에 여러 번 받으면 429 를 준다. 실제로 배포가 이것 때문에 막힌 적이 있다.
+        // 잠깐 기다렸다 다시 시도한다. 그래도 안 되면 실패시킨다(mmdb 없는 jar 는 지도가 빈 채로 뜬다).
+        def attempts = 4
+        for (int i = 1; ; i++) {
+            try {
+                tarFile.withOutputStream { os ->
+                    new URI(url).toURL().openStream().withCloseable { input -> os << input }
+                }
+                break
+            } catch (IOException e) {
+                if (i >= attempts) {
+                    throw new GradleException("[geoip] ${attempts}회 시도 실패: ${e.message}", e)
+                }
+                def waitSec = 15 * i
+                logger.warn("[geoip] 다운로드 실패(${e.message}) → ${waitSec}초 후 재시도 (${i}/${attempts})")
+                Thread.sleep(waitSec * 1000L)
+            }
         }
         // tar.gz 안의 GeoLite2-Country_YYYYMMDD/GeoLite2-Country.mmdb 를 평탄화해 추출
         copy {


### PR DESCRIPTION
## 문제

오늘 빌드를 여러 번 돌렸더니 MaxMind 가 429 를 반환했다.

```
Execution failed for task ':api-service:downloadGeoLite2'.
> java.io.IOException: Server returned HTTP response code: 429
build: failure → image: skipped → deploy: skipped
```

**코드와 무관하게 배포가 통째로 막힌다.** 재실행해도 리밋이 안 풀려 계속 실패했다.

## 변경

**1. CI 캐시** — `api-service/build/geoip` 를 캐시한다. 다운로드 태스크가 `outputs.upToDateWhen { outFile.exists() }` 라 캐시가 맞으면 아예 받지 않는다. GeoLite2 는 주 단위로 갱신되므로 하루에 몇 번을 빌드해도 한 번만 받으면 된다.

**2. 재시도** — 4회(15/30/45초 대기). 429 는 대개 잠깐이라 이걸로 대부분 넘어간다.

## 실패는 여전히 실패로 둔다

끝까지 안 되면 빌드를 실패시킨다. mmdb 없는 jar 를 배포하면 `GET /api/events/geo` 가 빈 배열을 주고 **위협 지도가 조용히 빈 채로** 뜬다. 그 상태를 성공으로 넘기면 발표 중에야 알아차리게 된다.