### PR TITLE
fix: Windows 수집 쿼리가 없는 테이블·컬럼을 조회하던 문제

### DIFF
--- a/api-service/src/main/java/com/edrdog/apiservice/osquery/OsqueryConfig.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/osquery/OsqueryConfig.java
@@ -82,12 +82,12 @@ public final class OsqueryConfig {
               },
               "schedule": {
                 "process_etw_events": {
-                  "query": "SELECT e.path AS path, e.cmdline AS cmdline, p.name AS parent, e.pid AS pid, e.time AS time FROM process_etw_events e LEFT JOIN processes p ON e.ppid = p.pid WHERE e.type = 'ProcessStart'",
+                  "query": "SELECT e.path AS path, e.cmdline AS cmdline, p.name AS parent, e.pid AS pid FROM process_etw_events e LEFT JOIN processes p ON e.ppid = p.pid WHERE e.type = 'ProcessStart'",
                   "interval": 10,
                   "description": "프로세스 생성 이벤트(ETW)"
                 },
                 "script_etw_events": {
-                  "query": "SELECT e.path AS path, e.cmdline AS cmdline, p.name AS parent, e.pid AS pid, e.time AS time FROM process_etw_events e LEFT JOIN processes p ON e.ppid = p.pid WHERE e.type = 'ProcessStart' AND (e.path LIKE '%\\\\powershell.exe' OR e.path LIKE '%\\\\cmd.exe' OR e.path LIKE '%\\\\wscript.exe' OR e.path LIKE '%\\\\cscript.exe' OR e.path LIKE '%\\\\mshta.exe')",
+                  "query": "SELECT e.path AS path, e.cmdline AS cmdline, p.name AS parent, e.pid AS pid FROM process_etw_events e LEFT JOIN processes p ON e.ppid = p.pid WHERE e.type = 'ProcessStart' AND (e.path LIKE '%\\\\powershell.exe' OR e.path LIKE '%\\\\cmd.exe' OR e.path LIKE '%\\\\wscript.exe' OR e.path LIKE '%\\\\cscript.exe' OR e.path LIKE '%\\\\mshta.exe')",
                   "interval": 10,
                   "description": "스크립트 인터프리터 실행. cmdline 의 스크립트 경로로 임시/다운로드 실행을 detector 가 MEDIUM(T1059) 판정"
                 },

--- a/api-service/src/main/java/com/edrdog/apiservice/osquery/OsqueryConfig.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/osquery/OsqueryConfig.java
@@ -92,9 +92,9 @@ public final class OsqueryConfig {
                   "description": "스크립트 인터프리터 실행. cmdline 의 스크립트 경로로 임시/다운로드 실행을 detector 가 MEDIUM(T1059) 판정"
                 },
                 "file_events": {
-                  "query": "SELECT target_path, action, time FROM file_events WHERE action IN ('CREATED', 'UPDATED', 'MOVED_TO')",
+                  "query": "SELECT path, action, time FROM ntfs_journal_events WHERE path LIKE '%\\\\Start Menu\\\\Programs\\\\Startup\\\\%'",
                   "interval": 10,
-                  "description": "시작프로그램(Startup) 경로 FIM. target_path 로 지속성 확보를 detector 가 MEDIUM(T1547) 판정. file_paths.autorun 참조"
+                  "description": "시작프로그램(Startup) 경로 FIM. path 로 지속성 확보를 detector 가 MEDIUM(T1547) 판정"
                 }
               }
             }

--- a/api-service/src/test/java/com/edrdog/apiservice/osquery/OsqueryConfigTest.java
+++ b/api-service/src/test/java/com/edrdog/apiservice/osquery/OsqueryConfigTest.java
@@ -97,4 +97,32 @@ class OsqueryConfigTest {
 
         assertTrue(s.has("process_events"), "Windows 비트가 없으면 mac 스케줄로 폴백");
     }
+
+    /**
+     * file_events 는 macOS/Linux 전용 테이블이다. Windows 에서 그 쿼리를 내려주면
+     * "no such table" 로 실패한다(실기기 로그로 확인). NTFS USN 저널은 별도 테이블을 쓴다.
+     */
+    @Test
+    void windows_파일_감시는_ntfs_journal_events_를_쓴다() throws Exception {
+        JsonNode s = schedule("windows");
+
+        String query = s.get("file_events").get("query").asText();
+        assertTrue(query.contains("ntfs_journal_events"), "Windows 파일 감시는 NTFS USN 저널 테이블");
+        assertFalse(query.contains("FROM file_events"), "Windows 에 file_events 테이블은 없다");
+        // 백슬래시가 하나여야 실제 Windows 경로와 매칭된다. 이스케이프가 한 겹 남으면
+        // 조건이 절대 참이 되지 않아, 오류 없이 결과만 0건이 된다.
+        assertTrue(query.contains("%\\Start Menu\\Programs\\Startup\\%"),
+                "시작프로그램 경로로 걸러야 한다(백슬래시 1개). 실제 쿼리: " + query);
+    }
+
+    @Test
+    void windows_파일_이벤트는_path_컬럼을_내려준다() throws Exception {
+        JsonNode s = schedule("windows");
+
+        // ntfs_journal_events 의 경로 컬럼은 target_path 가 아니라 path 다(실기기 PRAGMA 로 확인).
+        // RawEventMapper 는 target_path 가 없으면 path 로 폴백하므로 별칭 없이 그대로 내려도 된다.
+        String query = s.get("file_events").get("query").asText();
+        assertTrue(query.contains("path"), "판정에 쓸 경로 컬럼이 있어야 한다");
+        assertTrue(query.contains("time"), "이벤트 시각이 있어야 한다");
+    }
 }

