### PR TITLE
feat: Fleet enroll secret 조회 API + 시드 격리 권고 정리

### DIFF
--- a/api-service/src/main/java/com/edrdog/apiservice/demo/DemoData.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/demo/DemoData.java
@@ -168,11 +168,15 @@ public final class DemoData {
         };
     }
 
-    /** detector dto Alert.actionFor 와 동일 규칙. */
+    /**
+     * detector dto Alert.actionFor 와 동일 규칙.
+     *
+     * <p>CRITICAL 도 kill 이다. 격리는 구현이 없어 실제로 할 수 있는 건 프로세스 종료뿐인데,
+     * 시드만 isolate 로 권고하면 화면에서 "격리하세요" 아래 종료 버튼이 붙어 서로 어긋난다.
+     */
     private static String actionFor(String severity) {
         return switch (severity) {
-            case "CRITICAL" -> "isolate";
-            case "HIGH" -> "kill";
+            case "CRITICAL", "HIGH" -> "kill";
             default -> "notify";
         };
     }

--- a/api-service/src/main/java/com/edrdog/apiservice/responder/ResponderClient.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/responder/ResponderClient.java
@@ -46,6 +46,28 @@ public class ResponderClient {
         }
     }
 
+    /**
+     * Fleet enroll secret 조회를 responder 에 위임한다(Fleet 토큰은 responder 만 들고 있다).
+     * responder 가 죽어 있거나 오류면 null 로 답한다. 안내 화면이 값을 못 받았을 뿐이라
+     * 온보딩 나머지 단계까지 막을 이유는 없다.
+     */
+    public String fleetEnrollSecret() {
+        try {
+            FleetEnrollSecret res = http.get()
+                    .uri("/api/responder/fleet/enroll-secret")
+                    .retrieve()
+                    .body(FleetEnrollSecret.class);
+            return res == null ? null : res.secret();
+        } catch (RestClientException e) {
+            log.error("responder Fleet enroll secret 조회 실패 err={}", e.toString());
+            return null;
+        }
+    }
+
+    /** responder Fleet enroll secret 응답(FleetSecretController.FleetEnrollSecret 과 동일 필드). */
+    private record FleetEnrollSecret(String secret) {
+    }
+
     /** responder kill 요청 본문(responder KillController.KillRequest 와 동일 필드). */
     private record KillCommand(String host, String target) {
     }

--- a/api-service/src/main/java/com/edrdog/apiservice/responder/web/FleetController.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/responder/web/FleetController.java
@@ -1,0 +1,54 @@
+package com.edrdog.apiservice.responder.web;
+
+import com.edrdog.apiservice.auth.service.AuthService;
+import com.edrdog.apiservice.responder.ResponderClient;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Fleet 연동 값 조회. 지금은 온보딩 안내에 넣을 enroll secret 하나뿐이다.
+ *
+ * <p>인증은 세션 Bearer + 프론트 X-API-Key 둘 다 요구한다(면제 경로에 넣지 않는다).
+ * Fleet 은 인스턴스가 하나라 이 값에는 tenant 구분이 없다. 로그인한 사람에게만 보여준다.
+ */
+@RestController
+@RequestMapping("/api/fleet")
+@Tag(name = "fleet", description = "Fleet 연동 값 조회 (온보딩 안내용)")
+public class FleetController {
+
+    private static final String BEARER_PREFIX = "Bearer ";
+
+    private final ResponderClient responder;
+    private final AuthService auth;
+
+    public FleetController(ResponderClient responder, AuthService auth) {
+        this.responder = responder;
+        this.auth = auth;
+    }
+
+    @Operation(summary = "Fleet enroll secret 조회",
+            description = "fleetd 패키지를 만들 때 쓰는 Fleet 자체 enroll secret. tenant 별 EDRdog enroll secret 과 다른 값이다. "
+                    + "Fleet 이 응답하지 않으면 secret 이 null 이다.")
+    @GetMapping("/enroll-secret")
+    public FleetEnrollSecretResponse enrollSecret(
+            @RequestHeader(name = "Authorization", required = false) String authorization) {
+        auth.resolve(bearerToken(authorization));   // 로그인하지 않았으면 여기서 401
+        return new FleetEnrollSecretResponse(responder.fleetEnrollSecret());
+    }
+
+    /** "Bearer " 접두어를 떼서 토큰만 반환. 없으면 null. */
+    private static String bearerToken(String authorization) {
+        if (authorization == null || !authorization.startsWith(BEARER_PREFIX)) {
+            return null;
+        }
+        return authorization.substring(BEARER_PREFIX.length()).trim();
+    }
+
+    /** 조회 응답. Fleet 이 값을 주지 못하면 secret 이 null 이다. */
+    public record FleetEnrollSecretResponse(String secret) {
+    }
+}

