### PR TITLE
release: 조치 시 알림 confirmed 처리 + GeoLite2 CI 캐시

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -17,6 +17,14 @@ jobs:
           distribution: temurin
           java-version: '21'
       - uses: gradle/actions/setup-gradle@v4
+      # GeoLite2 mmdb 캐시. MaxMind 는 짧은 시간에 여러 번 받으면 429 를 준다(실제로 배포가 막혔다).
+      # DB 는 주 단위로 갱신되므로 주차 키로 캐시하면 하루에 몇 번을 빌드해도 한 번만 받는다.
+      - name: GeoLite2 캐시
+        uses: actions/cache@v4
+        with:
+          path: api-service/build/geoip
+          key: geolite2-${{ hashFiles('api-service/build.gradle') }}-week
+          restore-keys: geolite2-
       - name: Build + test
         # GeoLite2 mmdb 는 빌드 시점에 받아 jar 에 번들된다. 이 키가 없으면 다운로드를 건너뛰고
         # 빌드는 그대로 성공하지만, 런타임에 GET /api/events/geo 가 항상 빈 배열을 준다(위협 지도가 빈다).

--- a/api-service/build.gradle
+++ b/api-service/build.gradle
@@ -34,8 +34,23 @@ tasks.register('downloadGeoLite2') {
         def tarFile = new File(outDir, 'GeoLite2-Country.tar.gz')
         def url = "https://download.maxmind.com/app/geoip_download?edition_id=GeoLite2-Country&license_key=${key}&suffix=tar.gz"
         logger.lifecycle('[geoip] GeoLite2-Country 다운로드 중...')
-        tarFile.withOutputStream { os ->
-            new URI(url).toURL().openStream().withCloseable { input -> os << input }
+        // MaxMind 는 짧은 시간에 여러 번 받으면 429 를 준다. 실제로 배포가 이것 때문에 막힌 적이 있다.
+        // 잠깐 기다렸다 다시 시도한다. 그래도 안 되면 실패시킨다(mmdb 없는 jar 는 지도가 빈 채로 뜬다).
+        def attempts = 4
+        for (int i = 1; ; i++) {
+            try {
+                tarFile.withOutputStream { os ->
+                    new URI(url).toURL().openStream().withCloseable { input -> os << input }
+                }
+                break
+            } catch (IOException e) {
+                if (i >= attempts) {
+                    throw new GradleException("[geoip] ${attempts}회 시도 실패: ${e.message}", e)
+                }
+                def waitSec = 15 * i
+                logger.warn("[geoip] 다운로드 실패(${e.message}) → ${waitSec}초 후 재시도 (${i}/${attempts})")
+                Thread.sleep(waitSec * 1000L)
+            }
         }
         // tar.gz 안의 GeoLite2-Country_YYYYMMDD/GeoLite2-Country.mmdb 를 평탄화해 추출
         copy {

--- a/api-service/src/main/java/com/edrdog/apiservice/alert/web/AlertController.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/alert/web/AlertController.java
@@ -1,6 +1,7 @@
 package com.edrdog.apiservice.alert.web;
 
 import com.edrdog.apiservice.alert.AlertService;
+import com.edrdog.apiservice.alert.AlertStatus;
 import com.edrdog.apiservice.auth.exception.AuthException;
 import com.edrdog.apiservice.auth.service.AuthService;
 import com.edrdog.apiservice.auth.service.Principal;
@@ -135,7 +136,13 @@ public class AlertController {
             throw AuthException.invalidInput("target 프로세스가 필요합니다");
         }
         AlertResponse alert = alerts.get(tenantId, id);   // 타 tenant 면 404, 통과하면 권위 있는 host 확보
-        return responder.kill(alert.host(), request.target());
+        KillResult result = responder.kill(alert.host(), request.target());
+        // 종료에 성공했으면 그 알림은 처리된 것이다. open 으로 남겨두면 목록에서 조치 여부를
+        // 알 수 없어 같은 알림을 또 붙잡게 된다. 실패했으면 그대로 둔다(처리된 것처럼 보이면 안 된다).
+        if (result.killed()) {
+            alerts.triage(tenantId, id, AlertStatus.CONFIRMED);
+        }
+        return result;
     }
 
     /** Bearer 토큰을 검증해 현재 유저의 tenant 를 문자열로 반환. 토큰이 없거나 만료면 AuthService 가 401. */

--- a/api-service/src/main/java/com/edrdog/apiservice/demo/DemoData.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/demo/DemoData.java
@@ -168,11 +168,15 @@ public final class DemoData {
         };
     }
 
-    /** detector dto Alert.actionFor 와 동일 규칙. */
+    /**
+     * detector dto Alert.actionFor 와 동일 규칙.
+     *
+     * <p>CRITICAL 도 kill 이다. 격리는 구현이 없어 실제로 할 수 있는 건 프로세스 종료뿐인데,
+     * 시드만 isolate 로 권고하면 화면에서 "격리하세요" 아래 종료 버튼이 붙어 서로 어긋난다.
+     */
     private static String actionFor(String severity) {
         return switch (severity) {
-            case "CRITICAL" -> "isolate";
-            case "HIGH" -> "kill";
+            case "CRITICAL", "HIGH" -> "kill";
             default -> "notify";
         };
     }

--- a/api-service/src/main/java/com/edrdog/apiservice/responder/KillResult.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/responder/KillResult.java
@@ -9,4 +9,11 @@ package com.edrdog.apiservice.responder;
  * @param executionId Fleet 실행 식별자 (없으면 null)
  */
 public record KillResult(String host, String target, String status, String executionId) {
+
+    /** 실제로 프로세스를 종료한 결과. 이때만 알림을 처리 완료로 넘긴다. */
+    public static final String KILLED = "KILLED";
+
+    public boolean killed() {
+        return KILLED.equals(status);
+    }
 }

--- a/api-service/src/main/java/com/edrdog/apiservice/responder/ResponderClient.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/responder/ResponderClient.java
@@ -46,6 +46,28 @@ public class ResponderClient {
         }
     }
 
