### PR TITLE
fix: Windows 수집이 조용히 0건이던 문제 (플랫폼 판정 + 서비스 등록)

### DIFF
--- a/api-service/src/main/java/com/edrdog/apiservice/osquery/OsqueryConfig.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/osquery/OsqueryConfig.java
@@ -100,17 +100,40 @@ public final class OsqueryConfig {
             }
             """;
 
+    /** osquery PlatformType 비트마스크의 TYPE_WINDOWS. */
+    private static final int TYPE_WINDOWS = 0x02;
+
     /**
-     * enroll 시 저장한 platform 으로 스케줄을 고른다. 값에 windows 가 들어가면 Windows, 그 외(darwin/미상)는 macOS.
-     * osquery {@code platform_type} 은 버전에 따라 문자열이 다를 수 있어 느슨하게 판정한다.
-     * ("darwin" 이 "win" 을 부분문자열로 포함하므로 "windows" 로 정확히 본다.)
+     * enroll 시 저장한 platform 으로 스케줄을 고른다. Windows 면 ETW 스케줄, 그 외(darwin/미상)는 macOS.
      */
     public static String forPlatform(String platform) {
         return isWindows(platform) ? WINDOWS_JSON : MACOS_JSON;
     }
 
+    /**
+     * osquery 가 enroll 에 싣는 {@code platform_type} 은 이름이 아니라 <b>비트마스크 숫자</b>다.
+     * 실기기에서 Windows 는 {@code 2}, macOS 는 {@code 21}(POSIX 1 + BSD 4 + OSX 16) 로 들어왔다.
+     *
+     * <p>문자열로만 보면 숫자가 전부 macOS 로 떨어져, Windows 엔드포인트가 macOS 스케줄을 받는다.
+     * 그러면 {@code es_process_events} 처럼 그 OS 에 없는 테이블을 조회하게 되고, 오류 없이
+     * 결과만 비어서 <b>수집이 조용히 0건</b>이 된다. 실제로 그렇게 막혔다.
+     *
+     * <p>이름도 함께 받는다. 값의 형태가 버전에 따라 다를 수 있고, 이름으로 오면 그쪽이 더 분명하다.
+     * ("darwin" 이 "win" 을 부분문자열로 포함하므로 "windows" 로 정확히 본다.)
+     */
     private static boolean isWindows(String platform) {
-        return platform != null && platform.toLowerCase().contains("windows");
+        if (platform == null) {
+            return false;
+        }
+        String value = platform.trim().toLowerCase();
+        if (value.contains("windows")) {
+            return true;
+        }
+        try {
+            return (Integer.parseInt(value) & TYPE_WINDOWS) != 0;
+        } catch (NumberFormatException e) {
+            return false;   // 이름도 숫자도 아니면 판단 근거가 없다. macOS 로 폴백한다.
+        }
     }
 
     private OsqueryConfig() {

--- a/api-service/src/test/java/com/edrdog/apiservice/osquery/OsqueryConfigTest.java
+++ b/api-service/src/test/java/com/edrdog/apiservice/osquery/OsqueryConfigTest.java
@@ -69,4 +69,32 @@ class OsqueryConfigTest {
         assertTrue(s.has("process_events"), "플랫폼 미상이면 mac 스케줄로 폴백");
         assertTrue(s.has("socket_events"));
     }
+
+    /**
+     * osquery 가 enroll 에 싣는 platform_type 은 이름이 아니라 비트마스크 숫자다.
+     * 실기기에서 Windows 는 2, macOS 는 21 로 들어왔다(POSIX 1 + BSD 4 + OSX 16).
+     * 문자열로만 판정하면 Windows 가 macOS 스케줄을 받아 없는 테이블을 조회하고, 수집이 조용히 0건이 된다.
+     */
+    @Test
+    void platform_type_이_숫자로_와도_Windows_를_알아본다() throws Exception {
+        JsonNode s = schedule("2");
+
+        assertTrue(s.has("process_etw_events"), "platform_type=2 는 Windows(TYPE_WINDOWS=0x02)");
+        assertFalse(s.has("process_events"), "mac 스케줄을 내려주면 없는 테이블을 조회하게 된다");
+    }
+
+    @Test
+    void platform_type_숫자가_macOS_면_mac_스케줄을_내려준다() throws Exception {
+        JsonNode s = schedule("21");
+
+        assertTrue(s.has("process_events"), "platform_type=21 은 macOS(POSIX+BSD+OSX)");
+        assertFalse(s.has("process_etw_events"));
+    }
+
+    @Test
+    void Windows_비트가_없는_숫자는_macOS_로_폴백한다() throws Exception {
+        JsonNode s = schedule("9");   // POSIX(1) + LINUX(8)
+
+        assertTrue(s.has("process_events"), "Windows 비트가 없으면 mac 스케줄로 폴백");
+    }
 }

--- a/collector-service/scripts/edrdog-install-windows.ps1
+++ b/collector-service/scripts/edrdog-install-windows.ps1
@@ -124,8 +124,23 @@ if (Get-Service osqueryd -ErrorAction SilentlyContinue) {
     sc.exe delete osqueryd | Out-Null
     Start-Sleep -Seconds 2
 }
-sc.exe create osqueryd binPath= "`"$OsqueryExe`" --flagfile=`"$FlagsPath`"" start= auto DisplayName= "osquery daemon (EDRdog)" | Out-Null
-Start-Service osqueryd
+# sc.exe 가 아니라 New-Service 를 쓴다. PowerShell 5.1 은 외부 명령에 따옴표가 들어간 인자를
+# 그대로 넘기지 못해서, 공백이 있는 경로("C:\Program Files\...")를 binPath 로 주면 등록이
+# 실패한다. 게다가 sc.exe 결과를 Out-Null 로 버리면 그 실패가 화면에 남지 않아, 다음 줄의
+# Start-Service 에서 "서비스를 찾을 수 없다"는 엉뚱한 오류로만 드러난다. 실기기에서 그랬다.
+$binPath = '"{0}" --flagfile="{1}"' -f $OsqueryExe, $FlagsPath
+try {
+    New-Service -Name osqueryd -BinaryPathName $binPath -StartupType Automatic `
+        -DisplayName 'osquery daemon (EDRdog)' -ErrorAction Stop | Out-Null
+} catch {
+    Fail "서비스 등록 실패: $_"
+}
+
+try {
+    Start-Service osqueryd -ErrorAction Stop
+} catch {
+    Fail "서비스 시작 실패: $_"
+}
 Start-Sleep -Seconds 3
 
 $svc = Get-Service osqueryd


### PR DESCRIPTION
Windows 실기기 테스트에서 드러난 두 가지. 둘 다 **실패했는데 아무 말도 안 하는** 종류라 원인을 찾기 어려웠다.

## 1. Windows 엔드포인트가 macOS 수집 스케줄을 받고 있었다

osquery 설치와 서버 연결까지 정상인데 수집이 0건이었다. 화면 기기 목록에도 안 나타났다.

osquery 가 enroll 에 싣는 `platform_type` 은 이름이 아니라 **비트마스크 숫자**다. 실기기 DB 값이다.

```
DESKTOP-5JINDPN                     platform = 2    (TYPE_WINDOWS)
gimdonghyeon-ui-MacBookPro.local    platform = 21   (POSIX 1 + BSD 4 + OSX 16)
```

판정이 `contains("windows")` 뿐이라 숫자는 전부 macOS 로 떨어졌다. Windows 엔드포인트가 `es_process_events` 처럼 그 OS 에 없는 테이블을 조회했고, **오류 없이 결과만 비어서** 수집이 0건이 됐다. macOS 는 우연히 맞아서 지금까지 안 드러났다.

이름과 숫자를 모두 받도록 고쳤다. 숫자면 `TYPE_WINDOWS` 비트로 판정한다.

**기존 테스트는 `"windows"` 문자열만 넣어서 통과했다.** 실기기가 실제로 보내는 값(2, 21, 9)으로 테스트를 더했다.

## 2. 서비스 등록 실패가 화면에 안 나왔다

설치 스크립트가 여기서 막혔는데 화면에는 이것만 나온다.

```
Start-Service : 서비스 이름이 'osqueryd'인 서비스를 찾을 수 없습니다.
```

진짜 원인은 그 앞줄이다. `sc.exe create` 가 실패했는데 `| Out-Null` 이 오류까지 버려서 아무 메시지도 남지 않았다.

`sc.exe` 가 실패한 이유는 인자 전달이다. PowerShell 5.1 은 외부 명령에 따옴표가 들어간 인자를 그대로 넘기지 못해서, 공백이 있는 경로(`C:\Program Files\...`)를 `binPath` 로 주면 깨진다. 같은 값으로 `New-Service` 를 부르면 정상 등록되는 것을 실기기에서 확인했다.

- `sc.exe create` → `New-Service`
- 등록과 시작을 각각 try/catch 로 감싸 실패한 자리에서 멈추고 이유를 출력

## 배포 후

이미 등록된 Windows 호스트는 재설치할 필요가 없다. `config_refresh=60` 이라 api-service 가 새로 뜨면 1분 안에 올바른 스케줄을 받는다.

프론트 대응(설치 명령 절대 경로)은 Frontend 레포에 따로 올린다.