--- a/api-service/src/test/java/com/edrdog/apiservice/demo/DemoDataTest.java
+++ b/api-service/src/test/java/com/edrdog/apiservice/demo/DemoDataTest.java
@@ -9,6 +9,7 @@ import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -56,15 +57,22 @@ class DemoDataTest {
         assertEquals(Set.of("CRITICAL", "HIGH", "MEDIUM"), severities);
     }
 
+    /** 격리는 구현이 없어 CRITICAL 도 kill 로 권고한다(detector Alert.actionFor 와 같은 규칙). */
     @Test
     void action_은_severity_규칙과_일치한다() {
         for (Alert a : DemoData.alerts(TENANT, NOW)) {
             String expected = switch (a.severity()) {
-                case "CRITICAL" -> "isolate";
-                case "HIGH" -> "kill";
+                case "CRITICAL", "HIGH" -> "kill";
                 default -> "notify";
             };
             assertEquals(expected, a.action(), a.ruleId() + " 의 action");
+        }
+    }
+
+    @Test
+    void 시드에는_격리_권고가_남아있지_않다() {
+        for (Alert a : DemoData.alerts(TENANT, NOW)) {
+            assertNotEquals("isolate", a.action(), a.ruleId() + " 의 action");
         }
     }
 

--- a/responder-service/src/main/java/com/edrdog/responderservice/api/FleetSecretController.java
+++ b/responder-service/src/main/java/com/edrdog/responderservice/api/FleetSecretController.java
@@ -1,0 +1,45 @@
+package com.edrdog.responderservice.api;
+
+import com.edrdog.responderservice.fleet.FleetClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Fleet enroll secret 조회. 온보딩의 "기기를 Fleet 에 등록" 안내가 이 값을 필요로 한다.
+ *
+ * <p>responder 는 클러스터 안에서만 열리고 앱 인증이 없다. 바깥 노출은 api-service 가 Bearer 로
+ * 인증한 뒤 프록시하는 경로 하나뿐이다(kill 과 같은 구조).
+ */
+@RestController
+@RequestMapping("/api/responder/fleet")
+public class FleetSecretController {
+
+    private static final Logger log = LoggerFactory.getLogger(FleetSecretController.class);
+
+    private final FleetClient fleet;
+
+    public FleetSecretController(FleetClient fleet) {
+        this.fleet = fleet;
+    }
+
+    /**
+     * Fleet enroll secret. Fleet 이 죽어 있거나 토큰이 만료면 500 대신 값 없음으로 답한다.
+     * 화면은 "값을 가져오지 못함"을 안내하면 되고, 조회 실패가 온보딩 전체를 깨뜨릴 이유는 없다.
+     */
+    @GetMapping("/enroll-secret")
+    public FleetEnrollSecret enrollSecret() {
+        try {
+            return new FleetEnrollSecret(fleet.enrollSecret());
+        } catch (RuntimeException e) {
+            log.error("Fleet enroll secret 조회 실패 err={}", e.toString());
+            return new FleetEnrollSecret(null);
+        }
+    }
+
+    /** 조회 응답. 값이 없으면 secret 이 null 이다. */
+    public record FleetEnrollSecret(String secret) {
+    }
+}

