### PR TITLE
fix: Windows 프로세스 쿼리가 없는 time 컬럼을 고르던 문제

### DIFF
--- a/api-service/src/main/java/com/edrdog/apiservice/osquery/OsqueryConfig.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/osquery/OsqueryConfig.java
@@ -82,12 +82,12 @@ public final class OsqueryConfig {
               },
               "schedule": {
                 "process_etw_events": {
-                  "query": "SELECT e.path AS path, e.cmdline AS cmdline, p.name AS parent, e.pid AS pid, e.time AS time FROM process_etw_events e LEFT JOIN processes p ON e.ppid = p.pid WHERE e.type = 'ProcessStart'",
+                  "query": "SELECT e.path AS path, e.cmdline AS cmdline, p.name AS parent, e.pid AS pid FROM process_etw_events e LEFT JOIN processes p ON e.ppid = p.pid WHERE e.type = 'ProcessStart'",
                   "interval": 10,
                   "description": "프로세스 생성 이벤트(ETW)"
                 },
                 "script_etw_events": {
-                  "query": "SELECT e.path AS path, e.cmdline AS cmdline, p.name AS parent, e.pid AS pid, e.time AS time FROM process_etw_events e LEFT JOIN processes p ON e.ppid = p.pid WHERE e.type = 'ProcessStart' AND (e.path LIKE '%\\\\powershell.exe' OR e.path LIKE '%\\\\cmd.exe' OR e.path LIKE '%\\\\wscript.exe' OR e.path LIKE '%\\\\cscript.exe' OR e.path LIKE '%\\\\mshta.exe')",
+                  "query": "SELECT e.path AS path, e.cmdline AS cmdline, p.name AS parent, e.pid AS pid FROM process_etw_events e LEFT JOIN processes p ON e.ppid = p.pid WHERE e.type = 'ProcessStart' AND (e.path LIKE '%\\\\powershell.exe' OR e.path LIKE '%\\\\cmd.exe' OR e.path LIKE '%\\\\wscript.exe' OR e.path LIKE '%\\\\cscript.exe' OR e.path LIKE '%\\\\mshta.exe')",
                   "interval": 10,
                   "description": "스크립트 인터프리터 실행. cmdline 의 스크립트 경로로 임시/다운로드 실행을 detector 가 MEDIUM(T1059) 판정"
                 },

--- a/api-service/src/test/java/com/edrdog/apiservice/osquery/OsqueryConfigTest.java
+++ b/api-service/src/test/java/com/edrdog/apiservice/osquery/OsqueryConfigTest.java
@@ -115,6 +115,34 @@ class OsqueryConfigTest {
                 "시작프로그램 경로로 걸러야 한다(백슬래시 1개). 실제 쿼리: " + query);
     }
 
+    /**
+     * process_etw_events 에는 time 컬럼이 없다. 실기기 PRAGMA 로 확인한 컬럼은
+     * type / pid / ppid / session_id / flags / exit_code / path / cmdline / username /
+     * token_elevation_type / token_elevation_status / mandatory_label / datetime 이다.
+     *
+     * <p>없는 컬럼을 선택하면 쿼리 전체가 실패해 수집이 0건이 된다. 시각은 result-log 최상위의
+     * unixTime 으로 들어오므로(RawEventMapper) 컬럼을 고를 필요가 없다.
+     */
+    @Test
+    void windows_프로세스_쿼리는_없는_time_컬럼을_고르지_않는다() throws Exception {
+        JsonNode s = schedule("windows");
+
+        for (String key : new String[]{"process_etw_events", "script_etw_events"}) {
+            String query = s.get(key).get("query").asText();
+            assertFalse(query.contains("e.time"), key + " 는 없는 컬럼을 고르면 안 된다: " + query);
+            assertTrue(query.contains("e.ppid"), key + " 는 parent 조인에 ppid 를 쓴다");
+        }
+    }
+
+    /** 실행 경로 LIKE 도 백슬래시가 하나여야 매칭된다. 한 겹 남으면 조용히 0건이 된다. */
+    @Test
+    void windows_스크립트_쿼리의_경로_패턴은_백슬래시가_하나다() throws Exception {
+        String query = schedule("windows").get("script_etw_events").get("query").asText();
+
+        assertTrue(query.contains("'%\\powershell.exe'"), "실제 쿼리: " + query);
+        assertTrue(query.contains("'%\\cmd.exe'"), "실제 쿼리: " + query);
+    }
+
     @Test
     void windows_파일_이벤트는_path_컬럼을_내려준다() throws Exception {
         JsonNode s = schedule("windows");


### PR DESCRIPTION
#129 에 담겨야 했는데 푸시가 머지 시점에 반영되지 않아 빠진 커밋이다. 내용은 그대로다.

## 문제

파일 감시(#129)를 고치고 나서도 Windows 수집은 0건이었다. 프로세스 쿼리도 같은 종류의 실수였다.

실기기 PRAGMA 로 확인한 `process_etw_events` 컬럼:

```
type, pid, ppid, session_id, flags, exit_code, path, cmdline,
username, token_elevation_type, token_elevation_status, mandatory_label, datetime
```

`time` 이 없는데 `e.time AS time` 을 고르고 있었다. 없는 컬럼이라 쿼리 전체가 실패했고, 오류 없이 결과만 비어 수집이 0건이 됐다. `process_etw_events` 와 `script_etw_events` 둘 다.

## 수정

`time` 선택을 뺀다. 시각은 result-log 최상위 `unixTime` 으로 들어오고 `RawEventMapper` 가 그것을 먼저 본다. osquery 가 항상 붙여주는 값이라 컬럼을 고를 필요가 없다.

macOS 쪽 `es_process_events` 에는 `time` 이 있으므로 그대로 둔다.

실행 경로 LIKE 패턴의 백슬래시가 한 겹으로 나가는지도 테스트로 고정했다.