+    /**
+     * Fleet enroll secret 조회를 responder 에 위임한다(Fleet 토큰은 responder 만 들고 있다).
+     * responder 가 죽어 있거나 오류면 null 로 답한다. 안내 화면이 값을 못 받았을 뿐이라
+     * 온보딩 나머지 단계까지 막을 이유는 없다.
+     */
+    public String fleetEnrollSecret() {
+        try {
+            FleetEnrollSecret res = http.get()
+                    .uri("/api/responder/fleet/enroll-secret")
+                    .retrieve()
+                    .body(FleetEnrollSecret.class);
+            return res == null ? null : res.secret();
+        } catch (RestClientException e) {
+            log.error("responder Fleet enroll secret 조회 실패 err={}", e.toString());
+            return null;
+        }
+    }
+
+    /** responder Fleet enroll secret 응답(FleetSecretController.FleetEnrollSecret 과 동일 필드). */
+    private record FleetEnrollSecret(String secret) {
+    }
+
     /** responder kill 요청 본문(responder KillController.KillRequest 와 동일 필드). */
     private record KillCommand(String host, String target) {
     }

--- a/api-service/src/main/java/com/edrdog/apiservice/responder/web/FleetController.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/responder/web/FleetController.java
@@ -1,0 +1,54 @@
+package com.edrdog.apiservice.responder.web;
+
+import com.edrdog.apiservice.auth.service.AuthService;
+import com.edrdog.apiservice.responder.ResponderClient;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Fleet 연동 값 조회. 지금은 온보딩 안내에 넣을 enroll secret 하나뿐이다.
+ *
+ * <p>인증은 세션 Bearer + 프론트 X-API-Key 둘 다 요구한다(면제 경로에 넣지 않는다).
+ * Fleet 은 인스턴스가 하나라 이 값에는 tenant 구분이 없다. 로그인한 사람에게만 보여준다.
+ */
+@RestController
+@RequestMapping("/api/fleet")
+@Tag(name = "fleet", description = "Fleet 연동 값 조회 (온보딩 안내용)")
+public class FleetController {
+
+    private static final String BEARER_PREFIX = "Bearer ";
+
+    private final ResponderClient responder;
+    private final AuthService auth;
+
+    public FleetController(ResponderClient responder, AuthService auth) {
+        this.responder = responder;
+        this.auth = auth;
+    }
+
+    @Operation(summary = "Fleet enroll secret 조회",
+            description = "fleetd 패키지를 만들 때 쓰는 Fleet 자체 enroll secret. tenant 별 EDRdog enroll secret 과 다른 값이다. "
+                    + "Fleet 이 응답하지 않으면 secret 이 null 이다.")
+    @GetMapping("/enroll-secret")
+    public FleetEnrollSecretResponse enrollSecret(
+            @RequestHeader(name = "Authorization", required = false) String authorization) {
+        auth.resolve(bearerToken(authorization));   // 로그인하지 않았으면 여기서 401
+        return new FleetEnrollSecretResponse(responder.fleetEnrollSecret());
+    }
+
+    /** "Bearer " 접두어를 떼서 토큰만 반환. 없으면 null. */
+    private static String bearerToken(String authorization) {
+        if (authorization == null || !authorization.startsWith(BEARER_PREFIX)) {
+            return null;
+        }
+        return authorization.substring(BEARER_PREFIX.length()).trim();
+    }
+
+    /** 조회 응답. Fleet 이 값을 주지 못하면 secret 이 null 이다. */
+    public record FleetEnrollSecretResponse(String secret) {
+    }
+}