--- a/responder-service/src/main/java/com/edrdog/responderservice/fleet/FleetClient.java
+++ b/responder-service/src/main/java/com/edrdog/responderservice/fleet/FleetClient.java
@@ -105,6 +105,20 @@ public class FleetClient {
         throw new IllegalStateException("Fleet 에서 호스트를 찾지 못함: " + identifier);
     }
 
+    /**
+     * Fleet 자체 enroll secret(fleetd 패키지 빌드용). 없거나 형태가 어긋나면 null.
+     *
+     * <p>온보딩 안내가 "관리자에게 문의"로 끊기지 않도록 서버가 대신 읽어준다. 조치(kill)를 쓰려면
+     * 기기를 Fleet 에 등록해야 하는데, 그 값을 보려고 Fleet 콘솔 계정을 따로 받아야 했다.
+     */
+    public String enrollSecret() {
+        FleetEnrollSecretResponse res = http.get()
+                .uri("/api/v1/fleet/spec/enroll_secret")
+                .retrieve()
+                .body(FleetEnrollSecretResponse.class);
+        return res == null ? null : res.first();
+    }
+
     /** 스크립트를 호스트에서 동기 실행하고 결과를 반환. */
     public FleetScriptResult runScriptSync(int hostId, String scriptContents) {
         return http.post()

--- a/responder-service/src/main/java/com/edrdog/responderservice/fleet/FleetEnrollSecretResponse.java
+++ b/responder-service/src/main/java/com/edrdog/responderservice/fleet/FleetEnrollSecretResponse.java
@@ -1,0 +1,42 @@
+package com.edrdog.responderservice.fleet;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import java.util.List;
+
+/**
+ * {@code GET /api/v1/fleet/spec/enroll_secret} 응답 중 필요한 부분만.
+ *
+ * <p>이 값은 EDRdog enroll secret 과 다른 것이다. fleetd 패키지를 만들 때 쓰는 Fleet 자체 값이고,
+ * 원래는 Fleet 콘솔이나 {@code fleetctl get enroll-secret} 으로 봐야 한다. 그러려면 Fleet 계정이
+ * 필요해서 온보딩이 "관리자에게 문의"로 끊긴다. 서버가 이미 Fleet 관리자 토큰을 들고 있으니
+ * 대신 읽어다 준다.
+ *
+ * <p>{@code created_at} 같은 나머지 필드는 쓰지 않으므로 무시한다.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record FleetEnrollSecretResponse(Spec spec) {
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record Spec(List<Secret> secrets) {
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record Secret(String secret) {
+    }
+
+    /**
+     * 안내에 넣을 enroll secret. 회전 중이면 여러 개일 수 있는데 안내에는 하나만 들어가므로
+     * 첫 번째를 쓴다. 응답 형태가 어긋나거나 값이 비면 null 이다(빈 값을 명령어에 박지 않는다).
+     */
+    public String first() {
+        if (spec == null || spec.secrets() == null || spec.secrets().isEmpty()) {
+            return null;
+        }
+        Secret head = spec.secrets().get(0);
+        if (head == null || head.secret() == null || head.secret().isBlank()) {
+            return null;
+        }
+        return head.secret();
+    }
+}

