### PR TITLE
fix: Windows 파일 감시가 없는 테이블을 조회하던 문제

### DIFF
--- a/api-service/src/main/java/com/edrdog/apiservice/osquery/OsqueryConfig.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/osquery/OsqueryConfig.java
@@ -92,9 +92,9 @@ public final class OsqueryConfig {
                   "description": "스크립트 인터프리터 실행. cmdline 의 스크립트 경로로 임시/다운로드 실행을 detector 가 MEDIUM(T1059) 판정"
                 },
                 "file_events": {
-                  "query": "SELECT target_path, action, time FROM file_events WHERE action IN ('CREATED', 'UPDATED', 'MOVED_TO')",
+                  "query": "SELECT path, action, time FROM ntfs_journal_events WHERE path LIKE '%\\\\Start Menu\\\\Programs\\\\Startup\\\\%'",
                   "interval": 10,
-                  "description": "시작프로그램(Startup) 경로 FIM. target_path 로 지속성 확보를 detector 가 MEDIUM(T1547) 판정. file_paths.autorun 참조"
+                  "description": "시작프로그램(Startup) 경로 FIM. path 로 지속성 확보를 detector 가 MEDIUM(T1547) 판정"
                 }
               }
             }

--- a/api-service/src/test/java/com/edrdog/apiservice/osquery/OsqueryConfigTest.java
+++ b/api-service/src/test/java/com/edrdog/apiservice/osquery/OsqueryConfigTest.java
@@ -97,4 +97,32 @@ class OsqueryConfigTest {
 
         assertTrue(s.has("process_events"), "Windows 비트가 없으면 mac 스케줄로 폴백");
     }
+
+    /**
+     * file_events 는 macOS/Linux 전용 테이블이다. Windows 에서 그 쿼리를 내려주면
+     * "no such table" 로 실패한다(실기기 로그로 확인). NTFS USN 저널은 별도 테이블을 쓴다.
+     */
+    @Test
+    void windows_파일_감시는_ntfs_journal_events_를_쓴다() throws Exception {
+        JsonNode s = schedule("windows");
+
+        String query = s.get("file_events").get("query").asText();
+        assertTrue(query.contains("ntfs_journal_events"), "Windows 파일 감시는 NTFS USN 저널 테이블");
+        assertFalse(query.contains("FROM file_events"), "Windows 에 file_events 테이블은 없다");
+        // 백슬래시가 하나여야 실제 Windows 경로와 매칭된다. 이스케이프가 한 겹 남으면
+        // 조건이 절대 참이 되지 않아, 오류 없이 결과만 0건이 된다.
+        assertTrue(query.contains("%\\Start Menu\\Programs\\Startup\\%"),
+                "시작프로그램 경로로 걸러야 한다(백슬래시 1개). 실제 쿼리: " + query);
+    }
+
+    @Test
+    void windows_파일_이벤트는_path_컬럼을_내려준다() throws Exception {
+        JsonNode s = schedule("windows");
+
+        // ntfs_journal_events 의 경로 컬럼은 target_path 가 아니라 path 다(실기기 PRAGMA 로 확인).
+        // RawEventMapper 는 target_path 가 없으면 path 로 폴백하므로 별칭 없이 그대로 내려도 된다.
+        String query = s.get("file_events").get("query").asText();
+        assertTrue(query.contains("path"), "판정에 쓸 경로 컬럼이 있어야 한다");
+        assertTrue(query.contains("time"), "이벤트 시각이 있어야 한다");
+    }
 }


### PR DESCRIPTION
## 증상

플랫폼 판정(#127)을 고쳐 Windows 가 제 스케줄을 받게 되자 다음 오류가 드러났다.

```
Error executing scheduled query file_events: no such table: file_events
```

## 원인

`file_events` 는 macOS/Linux 전용 테이블이다. Windows 의 파일 이벤트는 NTFS USN 저널을 읽는 `ntfs_journal_events` 로 온다. 플래그(`--enable_ntfs_event_publisher`)는 맞게 켜져 있었고 쿼리만 macOS 것을 그대로 쓰고 있었다.

## 실기기에서 확인한 것

```
PRAGMA table_info(ntfs_journal_events)
→ action, category, old_path, path, record_timestamp, record_usn,
  node_ref_number, parent_ref_number, drive_letter, file_attributes, partial, time
```

경로 컬럼이 `target_path` 가 아니라 `path` 다. `RawEventMapper` 가 `target_path` 없으면 `path` 로 폴백하므로 별칭 없이 그대로 내린다.

## 판단한 것

**action 값으로 거르지 않고 경로로 거른다.** USN 이벤트 타입 문자열을 확인하지 못했고, 틀린 값을 넣으면 또 오류 없이 0건이 된다. 자동실행 경로에 무엇이 생기든 R4 의 판정 대상이라 경로 필터로 충분하다. 볼륨 전체를 받지 않도록 Startup 경로로 좁혔다.

**쿼리 안 백슬래시가 한 겹으로 나가는지 테스트로 고정했다.** 텍스트블록과 JSON 이스케이프가 겹쳐 있어서, 한 겹 남으면 조건이 절대 참이 되지 않고 역시 조용히 0건이 된다.

## 영향

이 쿼리 하나만 실패하고 있었으므로 프로세스·스크립트 수집(R1, R3)은 이미 정상이었다. 이 수정으로 R4(자동실행 경로 파일 생성)까지 동작한다.