### PR TITLE
feat: 조치에 성공하면 알림을 confirmed 로 넘긴다

### DIFF
--- a/api-service/src/main/java/com/edrdog/apiservice/alert/web/AlertController.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/alert/web/AlertController.java
@@ -1,6 +1,7 @@
 package com.edrdog.apiservice.alert.web;
 
 import com.edrdog.apiservice.alert.AlertService;
+import com.edrdog.apiservice.alert.AlertStatus;
 import com.edrdog.apiservice.auth.exception.AuthException;
 import com.edrdog.apiservice.auth.service.AuthService;
 import com.edrdog.apiservice.auth.service.Principal;
@@ -135,7 +136,13 @@ public class AlertController {
             throw AuthException.invalidInput("target 프로세스가 필요합니다");
         }
         AlertResponse alert = alerts.get(tenantId, id);   // 타 tenant 면 404, 통과하면 권위 있는 host 확보
-        return responder.kill(alert.host(), request.target());
+        KillResult result = responder.kill(alert.host(), request.target());
+        // 종료에 성공했으면 그 알림은 처리된 것이다. open 으로 남겨두면 목록에서 조치 여부를
+        // 알 수 없어 같은 알림을 또 붙잡게 된다. 실패했으면 그대로 둔다(처리된 것처럼 보이면 안 된다).
+        if (result.killed()) {
+            alerts.triage(tenantId, id, AlertStatus.CONFIRMED);
+        }
+        return result;
     }
 
     /** Bearer 토큰을 검증해 현재 유저의 tenant 를 문자열로 반환. 토큰이 없거나 만료면 AuthService 가 401. */

--- a/api-service/src/main/java/com/edrdog/apiservice/responder/KillResult.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/responder/KillResult.java
@@ -9,4 +9,11 @@ package com.edrdog.apiservice.responder;
  * @param executionId Fleet 실행 식별자 (없으면 null)
  */
 public record KillResult(String host, String target, String status, String executionId) {
+
+    /** 실제로 프로세스를 종료한 결과. 이때만 알림을 처리 완료로 넘긴다. */
+    public static final String KILLED = "KILLED";
+
+    public boolean killed() {
+        return KILLED.equals(status);
+    }
 }

--- a/api-service/src/test/java/com/edrdog/apiservice/alert/web/AlertApiIntegrationTest.java
+++ b/api-service/src/test/java/com/edrdog/apiservice/alert/web/AlertApiIntegrationTest.java
@@ -192,6 +192,42 @@ class AlertApiIntegrationTest {
     }
 
     @Test
+    void 조치가_성공하면_알림이_confirmed_로_넘어간다() throws Exception {
+        // 조치했는데 알림이 open 그대로면 목록에서 처리 여부를 알 수 없다.
+        String[] a = signup("a-respond-confirm@edrdog.com");
+        String id = seedAlert(a[1], "hostC", 300L);
+        when(responder.kill(eq("hostC"), eq("evil.exe")))
+                .thenReturn(new KillResult("hostC", "evil.exe", "KILLED", "exec-2"));
+
+        mvc.perform(post("/api/alerts/" + id + "/respond").header("Authorization", "Bearer " + a[0])
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"target\":\"evil.exe\"}"))
+                .andExpect(status().isOk());
+
+        mvc.perform(get("/api/alerts/" + id).header("Authorization", "Bearer " + a[0]))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("confirmed"));
+    }
+
+    @Test
+    void 조치가_실패하면_알림_상태를_바꾸지_않는다() throws Exception {
+        // 종료되지 않았는데 처리된 것처럼 보이면 안 된다.
+        String[] a = signup("a-respond-fail@edrdog.com");
+        String id = seedAlert(a[1], "hostD", 400L);
+        when(responder.kill(eq("hostD"), eq("evil.exe")))
+                .thenReturn(new KillResult("hostD", "evil.exe", "FAILED", null));
+
+        mvc.perform(post("/api/alerts/" + id + "/respond").header("Authorization", "Bearer " + a[0])
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"target\":\"evil.exe\"}"))
+                .andExpect(status().isOk());
+
+        mvc.perform(get("/api/alerts/" + id).header("Authorization", "Bearer " + a[0]))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("open"));
+    }
+
+    @Test
     void 남의_alert_respond_는_404이고_responder를_호출하지_않는다() throws Exception {
         String[] a = signup("a-presp@edrdog.com");
         String[] b = signup("b-presp@edrdog.com");


### PR DESCRIPTION
## 문제

버튼을 눌러 프로세스를 종료했는데 **알림이 open 그대로 목록에 남는다.** 사용자 입장에서는 조치가 된 건지 알 수 없고, 같은 알림을 또 붙잡게 된다.

조치와 트리아지가 따로 놀고 있었다.

## 변경

- `respond` 가 `KILLED` 를 받으면 그 알림을 `confirmed` 로 트리아지한다
- **실패하면 상태를 바꾸지 않는다** (`NO_MATCH`/`TIMEOUT`/`FAILED`/`COOLDOWN`/`DISABLED`). 종료되지 않았는데 처리된 것처럼 보이면 안 된다
- `KillResult.killed()` 로 판정을 한곳에 둔다

클라이언트가 kill 후 PATCH 를 한 번 더 호출하는 방식도 가능하지만, 서버에서 하면 어느 클라이언트로 조치하든 결과가 같고 중간에 실패해 상태가 어긋날 여지가 없다.

## 테스트

- 성공 시 `confirmed` 로 바뀐다
- 실패 시 `open` 유지

api-service 전체 통과.

## 관련

화면 쪽 표시는 Frontend#67 에서 함께 처리한다(결과 배지, 버튼 잠금, 목록에서 사라지는 이유 안내).