### PR TITLE
feat: 등록만 된 기기도 기기 목록에 보여준다

### DIFF
--- a/api-service/src/main/java/com/edrdog/apiservice/host/EnrolledHost.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/host/EnrolledHost.java
@@ -1,0 +1,9 @@
+package com.edrdog.apiservice.host;
+
+/**
+ * osquery_nodes 에 등록된 노드의 host/마지막 접속 시각(HostAggregator 입력용 순수 값 객체).
+ * JPA 엔티티(OsqueryNode)를 그대로 아래로 넘기지 않고 HostService 에서 변환해 넘긴다
+ * (HostAlertCount 가 AlertStatusRecord 를 그대로 안 쓰는 것과 같은 패턴).
+ */
+public record EnrolledHost(String host, long agentSeen) {
+}

--- a/api-service/src/main/java/com/edrdog/apiservice/host/HostAggregator.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/host/HostAggregator.java
@@ -5,15 +5,20 @@ import com.edrdog.apiservice.host.web.HostResponse;
 import com.edrdog.apiservice.host.web.HostSummary;
 
 import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
 /**
- * events(호스트+last_seen)와 alerts(host 별 열린 alert 집계)를 병합하는 순수 로직.
- * 두 저장소(ClickHouse/MySQL)라 SQL 조인이 안 되므로 여기서 host 기준으로 합친다.
- * 호스트 집합은 events 기준이다(관측된 호스트). alert 만 있고 events 없는 host 는 나오지 않는다.
+ * events(호스트+last_seen), alerts(host 별 열린 alert 집계), osquery_nodes(등록 노드)를 병합하는 순수 로직.
+ * 세 저장소(ClickHouse/MySQL)라 SQL 조인이 안 되므로 여기서 host 기준으로 합친다.
+ * 호스트 집합은 events ∪ 등록 노드다. osquery 가 enroll 에 성공해도 이벤트가 0건이면 화면에서
+ * 기기 상태를 전혀 볼 수 없었던 문제 때문에, 이벤트 없이 등록만 된 기기도 목록에 넣는다.
+ * alert 만 있고 events/등록 둘 다 없는 host 는 여전히 나오지 않는다.
  */
 public final class HostAggregator {
 
@@ -21,14 +26,21 @@ public final class HostAggregator {
     }
 
     /**
-     * events 행(host, last_seen)에 host 별 alert 집계를 붙여 목록을 만든다.
-     * events 쿼리가 last_seen DESC 로 정렬돼 오므로 그 순서를 그대로 유지한다.
+     * events 행(host, last_seen)에 host 별 alert 집계와 등록 노드 정보를 붙여 목록을 만든다.
+     * events 쿼리가 last_seen DESC 로 정렬돼 오므로 그 순서를 그대로 유지하고,
+     * events 는 없고 등록만 된 host 는 agentSeen DESC 로 정렬해 뒤에 붙인다.
+     * host 이름은 osquery 가 OS 원본 그대로 보내 대소문자가 어긋나는 사례가 있어(Fleet 조회에서 겪음)
+     * 매칭은 소문자로 하되, 화면 표시명은 events 쪽 원본을 우선한다.
      */
-    public static List<HostResponse> hosts(List<Map<String, Object>> eventRows, List<HostAlertCount> alertCounts) {
+    public static List<HostResponse> hosts(List<Map<String, Object>> eventRows, List<HostAlertCount> alertCounts,
+                                            List<EnrolledHost> enrolledHosts) {
         Map<String, HostAlertCount> byHost = alertCounts.stream()
                 .collect(Collectors.toMap(HostAlertCount::host, Function.identity()));
+        Map<String, EnrolledHost> enrolledByHost = enrolledHosts.stream()
+                .collect(Collectors.toMap(e -> e.host().toLowerCase(), Function.identity(), (a, b) -> a));
 
         List<HostResponse> out = new ArrayList<>();
+        Set<String> matched = new HashSet<>();
         for (Map<String, Object> row : eventRows) {
             String host = String.valueOf(row.get("host"));
             long lastSeen = Long.parseLong(String.valueOf(row.get("last_seen")));
@@ -36,23 +48,47 @@ public final class HostAggregator {
             long critical = c == null ? 0 : c.openCritical();
             long high = c == null ? 0 : c.openHigh();
             long threats = c == null ? 0 : c.openTotal();
-            out.add(new HostResponse(host, lastSeen, HostStatus.classify(critical, high), threats));
+
+            EnrolledHost node = enrolledByHost.get(host.toLowerCase());
+            boolean isEnrolled = node != null;
+            long agentSeen = node == null ? 0 : node.agentSeen();
+            matched.add(host.toLowerCase());
+
+            out.add(new HostResponse(host, lastSeen, HostStatus.classify(critical, high), threats,
+                    isEnrolled, agentSeen));
         }
+
+        // 이벤트 없이 등록만 된 기기: 위협 없는 정상 상태로 목록 뒤에 붙인다.
+        enrolledByHost.values().stream()
+                .filter(node -> !matched.contains(node.host().toLowerCase()))
+                .sorted(Comparator.comparingLong(EnrolledHost::agentSeen).reversed())
+                .forEach(node -> out.add(new HostResponse(node.host(), 0L, HostStatus.HEALTHY, 0L,
+                        true, node.agentSeen())));
+
         return out;
     }
 
-    /** 목록의 각 host status 를 세어 도넛용 집계를 만든다. */
+    /**
+     * 목록의 각 host status 를 세어 도넛용 집계를 만든다.
+     * 등록만 되고 이벤트가 한 번도 없는 기기(lastSeen=0 && enrolled)는 알림이 없어 status 가 healthy 로
+     * 나오지만 그건 "정상"이 아니라 "아직 관측된 적 없음"이라 healthy 에서 빼서 noEvents 로 센다.
+     */
     public static HostSummary summary(List<HostResponse> hosts) {
         long healthy = 0;
         long warning = 0;
         long critical = 0;
+        long noEvents = 0;
         for (HostResponse h : hosts) {
+            if (h.lastSeen() == 0 && h.enrolled()) {
+                noEvents++;
+                continue;
+            }
             switch (h.status()) {
                 case HostStatus.CRITICAL -> critical++;
                 case HostStatus.WARNING -> warning++;
                 default -> healthy++;
             }
         }
-        return new HostSummary(healthy, warning, critical, hosts.size());
+        return new HostSummary(healthy, warning, critical, hosts.size(), noEvents);
     }
 }

--- a/api-service/src/main/java/com/edrdog/apiservice/host/HostService.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/host/HostService.java
@@ -7,6 +7,8 @@ import com.edrdog.apiservice.alert.HostAlertCount;
 import com.edrdog.apiservice.clickhouse.ClickHouseReader;
 import com.edrdog.apiservice.host.web.HostResponse;
 import com.edrdog.apiservice.host.web.HostSummary;
+import com.edrdog.apiservice.osquery.domain.OsqueryNode;
+import com.edrdog.apiservice.osquery.repository.OsqueryNodeRepository;
 import com.edrdog.apiservice.query.EventQueryBuilder;
 import org.springframework.stereotype.Service;
 
@@ -15,7 +17,8 @@ import java.util.Map;
 
 /**
  * 엔드포인트(호스트) 목록·요약 조회. events(ClickHouse)로 관측 호스트+last_seen 을,
- * alerts(ClickHouse)로 host 별 열린 alert 집계를 각각 뽑아 병합한다. 조회는 항상 tenant 로 격리한다.
+ * alerts(ClickHouse)로 host 별 열린 alert 집계를, osquery_nodes(MySQL)로 등록 노드를 각각 뽑아 병합한다.
+ * 조회는 항상 tenant 로 격리한다.
  * "열린(open)" 판정은 오버레이(MySQL)에 트리아지된 id 를 빼서 정한다(오버레이 행 없으면 open).
  */
 @Service
@@ -25,25 +28,59 @@ public class HostService {
     private final EventQueryBuilder builder;
     private final AlertQueryBuilder alertBuilder;
     private final AlertStatusRepository statuses;
+    private final OsqueryNodeRepository nodes;
 
     public HostService(ClickHouseReader reader, EventQueryBuilder builder,
-                       AlertQueryBuilder alertBuilder, AlertStatusRepository statuses) {
+                       AlertQueryBuilder alertBuilder, AlertStatusRepository statuses,
+                       OsqueryNodeRepository nodes) {
         this.reader = reader;
         this.builder = builder;
         this.alertBuilder = alertBuilder;
         this.statuses = statuses;
+        this.nodes = nodes;
     }
 
-    /** tenant 의 관측 호스트 목록(host, last_seen, status, 위협수). last_seen 최신순. */
+    /**
+     * tenant 의 호스트 목록(host, last_seen, status, 위협수, enrolled, agentSeen). last_seen 최신순,
+     * 이벤트 없이 등록만 된 기기는 그 뒤에 agentSeen 최신순으로 붙는다.
+     */
     public List<HostResponse> hosts(String tenantId) {
         List<Map<String, Object>> rows = reader.query(builder.hostsLastSeen(tenantId));
         List<HostAlertCount> counts = openCounts(tenantId);
-        return HostAggregator.hosts(rows, counts);
+        List<EnrolledHost> enrolled = enrolledHosts(tenantId);
+        return HostAggregator.hosts(rows, counts, enrolled);
     }
 
-    /** tenant 의 도넛용 상태 집계(정상/주의/위험 수 + 총 관측 호스트 수). */
+    /** tenant 의 도넛용 상태 집계(정상/주의/위험 수 + 총 호스트 수. 등록만 된 기기도 포함). */
     public HostSummary summary(String tenantId) {
         return HostAggregator.summary(hosts(tenantId));
+    }
+
+    /**
+     * tenant 의 등록 노드를 순수 값 객체로 변환한다. OsqueryNode.tenantId 는 Long 인데
+     * HostService.hosts(String) 은 문자열을 받으므로 변환하되, 숫자가 아닌 값이 와도
+     * (예: 잘못된 토큰/테스트 데이터) 예외로 죽이지 않고 빈 목록으로 처리한다.
+     */
+    private List<EnrolledHost> enrolledHosts(String tenantId) {
+        Long id = parseTenantId(tenantId);
+        if (id == null) {
+            return List.of();
+        }
+        return nodes.findByTenantId(id).stream()
+                .map(HostService::toEnrolledHost)
+                .toList();
+    }
+
+    private static EnrolledHost toEnrolledHost(OsqueryNode node) {
+        return new EnrolledHost(node.getHostIdentifier(), node.getLastSeenAt().toEpochMilli());
+    }
+
+    private static Long parseTenantId(String tenantId) {
+        try {
+            return Long.parseLong(tenantId);
+        } catch (NumberFormatException e) {
+            return null;
+        }
     }
 
     /** 오버레이의 트리아지된 id 를 제외한 host 별 열린 alert 집계를 ClickHouse 에서 뽑는다. */

--- a/api-service/src/main/java/com/edrdog/apiservice/host/web/HostResponse.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/host/web/HostResponse.java
@@ -3,11 +3,15 @@ package com.edrdog.apiservice.host.web;
 /**
  * 엔드포인트(호스트) 목록 한 행. status 는 영문 enum(healthy|warning|critical),
  * threats 는 열린 alert 총수, lastSeen 은 events 최신 ts(epoch millis).
+ * enrolled 는 osquery_nodes 에 등록된 기기인지, agentSeen 은 osquery 가 서버에 마지막으로
+ * 붙은 시각(epoch millis, 미등록이면 0)이다. 이벤트가 0건이어도 등록만 됐으면 화면에 보이게 하기 위함이다.
  */
 public record HostResponse(
         String host,
         long lastSeen,
         String status,
-        long threats
+        long threats,
+        boolean enrolled,
+        long agentSeen
 ) {
 }

--- a/api-service/src/main/java/com/edrdog/apiservice/host/web/HostSummary.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/host/web/HostSummary.java
@@ -1,12 +1,15 @@
 package com.edrdog.apiservice.host.web;
 
 /**
- * 대시보드 도넛용 상태 집계. 목록의 각 호스트 status 를 세어 정상/주의/위험 수와 총 관측 호스트 수를 준다.
+ * 대시보드 도넛용 상태 집계. 목록의 각 호스트 status 를 세어 정상/주의/위험 수와 총 호스트 수를 준다.
+ * 등록만 되고 이벤트가 한 번도 없는 기기는 "정상"이 아니라 "아직 모름"이라 healthy 에서 빼서 noEvents 로 따로 센다.
+ * healthy + warning + critical + noEvents == total 이 항상 성립한다.
  */
 public record HostSummary(
         long healthy,
         long warning,
         long critical,
-        long total
+        long total,
+        long noEvents
 ) {
 }

--- a/api-service/src/main/java/com/edrdog/apiservice/osquery/repository/OsqueryNodeRepository.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/osquery/repository/OsqueryNodeRepository.java
@@ -3,10 +3,14 @@ package com.edrdog.apiservice.osquery.repository;
 import com.edrdog.apiservice.osquery.domain.OsqueryNode;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface OsqueryNodeRepository extends JpaRepository<OsqueryNode, String> {
 
     /** 같은 tenant 의 같은 host 재-enroll 시 노드를 재사용(무한 증식 방지). */
     Optional<OsqueryNode> findByTenantIdAndHostIdentifier(Long tenantId, String hostIdentifier);
+
+    /** tenant 의 등록 노드 전체(호스트 목록 화면에서 events 와 병합하는 데 쓴다). */
+    List<OsqueryNode> findByTenantId(Long tenantId);
 }

--- a/api-service/src/test/java/com/edrdog/apiservice/host/HostAggregatorTest.java
+++ b/api-service/src/test/java/com/edrdog/apiservice/host/HostAggregatorTest.java
@@ -9,10 +9,13 @@ import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * events 행과 alert 집계를 host 기준으로 병합하는 순수 로직 검증.
- * 호스트 집합은 events 기준, status/위협수는 alert 집계에서 붙는다.
+ * events 행, alert 집계, 등록 노드(osquery_nodes)를 host 기준으로 병합하는 순수 로직 검증.
+ * 호스트 집합은 events ∪ 등록 노드다(이벤트가 없어도 등록만 됐으면 목록에 나와야 한다).
+ * status/위협수는 alert 집계에서 붙는다.
  */
 class HostAggregatorTest {
 
@@ -26,10 +29,15 @@ class HostAggregatorTest {
         return new HostAlertCount(host, total, critical, high);
     }
 
+    /** osquery_nodes 등록 노드 값(host, agentSeen). */
+    private static EnrolledHost enrolled(String host, long agentSeen) {
+        return new EnrolledHost(host, agentSeen);
+    }
+
     @Test
     void alert_없는_host_는_정상_위협0() {
         List<HostResponse> hosts = HostAggregator.hosts(
-                List.of(row("h1", "1000")), List.of());
+                List.of(row("h1", "1000")), List.of(), List.of());
 
         assertEquals(1, hosts.size());
         HostResponse h = hosts.get(0);
@@ -43,7 +51,7 @@ class HostAggregatorTest {
     void 열린_CRITICAL_있는_host_는_위험_위협수는_열린총수() {
         List<HostResponse> hosts = HostAggregator.hosts(
                 List.of(row("h1", "1000")),
-                List.of(count("h1", 3, 1, 2)));
+                List.of(count("h1", 3, 1, 2)), List.of());
 
         HostResponse h = hosts.get(0);
         assertEquals(HostStatus.CRITICAL, h.status());
@@ -54,7 +62,7 @@ class HostAggregatorTest {
     void HIGH만_있는_host_는_주의() {
         List<HostResponse> hosts = HostAggregator.hosts(
                 List.of(row("h1", "1000")),
-                List.of(count("h1", 2, 0, 2)));
+                List.of(count("h1", 2, 0, 2)), List.of());
 
         assertEquals(HostStatus.WARNING, hosts.get(0).status());
         assertEquals(2L, hosts.get(0).threats());
@@ -64,7 +72,7 @@ class HostAggregatorTest {
     void events_순서를_그대로_유지한다() {
         List<HostResponse> hosts = HostAggregator.hosts(
                 List.of(row("h2", "3000"), row("h1", "1000")),
-                List.of(count("h1", 1, 1, 0)));
+                List.of(count("h1", 1, 1, 0)), List.of());
 
         assertEquals("h2", hosts.get(0).host());
         assertEquals("h1", hosts.get(1).host());
@@ -74,25 +82,91 @@ class HostAggregatorTest {
     void alert만_있고_events_없는_host_는_목록에_없다() {
         List<HostResponse> hosts = HostAggregator.hosts(
                 List.of(row("h1", "1000")),
-                List.of(count("ghost", 5, 5, 0)));
+                List.of(count("ghost", 5, 5, 0)), List.of());
 
         assertEquals(1, hosts.size());
         assertEquals("h1", hosts.get(0).host());
     }
 
     @Test
+    void events만_있고_등록이_없으면_enrolled_false_agentSeen_0() {
+        List<HostResponse> hosts = HostAggregator.hosts(
+                List.of(row("h1", "1000")), List.of(), List.of());
+
+        HostResponse h = hosts.get(0);
+        assertFalse(h.enrolled());
+        assertEquals(0L, h.agentSeen());
+    }
+
+    @Test
+    void events와_등록이_둘다_있으면_enrolled_true_lastSeen과_agentSeen_모두_채워짐() {
+        List<HostResponse> hosts = HostAggregator.hosts(
+                List.of(row("h1", "1000")), List.of(),
+                List.of(enrolled("h1", 5000)));
+
+        HostResponse h = hosts.get(0);
+        assertEquals("h1", h.host());
+        assertEquals(1000L, h.lastSeen());
+        assertTrue(h.enrolled());
+        assertEquals(5000L, h.agentSeen());
+    }
+
+    @Test
+    void 등록만_있고_events_없으면_lastSeen0_enrolled_true_agentSeen_채워져_목록에_포함() {
+        List<HostResponse> hosts = HostAggregator.hosts(
+                List.of(), List.of(), List.of(enrolled("h-new", 7000)));
+
+        assertEquals(1, hosts.size());
+        HostResponse h = hosts.get(0);
+        assertEquals("h-new", h.host());
+        assertEquals(0L, h.lastSeen());
+        assertEquals(0L, h.threats());
+        assertEquals(HostStatus.HEALTHY, h.status());
+        assertTrue(h.enrolled());
+        assertEquals(7000L, h.agentSeen());
+    }
+
+    @Test
+    void host_이름_대소문자가_달라도_같은_기기로_합쳐진다() {
+        List<HostResponse> hosts = HostAggregator.hosts(
+                List.of(row("DESKTOP-ABC", "1000")), List.of(),
+                List.of(enrolled("desktop-abc", 5000)));
+
+        assertEquals(1, hosts.size());
+        HostResponse h = hosts.get(0);
+        // 표시 이름은 events 쪽 원본을 우선한다.
+        assertEquals("DESKTOP-ABC", h.host());
+        assertTrue(h.enrolled());
+        assertEquals(5000L, h.agentSeen());
+    }
+
+    @Test
+    void 정렬은_events_있는_host가_앞이고_등록만_있는_host는_agentSeen_DESC로_뒤에_붙는다() {
+        List<HostResponse> hosts = HostAggregator.hosts(
+                List.of(row("h2", "3000"), row("h1", "1000")), List.of(),
+                List.of(enrolled("h-old", 100), enrolled("h-new", 9000)));
+
+        assertEquals(4, hosts.size());
+        assertEquals("h2", hosts.get(0).host());
+        assertEquals("h1", hosts.get(1).host());
+        assertEquals("h-new", hosts.get(2).host());
+        assertEquals("h-old", hosts.get(3).host());
+    }
+
+    @Test
     void 요약은_status별_수와_총수를_센다() {
         List<HostResponse> hosts = List.of(
-                new HostResponse("h1", 1, HostStatus.CRITICAL, 2),
-                new HostResponse("h2", 1, HostStatus.WARNING, 1),
-                new HostResponse("h3", 1, HostStatus.HEALTHY, 0),
-                new HostResponse("h4", 1, HostStatus.HEALTHY, 0));
+                new HostResponse("h1", 1, HostStatus.CRITICAL, 2, true, 1),
+                new HostResponse("h2", 1, HostStatus.WARNING, 1, false, 0),
+                new HostResponse("h3", 1, HostStatus.HEALTHY, 0, false, 0),
+                new HostResponse("h4", 1, HostStatus.HEALTHY, 0, true, 1));
 
         HostSummary s = HostAggregator.summary(hosts);
         assertEquals(2L, s.healthy());
         assertEquals(1L, s.warning());
         assertEquals(1L, s.critical());
         assertEquals(4L, s.total());
+        assertEquals(0L, s.noEvents());
     }
 
     @Test
@@ -102,5 +176,44 @@ class HostAggregatorTest {
         assertEquals(0L, s.warning());
         assertEquals(0L, s.critical());
         assertEquals(0L, s.total());
+        assertEquals(0L, s.noEvents());
+    }
+
+    @Test
+    void 수집없는_등록기기는_healthy가_아니라_noEvents로_잡힌다() {
+        // 등록만 되고 이벤트가 한 번도 없는 기기(lastSeen=0, enrolled=true)는 "정상"이 아니라 "아직 모름"이다.
+        List<HostResponse> hosts = List.of(
+                new HostResponse("h-new", 0, HostStatus.HEALTHY, 0, true, 5000));
+
+        HostSummary s = HostAggregator.summary(hosts);
+        assertEquals(0L, s.healthy());
+        assertEquals(1L, s.noEvents());
+        assertEquals(1L, s.total());
+    }
+
+    @Test
+    void 이벤트있는_정상기기는_그대로_healthy로_잡힌다() {
+        List<HostResponse> hosts = List.of(
+                new HostResponse("h1", 1000, HostStatus.HEALTHY, 0, true, 1000));
+
+        HostSummary s = HostAggregator.summary(hosts);
+        assertEquals(1L, s.healthy());
+        assertEquals(0L, s.noEvents());
+    }
+
+    @Test
+    void healthy_warning_critical_noEvents_합은_total과_같다() {
+        List<HostResponse> hosts = List.of(
+                new HostResponse("h1", 1000, HostStatus.CRITICAL, 1, true, 1000),
+                new HostResponse("h2", 1000, HostStatus.WARNING, 1, false, 0),
+                new HostResponse("h3", 1000, HostStatus.HEALTHY, 0, false, 0),
+                new HostResponse("h4", 0, HostStatus.HEALTHY, 0, true, 5000),
+                new HostResponse("h5", 0, HostStatus.HEALTHY, 0, true, 3000));
+
+        HostSummary s = HostAggregator.summary(hosts);
+        assertEquals(5L, s.total());
+        assertEquals(s.total(), s.healthy() + s.warning() + s.critical() + s.noEvents());
+        assertEquals(2L, s.noEvents());
+        assertEquals(1L, s.healthy());
     }
 }


### PR DESCRIPTION
## 문제

기기 목록이 ClickHouse events 기준이라, osquery 가 enroll 에 성공해도 이벤트가 0건이면 화면에 아무것도 안 떴다.

설치가 된 건지, 서버에 붙었는지, 어디서 막힌 건지 화면만 봐서는 알 수 없었다. Windows 엔드포인트를 붙이면서 이 때문에 몇 시간을 썼고, 매번 서버에 들어가 `osquery_nodes` 와 ClickHouse 를 직접 뒤져야 했다.

## 수정

호스트 집합을 `events ∪ osquery_nodes` 로 바꾼다.

| 필드 | 의미 |
|:---|:---|
| `lastSeen` | events 최신 시각. **이벤트가 없으면 0** |
| `enrolled` | 등록된 기기인가 |
| `agentSeen` | osquery 가 서버에 마지막으로 붙은 시각 |

**`agentSeen` 이 핵심이다.** "에이전트는 살아 있는데 이벤트만 없다" 와 "에이전트가 죽었다" 는 원인이 전혀 다른데, 지금까지 화면에서 구분할 수 없었다.

## 판단한 것

**host 매칭은 대소문자를 구분하지 않는다.** osquery 는 OS 가 준 hostname 을 그대로 보내고 대소문자가 어긋나는 사례가 실제로 있었다(Fleet 호스트 조회에서 겪었다). 표시명은 events 쪽 원본을 쓴다.

**요약에서 이벤트 없는 기기를 healthy 에서 뺐다.** 알림이 0건이라 healthy 로 잡히는데 그건 "정상"이 아니라 "아직 모름"이다. 그대로 두면 도넛이 검증도 안 된 상태를 정상이라고 말하게 된다. `noEvents` 로 따로 세고 `healthy + warning + critical + noEvents == total` 이 성립한다.

**JPA 엔티티를 aggregator 로 넘기지 않는다.** `EnrolledHost` 로 변환해 넘긴다(`HostAlertCount` 가 `AlertStatusRecord` 를 그대로 안 쓰는 것과 같은 패턴).

## 테스트

TDD 로 진행했다. 신규 케이스:

- events 만 있으면 `enrolled=false`, `agentSeen=0`
- events + 등록 둘 다면 양쪽 다 채워짐
- 등록만 있으면 `lastSeen=0` 이고 목록에 포함
- host 이름 대소문자가 달라도 같은 기기로 합쳐짐
- 정렬: events 있는 것이 앞, 없는 것은 `agentSeen` DESC 로 뒤
- 수집 없는 기기가 `healthy` 가 아니라 `noEvents` 로 잡힘
- `healthy + warning + critical + noEvents == total`

`./gradlew :api-service:test` 전체 통과.

프론트 대응은 Frontend 레포에 따로 올린다.