### PR TITLE
fix: GeoLite2 를 이미지 밖으로 빼서 MaxMind 한도가 배포를 막지 않게

### DIFF
--- a/api-service/build.gradle
+++ b/api-service/build.gradle
@@ -34,23 +34,35 @@ tasks.register('downloadGeoLite2') {
         def tarFile = new File(outDir, 'GeoLite2-Country.tar.gz')
         def url = "https://download.maxmind.com/app/geoip_download?edition_id=GeoLite2-Country&license_key=${key}&suffix=tar.gz"
         logger.lifecycle('[geoip] GeoLite2-Country 다운로드 중...')
-        // MaxMind 는 짧은 시간에 여러 번 받으면 429 를 준다. 실제로 배포가 이것 때문에 막힌 적이 있다.
-        // 잠깐 기다렸다 다시 시도한다. 그래도 안 되면 실패시킨다(mmdb 없는 jar 는 지도가 빈 채로 뜬다).
+        // MaxMind 는 하루 다운로드 한도가 있어 429 를 준다. 잠깐 기다렸다 다시 시도한다.
+        //
+        // 그래도 안 되면 빌드를 죽이지 않고 넘어간다. 예전에는 여기서 실패시켰는데, 그 바람에
+        // 한도에 걸린 날은 api-service 뿐 아니라 빌드 전체가 멈춰 배포가 통째로 막혔다.
+        // 지금은 운영에서 mmdb 를 이미지 밖(GEOIP_DB_PATH 볼륨)에서 읽으므로, jar 에 번들이
+        // 없어도 지도는 그대로 동작한다. 볼륨과 번들이 둘 다 없을 때만 지도가 비고,
+        // 그건 GeoIpResolver 가 기동 로그에 남긴다.
         def attempts = 4
-        for (int i = 1; ; i++) {
+        def downloaded = false
+        for (int i = 1; i <= attempts; i++) {
             try {
                 tarFile.withOutputStream { os ->
                     new URI(url).toURL().openStream().withCloseable { input -> os << input }
                 }
+                downloaded = true
                 break
             } catch (IOException e) {
                 if (i >= attempts) {
-                    throw new GradleException("[geoip] ${attempts}회 시도 실패: ${e.message}", e)
+                    logger.warn("[geoip] ${attempts}회 시도 실패: ${e.message} → mmdb 번들 없이 계속한다. "
+                            + '운영은 GEOIP_DB_PATH 볼륨의 파일을 쓴다.')
+                    break
                 }
                 def waitSec = 15 * i
                 logger.warn("[geoip] 다운로드 실패(${e.message}) → ${waitSec}초 후 재시도 (${i}/${attempts})")
                 Thread.sleep(waitSec * 1000L)
             }
+        }
+        if (!downloaded) {
+            return   // 받은 게 없으니 풀 것도 없다. 번들 없는 jar 로 계속한다.
         }
         // tar.gz 안의 GeoLite2-Country_YYYYMMDD/GeoLite2-Country.mmdb 를 평탄화해 추출
         copy {

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -107,6 +107,43 @@ Service 는 매니페스트가 서버 실제 상태(NodePort 30084)와 같아 ap
   **`extraPortMappings` 는 클러스터 생성 시에만 반영**되므로 기존 클러스터라면 다시 만들거나
   `kubectl -n edrdog port-forward svc/api-service-osquery 8443:8443` 로 우회한다.
 
+## GeoLite2 (위협 지도)
+
+mmdb 는 이미지 안이 아니라 **호스트 디스크**에 둔다. `api-service` 가 `GEOIP_DB_PATH`
+(`/etc/geoip/GeoLite2-Country.mmdb`, hostPath `/opt/edrdog/geoip`)를 먼저 읽고, 없으면 jar 번들로 넘어간다.
+
+이렇게 하는 이유: MaxMind 는 하루 다운로드 한도가 있어 429 를 준다. 빌드가 mmdb 를 못 받으면
+예전에는 빌드 전체가 멈춰 **배포가 통째로 막혔다**. 그렇다고 mmdb 없는 이미지를 올리면 위협 지도가
+조용히 빈다. 파일을 호스트에 두면 이미지를 어떻게 갈아도 지도가 살아 있고, 빌드는 429 가 나도
+경고만 남기고 지나간다.
+
+파일 배치는 1회다. 지금 도는 파드의 jar 에서 꺼내 쓰면 새로 받을 필요가 없다.
+
+```bash
+# 1) 지금 도는 파드의 jar 에서 mmdb 를 꺼낸다 (컨테이너에 unzip 이 없으므로 jar 를 통째로 복사)
+POD=$(sudo kubectl -n edrdog get pod -l app=api-service -o jsonpath='{.items[0].metadata.name}')
+sudo kubectl -n edrdog cp "$POD:/app/app.jar" /tmp/api.jar
+sudo mkdir -p /opt/edrdog/geoip
+sudo unzip -p /tmp/api.jar BOOT-INF/classes/GeoLite2-Country.mmdb > /tmp/GeoLite2-Country.mmdb
+sudo install -m 644 /tmp/GeoLite2-Country.mmdb /opt/edrdog/geoip/GeoLite2-Country.mmdb
+rm -f /tmp/api.jar /tmp/GeoLite2-Country.mmdb
+
+# 2) 크기가 0 이 아닌지 확인한다. 0 이면 그 이미지에 번들이 없던 것이다.
+ls -l /opt/edrdog/geoip/GeoLite2-Country.mmdb
+
+# 3) 매니페스트를 적용한다 (위 "매니페스트 변경을 배포서버에 반영하기" 와 같은 순서)
+IMG=$(sudo kubectl -n edrdog get deploy/api-service -o jsonpath='{.spec.template.spec.containers[0].image}')
+sudo kubectl -n edrdog apply -f k8s/api-service.yaml
+sudo kubectl -n edrdog set image deployment/api-service api-service="$IMG"
+sudo kubectl -n edrdog rollout status deployment/api-service
+
+# 4) 파일에서 읽었는지 로그로 확인한다
+sudo kubectl -n edrdog logs deploy/api-service | grep 'GeoIP DB 로드'
+```
+
+4번이 `GeoIP DB 로드(파일)` 이면 성공이다. `(클래스패스)` 면 볼륨의 파일을 못 읽어 jar 번들로
+넘어간 것이고, 그 상태로 mmdb 없는 이미지가 배포되면 지도가 빈다.
+
 ## 시크릿 (Infisical)
 
 매니페스트에 평문으로 박혀 있던 값(`DB_PASSWORD`, `CLICKHOUSE_PASSWORD` 등)을 Infisical 로 옮긴다.

--- a/k8s/api-service.yaml
+++ b/k8s/api-service.yaml
@@ -70,6 +70,14 @@ spec:
             # 메트릭/트레이스 OTLP 수집기 (k8s/otel-lgtm.yaml)
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: "http://otel-lgtm:4318"
+            # GeoLite2 mmdb 를 이미지 밖(호스트 디스크)에서 읽는다. GeoIpResolver 는 이 경로를
+            # 먼저 보고, 없으면 jar 에 번들된 것으로 넘어간다.
+            #
+            # 이미지 안에만 두면 MaxMind 다운로드가 429 로 막힌 날에는 배포 자체가 불가능하고
+            # (실제로 배포가 막혔다), 억지로 mmdb 없이 이미지를 올리면 위협 지도가 조용히 빈다.
+            # 파일을 호스트에 두면 이미지를 어떻게 갈아도 지도가 살아 있다.
+            - name: GEOIP_DB_PATH
+              value: "/etc/geoip/GeoLite2-Country.mmdb"
           readinessProbe:
             httpGet:
               path: /actuator/health
@@ -93,6 +101,9 @@ spec:
             - name: osquery-tls
               mountPath: /etc/osquery-tls
               readOnly: true
+            - name: geoip
+              mountPath: /etc/geoip
+              readOnly: true
       volumes:
         # optional:true 라 Secret 이 없어도 파드는 뜬다(빈 디렉터리로 마운트). 그때는 커넥터도 꺼져 있다.
         - name: osquery-tls
@@ -102,6 +113,13 @@ spec:
             items:
               - key: keystore.p12
                 path: keystore.p12
+        # 단일 노드 k3s 라 hostPath 로 충분하다. 파일이 없어도 파드는 그대로 뜨고
+        # (DirectoryOrCreate 로 빈 디렉터리가 만들어진다) GeoIpResolver 가 jar 번들로 넘어간다.
+        # 배치 절차는 k8s/README.md 참고.
+        - name: geoip
+          hostPath:
+            path: /opt/edrdog/geoip
+            type: DirectoryOrCreate
 ---
 # 프론트/외부 API 진입점. NodePort 30084 — 호스트(EC2)에서 도는 Caddy 가 localhost:30084 로 프록시한다.
 # 배포서버가 이미 이 형태로 떠 있는데 여기가 ClusterIP 로 남아 있어서, 이 파일을 apply 하면


### PR DESCRIPTION
## 문제

MaxMind 하루 한도(429)에 걸리면 `downloadGeoLite2` 가 빌드를 죽인다. 그 바람에 api-service 뿐 아니라 **빌드 잡 전체가 멈춰 배포가 통째로 막힌다.** 오늘 #120 머지 후 실제로 그랬다.

그렇다고 mmdb 없는 이미지를 올리면 위협 지도가 조용히 빈다. 지금 mmdb 는 **이미지 안에만** 있어서, 이미지를 갈아끼우는 순간 사라진다.

## 어떻게

`GeoIpResolver` 는 원래 `GEOIP_DB_PATH` 파일을 먼저 보고 없으면 jar 번들로 넘어간다. 그 경로를 실제로 쓴다.

- mmdb 를 호스트 디스크(hostPath `/opt/edrdog/geoip`)에 두고 `/etc/geoip` 로 마운트
- 빌드는 다운로드에 실패해도 경고만 남기고 지나간다. 받은 게 없으면 압축 해제도 건너뛴다

이미지를 어떻게 갈아도 지도가 살아 있고, 429 가 나도 배포가 막히지 않는다.

## 판단한 것

- **hostPath 로 충분하다.** 단일 노드 k3s 다. 파일이 없어도 `DirectoryOrCreate` 라 파드는 그대로 뜨고 jar 번들로 넘어간다
- **mmdb 를 레포에 커밋하지 않았다.** GeoLite2 는 재배포에 제약이 있다
- 키가 없을 때 skip 하던 기존 경로와 결과가 같다. 로컬에서 키 없이 `bootJar` 통과 확인

## 배포 전 서버 작업 1회

파일 배치가 선행돼야 효과가 있다. 지금 도는 파드의 jar 에서 꺼내 쓰면 새로 받을 필요가 없다. 절차는 `k8s/README.md` 의 "GeoLite2 (위협 지도)" 에 적었다.

적용 후 `GeoIP DB 로드(파일)` 로그가 뜨면 성공이다. `(클래스패스)` 면 볼륨을 못 읽어 번들로 넘어간 것이고, 그 상태로 번들 없는 이미지가 배포되면 지도가 빈다.