--- a/responder-service/src/test/java/com/edrdog/responderservice/fleet/FleetEnrollSecretResponseTest.java
+++ b/responder-service/src/test/java/com/edrdog/responderservice/fleet/FleetEnrollSecretResponseTest.java
@@ -1,0 +1,57 @@
+package com.edrdog.responderservice.fleet;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Fleet enroll secret 응답에서 쓸 값을 고르는 규칙.
+ *
+ * <p>Fleet 은 secret 을 여러 개 둘 수 있다(회전 중에는 옛것과 새것이 함께 산다).
+ * 온보딩 안내에 넣을 값은 하나뿐이라 첫 번째를 쓴다. 형태가 어긋나면 값이 아니라 없음으로 답해야
+ * 화면이 잘못된 secret 을 명령어에 박아 넣지 않는다.
+ */
+class FleetEnrollSecretResponseTest {
+
+    @Test
+    @DisplayName("secret 이 여럿이면 첫 번째를 쓴다")
+    void picksFirstSecret() {
+        FleetEnrollSecretResponse res = response(
+                new FleetEnrollSecretResponse.Secret("first"),
+                new FleetEnrollSecretResponse.Secret("second"));
+
+        assertThat(res.first()).isEqualTo("first");
+    }
+
+    @Test
+    @DisplayName("secret 목록이 비어 있으면 없음")
+    void emptyList_isNull() {
+        assertThat(response().first()).isNull();
+    }
+
+    @Test
+    @DisplayName("spec 이 없으면 없음")
+    void missingSpec_isNull() {
+        assertThat(new FleetEnrollSecretResponse(null).first()).isNull();
+    }
+
+    @Test
+    @DisplayName("secrets 가 없으면 없음")
+    void missingSecrets_isNull() {
+        assertThat(new FleetEnrollSecretResponse(new FleetEnrollSecretResponse.Spec(null)).first())
+                .isNull();
+    }
+
+    @Test
+    @DisplayName("첫 값이 비어 있으면 없음으로 본다(빈 문자열을 명령어에 박지 않는다)")
+    void blankSecret_isNull() {
+        assertThat(response(new FleetEnrollSecretResponse.Secret("  ")).first()).isNull();
+    }
+
+    private static FleetEnrollSecretResponse response(FleetEnrollSecretResponse.Secret... secrets) {
+        return new FleetEnrollSecretResponse(new FleetEnrollSecretResponse.Spec(List.of(secrets)));
+    }
+}


### PR DESCRIPTION
## 무엇을

온보딩 6번(kill 대상 기기 Fleet 등록)이 Fleet 콘솔 계정을 요구해서 "관리자에게 문의"로 끊겼다. 서버가 이미 Fleet 관리자 토큰을 들고 있으니 대신 읽어주도록 했다.

또 데모 시드만 CRITICAL 을 `isolate` 로 권고하고 있어, 화면에서 "격리하세요" 아래에 종료 버튼이 붙는 모순이 보였다.

## 어떻게

- `responder`: Fleet `/api/v1/fleet/spec/enroll_secret` 조회 + 내부 엔드포인트
- `api-service`: Bearer 인증 후 프록시 (`GET /api/fleet/enroll-secret`) — kill 과 같은 구조
- `DemoData.actionFor`: CRITICAL 도 `kill` (detector `Alert.actionFor` 와 동일 규칙)

## 판단한 것

- **면제 경로에 넣지 않았다.** Fleet 은 인스턴스가 하나라 이 값에 tenant 구분이 없다. Bearer 와 X-API-Key 를 둘 다 요구한다.
- **Fleet 무응답은 값 없음으로 답한다.** 500 을 던지면 조회 실패가 온보딩 전체를 막는다. 화면은 "가져오지 못했다"를 안내하고 기존 `fleetctl` 방식으로 되돌아간다.
- secret 이 여럿이면(회전 중) 첫 번째를 쓰고, 형태가 어긋나거나 비면 null 이다. 빈 값을 명령어에 박지 않는다.

## 테스트

- `FleetEnrollSecretResponseTest` 신규 (선택 규칙, TDD)
- `DemoDataTest` 옛 규칙 수정 + 시드에 isolate 가 새어 들어오지 않는 회귀 테스트
- `:api-service:test :responder-service:test` 통과

## 남은 것

실연동(실제 Fleet 값이 내려오는지)은 **배포 후에만 확인된다.** 배포 서버에 이 엔드포인트가 아직 없다.

프론트 대응 PR은 Frontend 레포에 따로 올린다.