--- a/api-service/src/test/java/com/edrdog/apiservice/alert/web/AlertApiIntegrationTest.java
+++ b/api-service/src/test/java/com/edrdog/apiservice/alert/web/AlertApiIntegrationTest.java
@@ -192,6 +192,42 @@ class AlertApiIntegrationTest {
     }
 
     @Test
+    void 조치가_성공하면_알림이_confirmed_로_넘어간다() throws Exception {
+        // 조치했는데 알림이 open 그대로면 목록에서 처리 여부를 알 수 없다.
+        String[] a = signup("a-respond-confirm@edrdog.com");
+        String id = seedAlert(a[1], "hostC", 300L);
+        when(responder.kill(eq("hostC"), eq("evil.exe")))
+                .thenReturn(new KillResult("hostC", "evil.exe", "KILLED", "exec-2"));
+
+        mvc.perform(post("/api/alerts/" + id + "/respond").header("Authorization", "Bearer " + a[0])
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"target\":\"evil.exe\"}"))
+                .andExpect(status().isOk());
+
+        mvc.perform(get("/api/alerts/" + id).header("Authorization", "Bearer " + a[0]))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("confirmed"));
+    }
+
+    @Test
+    void 조치가_실패하면_알림_상태를_바꾸지_않는다() throws Exception {
+        // 종료되지 않았는데 처리된 것처럼 보이면 안 된다.
+        String[] a = signup("a-respond-fail@edrdog.com");
+        String id = seedAlert(a[1], "hostD", 400L);
+        when(responder.kill(eq("hostD"), eq("evil.exe")))
+                .thenReturn(new KillResult("hostD", "evil.exe", "FAILED", null));
+
+        mvc.perform(post("/api/alerts/" + id + "/respond").header("Authorization", "Bearer " + a[0])
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"target\":\"evil.exe\"}"))
+                .andExpect(status().isOk());
+
+        mvc.perform(get("/api/alerts/" + id).header("Authorization", "Bearer " + a[0]))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("open"));
+    }
+
+    @Test
     void 남의_alert_respond_는_404이고_responder를_호출하지_않는다() throws Exception {
         String[] a = signup("a-presp@edrdog.com");
         String[] b = signup("b-presp@edrdog.com");

--- a/api-service/src/test/java/com/edrdog/apiservice/demo/DemoDataTest.java
+++ b/api-service/src/test/java/com/edrdog/apiservice/demo/DemoDataTest.java
@@ -9,6 +9,7 @@ import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -56,15 +57,22 @@ class DemoDataTest {
         assertEquals(Set.of("CRITICAL", "HIGH", "MEDIUM"), severities);
     }
 
+    /** 격리는 구현이 없어 CRITICAL 도 kill 로 권고한다(detector Alert.actionFor 와 같은 규칙). */
     @Test
     void action_은_severity_규칙과_일치한다() {
         for (Alert a : DemoData.alerts(TENANT, NOW)) {
             String expected = switch (a.severity()) {
-                case "CRITICAL" -> "isolate";
-                case "HIGH" -> "kill";
+                case "CRITICAL", "HIGH" -> "kill";
                 default -> "notify";
             };
             assertEquals(expected, a.action(), a.ruleId() + " 의 action");
+        }
+    }
+
+    @Test
+    void 시드에는_격리_권고가_남아있지_않다() {
+        for (Alert a : DemoData.alerts(TENANT, NOW)) {
+            assertNotEquals("isolate", a.action(), a.ruleId() + " 의 action");
         }
     }
 

--- a/responder-service/src/main/java/com/edrdog/responderservice/api/FleetSecretController.java
+++ b/responder-service/src/main/java/com/edrdog/responderservice/api/FleetSecretController.java
@@ -1,0 +1,45 @@
+package com.edrdog.responderservice.api;
+
+import com.edrdog.responderservice.fleet.FleetClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Fleet enroll secret 조회. 온보딩의 "기기를 Fleet 에 등록" 안내가 이 값을 필요로 한다.
+ *
+ * <p>responder 는 클러스터 안에서만 열리고 앱 인증이 없다. 바깥 노출은 api-service 가 Bearer 로
+ * 인증한 뒤 프록시하는 경로 하나뿐이다(kill 과 같은 구조).
+ */
+@RestController
+@RequestMapping("/api/responder/fleet")
+public class FleetSecretController {
+
+    private static final Logger log = LoggerFactory.getLogger(FleetSecretController.class);
+
+    private final FleetClient fleet;
+
+    public FleetSecretController(FleetClient fleet) {
+        this.fleet = fleet;
+    }
+
+    /**
+     * Fleet enroll secret. Fleet 이 죽어 있거나 토큰이 만료면 500 대신 값 없음으로 답한다.
+     * 화면은 "값을 가져오지 못함"을 안내하면 되고, 조회 실패가 온보딩 전체를 깨뜨릴 이유는 없다.
+     */
+    @GetMapping("/enroll-secret")
+    public FleetEnrollSecret enrollSecret() {
+        try {
+            return new FleetEnrollSecret(fleet.enrollSecret());
+        } catch (RuntimeException e) {
+            log.error("Fleet enroll secret 조회 실패 err={}", e.toString());
+            return new FleetEnrollSecret(null);
+        }
+    }
+
+    /** 조회 응답. 값이 없으면 secret 이 null 이다. */
+    public record FleetEnrollSecret(String secret) {
+    }
+}

--- a/responder-service/src/main/java/com/edrdog/responderservice/fleet/FleetClient.java
+++ b/responder-service/src/main/java/com/edrdog/responderservice/fleet/FleetClient.java
@@ -105,6 +105,20 @@ public class FleetClient {
         throw new IllegalStateException("Fleet 에서 호스트를 찾지 못함: " + identifier);
     }
 
+    /**
+     * Fleet 자체 enroll secret(fleetd 패키지 빌드용). 없거나 형태가 어긋나면 null.
+     *
+     * <p>온보딩 안내가 "관리자에게 문의"로 끊기지 않도록 서버가 대신 읽어준다. 조치(kill)를 쓰려면
+     * 기기를 Fleet 에 등록해야 하는데, 그 값을 보려고 Fleet 콘솔 계정을 따로 받아야 했다.
+     */
+    public String enrollSecret() {
+        FleetEnrollSecretResponse res = http.get()
+                .uri("/api/v1/fleet/spec/enroll_secret")
+                .retrieve()
+                .body(FleetEnrollSecretResponse.class);
+        return res == null ? null : res.first();
+    }
+
     /** 스크립트를 호스트에서 동기 실행하고 결과를 반환. */
     public FleetScriptResult runScriptSync(int hostId, String scriptContents) {
         return http.post()

--- a/responder-service/src/main/java/com/edrdog/responderservice/fleet/FleetEnrollSecretResponse.java
+++ b/responder-service/src/main/java/com/edrdog/responderservice/fleet/FleetEnrollSecretResponse.java
@@ -1,0 +1,42 @@
+package com.edrdog.responderservice.fleet;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import java.util.List;
+
+/**
+ * {@code GET /api/v1/fleet/spec/enroll_secret} 응답 중 필요한 부분만.
+ *
+ * <p>이 값은 EDRdog enroll secret 과 다른 것이다. fleetd 패키지를 만들 때 쓰는 Fleet 자체 값이고,
+ * 원래는 Fleet 콘솔이나 {@code fleetctl get enroll-secret} 으로 봐야 한다. 그러려면 Fleet 계정이
+ * 필요해서 온보딩이 "관리자에게 문의"로 끊긴다. 서버가 이미 Fleet 관리자 토큰을 들고 있으니
+ * 대신 읽어다 준다.
+ *
+ * <p>{@code created_at} 같은 나머지 필드는 쓰지 않으므로 무시한다.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record FleetEnrollSecretResponse(Spec spec) {
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record Spec(List<Secret> secrets) {
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record Secret(String secret) {
+    }
+
+    /**
+     * 안내에 넣을 enroll secret. 회전 중이면 여러 개일 수 있는데 안내에는 하나만 들어가므로
+     * 첫 번째를 쓴다. 응답 형태가 어긋나거나 값이 비면 null 이다(빈 값을 명령어에 박지 않는다).
+     */
+    public String first() {
+        if (spec == null || spec.secrets() == null || spec.secrets().isEmpty()) {
+            return null;
+        }
+        Secret head = spec.secrets().get(0);
+        if (head == null || head.secret() == null || head.secret().isBlank()) {
+            return null;
+        }
+        return head.secret();
+    }
+}

--- a/responder-service/src/test/java/com/edrdog/responderservice/fleet/FleetEnrollSecretResponseTest.java
+++ b/responder-service/src/test/java/com/edrdog/responderservice/fleet/FleetEnrollSecretResponseTest.java
@@ -1,0 +1,57 @@
+package com.edrdog.responderservice.fleet;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Fleet enroll secret 응답에서 쓸 값을 고르는 규칙.
+ *
+ * <p>Fleet 은 secret 을 여러 개 둘 수 있다(회전 중에는 옛것과 새것이 함께 산다).
+ * 온보딩 안내에 넣을 값은 하나뿐이라 첫 번째를 쓴다. 형태가 어긋나면 값이 아니라 없음으로 답해야
+ * 화면이 잘못된 secret 을 명령어에 박아 넣지 않는다.
+ */
+class FleetEnrollSecretResponseTest {
+
+    @Test
+    @DisplayName("secret 이 여럿이면 첫 번째를 쓴다")
+    void picksFirstSecret() {
+        FleetEnrollSecretResponse res = response(
+                new FleetEnrollSecretResponse.Secret("first"),
+                new FleetEnrollSecretResponse.Secret("second"));
+
+        assertThat(res.first()).isEqualTo("first");
+    }
+
+    @Test
+    @DisplayName("secret 목록이 비어 있으면 없음")
+    void emptyList_isNull() {
+        assertThat(response().first()).isNull();
+    }
+
+    @Test
+    @DisplayName("spec 이 없으면 없음")
+    void missingSpec_isNull() {
+        assertThat(new FleetEnrollSecretResponse(null).first()).isNull();
+    }
+
+    @Test
+    @DisplayName("secrets 가 없으면 없음")
+    void missingSecrets_isNull() {
+        assertThat(new FleetEnrollSecretResponse(new FleetEnrollSecretResponse.Spec(null)).first())
+                .isNull();
+    }
+
+    @Test
+    @DisplayName("첫 값이 비어 있으면 없음으로 본다(빈 문자열을 명령어에 박지 않는다)")
+    void blankSecret_isNull() {
+        assertThat(response(new FleetEnrollSecretResponse.Secret("  ")).first()).isNull();
+    }
+
+    private static FleetEnrollSecretResponse response(FleetEnrollSecretResponse.Secret... secrets) {
+        return new FleetEnrollSecretResponse(new FleetEnrollSecretResponse.Spec(List.of(secrets)));
+    }
+}


### PR DESCRIPTION
## 포함 내용

**#119 조치 성공 시 알림을 confirmed 로** — 버튼으로 프로세스를 종료했는데 알림이 open 그대로 목록에 남아 조치 여부를 알 수 없었다. `KILLED` 를 받으면 그 알림을 `confirmed` 로 넘긴다. 실패하면 상태를 바꾸지 않는다(처리된 것처럼 보이면 안 된다). 화면 표시는 Frontend#67 에서 함께 처리했다.

**#118 GeoLite2 CI 캐시 + 재시도** — MaxMind 일일 한도(429)에 걸리면 `build` 잡부터 실패해 배포가 통째로 막힌다. 실제로 오늘 이것 때문에 CD 가 죽었다. `api-service/build/geoip` 를 캐시하고 다운로드에 재시도 4회를 넣는다. 캐시가 한 번 채워지면 하루에 몇 번을 빌드해도 다시 받지 않는다.

## 머지 시점

**MaxMind 한도가 풀린 뒤(내일) 머지할 것.** 지금 머지하면 캐시가 비어 있어 다운로드를 시도하고, 한도가 남아 있으면 빌드가 또 실패한다.

## 이미 서버에 반영된 것

한도 때문에 CI 를 못 써서 오늘은 두 이미지를 수동으로 빌드해 올렸다. 이 PR 이 머지되면 CI 가 같은 커밋으로 이미지를 다시 만들어 대체한다.

| 서비스 | 태그 |
|---|---|
| detector-service | `7b820512...` |
| api-service | `9466843c...` (기존 이미지에서 mmdb 를 꺼내 재사용) |