--- a/api-service/src/test/java/com/edrdog/apiservice/osquery/OsqueryConfigTest.java
+++ b/api-service/src/test/java/com/edrdog/apiservice/osquery/OsqueryConfigTest.java
@@ -115,6 +115,34 @@ class OsqueryConfigTest {
                 "시작프로그램 경로로 걸러야 한다(백슬래시 1개). 실제 쿼리: " + query);
     }
 
+    /**
+     * process_etw_events 에는 time 컬럼이 없다. 실기기 PRAGMA 로 확인한 컬럼은
+     * type / pid / ppid / session_id / flags / exit_code / path / cmdline / username /
+     * token_elevation_type / token_elevation_status / mandatory_label / datetime 이다.
+     *
+     * <p>없는 컬럼을 선택하면 쿼리 전체가 실패해 수집이 0건이 된다. 시각은 result-log 최상위의
+     * unixTime 으로 들어오므로(RawEventMapper) 컬럼을 고를 필요가 없다.
+     */
+    @Test
+    void windows_프로세스_쿼리는_없는_time_컬럼을_고르지_않는다() throws Exception {
+        JsonNode s = schedule("windows");
+
+        for (String key : new String[]{"process_etw_events", "script_etw_events"}) {
+            String query = s.get(key).get("query").asText();
+            assertFalse(query.contains("e.time"), key + " 는 없는 컬럼을 고르면 안 된다: " + query);
+            assertTrue(query.contains("e.ppid"), key + " 는 parent 조인에 ppid 를 쓴다");
+        }
+    }
+
+    /** 실행 경로 LIKE 도 백슬래시가 하나여야 매칭된다. 한 겹 남으면 조용히 0건이 된다. */
+    @Test
+    void windows_스크립트_쿼리의_경로_패턴은_백슬래시가_하나다() throws Exception {
+        String query = schedule("windows").get("script_etw_events").get("query").asText();
+
+        assertTrue(query.contains("'%\\powershell.exe'"), "실제 쿼리: " + query);
+        assertTrue(query.contains("'%\\cmd.exe'"), "실제 쿼리: " + query);
+    }
+
     @Test
     void windows_파일_이벤트는_path_컬럼을_내려준다() throws Exception {
         JsonNode s = schedule("windows");


### PR DESCRIPTION
플랫폼 판정(#128)을 고쳐 Windows 가 제 스케줄을 받게 되자, 그 스케줄 안의 쿼리들이 전부 macOS 것을 그대로 쓰고 있다는 게 드러났다. 셋 다 **오류 없이 결과만 비어** 수집이 0건이 되는 종류다.

## 1. 파일 감시: 없는 테이블

```
Error executing scheduled query file_events: no such table: file_events
```

`file_events` 는 macOS/Linux 전용이다. Windows 는 NTFS USN 저널을 읽는 `ntfs_journal_events` 를 쓴다. 실기기 PRAGMA 로 컬럼을 확인했고, 경로 컬럼이 `target_path` 가 아니라 `path` 였다(`RawEventMapper` 가 폴백하므로 별칭 없이 내린다).

action 값으로 거르지 않고 경로로 거른다. USN 이벤트 타입 문자열을 확인하지 못했고, 틀리면 또 0건이 된다. 자동실행 경로에 무엇이 생기든 R4 판정 대상이라 경로 필터로 충분하다.

## 2. 프로세스 쿼리: 없는 컬럼

`process_etw_events` 컬럼(실기기 PRAGMA):

```
type, pid, ppid, session_id, flags, exit_code, path, cmdline,
username, token_elevation_type, token_elevation_status, mandatory_label, datetime
```

`time` 이 없는데 `e.time AS time` 을 고르고 있었다. 쿼리 전체가 실패했다. `process_etw_events` 와 `script_etw_events` 둘 다.

시각은 result-log 최상위 `unixTime` 으로 들어오므로 컬럼을 고를 필요가 없다.

## 3. 이스케이프

경로 LIKE 패턴의 백슬래시가 한 겹으로 나가는지 테스트로 고정했다. 텍스트블록과 JSON 이스케이프가 겹쳐 있어 한 겹 남으면 조건이 절대 참이 되지 않고, 역시 조용히 0건이 된다.

## 검증

`:api-service:test`, `:collector-service:test` 통과. 실기기에서 확인한 스키마를 테스트로 박아 뒀다.

배포 후 `config_refresh=60` 이라 Windows 호스트가 1분 안에 새 스케줄을 받는다. 재설치는 필요 없다.