### PR TITLE
fix: 설치 스크립트가 받은 해시를 잘못 읽던 문제

### DIFF
--- a/api-service/src/main/resources/install/macos.sh
+++ b/api-service/src/main/resources/install/macos.sh
@@ -62,8 +62,14 @@ curl -fsSL "$DOWNLOAD_BASE/$ASSET" -o "$TMP/agent" || fail "바이너리를 받�
 # 받은 것이 온전한지 본다. 끊긴 다운로드는 크기만 작고 그대로 실행돼서, 깔린 뒤에
 # "왜 안 뜨지" 로 시간을 버리게 된다.
 if curl -fsSL "$DOWNLOAD_BASE/$ASSET.sha256" -o "$TMP/want" 2>/dev/null; then
-  want="$(tr -d ' \t\n' < "$TMP/want" | cut -d'*' -f1 | tail -c 65)"
-  got="$(shasum -a 256 "$TMP/agent" | cut -d' ' -f1)"
+  # 파일 모양은 "<해시>  <파일명>" 이다. 해시는 첫 칸에 있다. 공백을 지우고 뒤에서 자르면
+  # 파일명 끝을 해시로 읽는다(실제로 그렇게 짰다가 모든 설치가 막혔다).
+  # \r 을 지우는 것은 파일이 CRLF 로 올라온 경우다.
+  want="$(awk 'NR==1 {print $1}' "$TMP/want" | tr -d '\r')"
+  got="$(shasum -a 256 "$TMP/agent" | awk '{print $1}')"
+  # 64자 16진수가 아니면 비교 자체가 무의미하다. 그걸 "일치하지 않음" 으로 뭉뚱그리면
+  # 릴리스 파일이 깨진 것과 바이너리가 바뀐 것을 구별할 수 없다.
+  [[ "$want" =~ ^[A-Fa-f0-9]{64}$ ]] || fail "$ASSET.sha256 의 모양이 예상과 다르다: $want"
   [[ "$want" == "$got" ]] || fail "받은 바이너리의 해시가 다르다 (기대 $want, 실제 $got)"
   echo "해시 확인됨."
 else

--- a/api-service/src/main/resources/install/windows.ps1
+++ b/api-service/src/main/resources/install/windows.ps1
@@ -56,18 +56,27 @@ try {
 
 # 받은 것이 온전한지 본다. 끊긴 다운로드는 크기만 작고 그대로 설치돼서, 깔린 뒤에
 # "왜 안 뜨지" 로 시간을 버리게 된다.
+#
+# try 로 감싸는 것은 해시 파일을 받는 것까지다. 비교까지 같이 감싸면 불일치가 catch 로
+# 흘러들어 경고로 강등되고 설치가 그대로 이어진다. 그러면 검사가 있으나 마나다.
+$want = $null
 try {
     $want = (Invoke-WebRequest -Uri "$DownloadBase/$asset.sha256" -UseBasicParsing).Content
-    $want = ($want -replace '[^A-Fa-f0-9]', '')
-    if ($want.Length -ge 64) {
-        $want = $want.Substring($want.Length - 64, 64)
-        $got = (Get-FileHash -Path $downloaded -Algorithm SHA256).Hash
-        if ($want -ne $got) { Fail "받은 바이너리의 해시가 다르다 (기대 $want, 실제 $got)" }
-        Write-Host '  해시 확인됨.'
-    }
 } catch {
     # 릴리스에 해시 파일이 없을 수 있다. 그 사실을 조용히 넘기지는 않는다.
     Write-Warning "$asset.sha256 이 없어 무결성을 확인하지 못했다"
+}
+if ($want) {
+    # 파일 모양은 "<해시>  <파일명>" 이다. 해시는 첫 칸에 있다. 16진수만 남기고 뒤에서
+    # 자르면 파일명 끝을 해시로 읽는다(실제로 그렇게 짰다가 모든 설치가 막혔다).
+    # edrdog-agent-windows-amd64.exe 는 a, d, e, 6, 4 처럼 16진수로 보이는 글자가 많다.
+    $want = (($want -split '\s+') | Where-Object { $_ })[0]
+    # 64자 16진수가 아니면 비교 자체가 무의미하다. 그걸 "일치하지 않음" 으로 뭉뚱그리면
+    # 릴리스 파일이 깨진 것과 바이너리가 바뀐 것을 구별할 수 없다.
+    if ($want -notmatch '^[A-Fa-f0-9]{64}$') { Fail "$asset.sha256 의 모양이 예상과 다르다: $want" }
+    $got = (Get-FileHash -Path $downloaded -Algorithm SHA256).Hash
+    if ($want -ne $got) { Fail "받은 바이너리의 해시가 다르다 (기대 $want, 실제 $got)" }
+    Write-Host '  해시 확인됨.'
 }
 
 New-Item -ItemType Directory -Force -Path $InstallDir | Out-Null

--- a/api-service/src/test/java/com/edrdog/apiservice/install/InstallTemplatesTest.java
+++ b/api-service/src/test/java/com/edrdog/apiservice/install/InstallTemplatesTest.java
@@ -56,6 +56,18 @@ class InstallTemplatesTest {
         assertTrue(scripts.macos().contains("/dev/tty"), "권한 대기를 /dev/tty 로 읽어야 한다");
     }
 
+    @Test
+    void 두_원본_모두_받은_해시의_모양을_먼저_본다() {
+        // .sha256 파일은 "<해시>  <파일명>" 이다. 처음에는 공백을 지우고 뒤에서 64자를
+        // 잘랐는데, 그러면 파일명 끝을 해시로 읽는다. 실제 릴리스로 받아 보고서야 알았고
+        // 그때까지 모든 설치가 해시 불일치로 막혀 있었다.
+        //
+        // 모양 검사를 먼저 두면 추출이 또 깨져도 "해시가 다르다" 가 아니라 "모양이 다르다"
+        // 로 나온다. 릴리스 파일이 깨진 것과 바이너리가 바뀐 것은 대응이 전혀 다르다.
+        assertTrue(scripts.macos().contains("[A-Fa-f0-9]{64}"), "macOS 원본이 해시 모양을 안 본다");
+        assertTrue(scripts.windows().contains("[A-Fa-f0-9]{64}"), "windows 원본이 해시 모양을 안 본다");
+    }
+
     private static void assertNoPlaceholderLeft(String out) {
         assertFalse(out.contains("{{"), "안 채운 자리표시자가 남았다: "
                 + out.replaceAll("(?s).*?(\\{\\{[A-Z_]*}}).*", "$1"));


### PR DESCRIPTION
릴리스(`agent-v0.1.0`)를 만들고 실제로 받아 보다 찾았다. **이대로면 설치가 한 대도 안 된다.**

## 무엇이 틀렸나

`.sha256` 파일은 `<해시>  <파일명>` 이다. 해시는 **첫 칸**에 있는데, 공백을 지운 뒤 **뒤에서** 64자를 잘랐다.

```
기대: 04a81950755ac765c25bf4909baf295388088528edrdog-agent-darwin-arm64
실제: c235af7e00479e524371bfb404a81950755ac765c25bf4909baf295388088528
```

macOS 스크립트는 불일치를 `fail` 로 처리하므로 설치가 거기서 멈춘다.

PowerShell 도 같은 실수다. 16진수만 남기고 뒤에서 잘랐는데 `edrdog-agent-windows-amd64.exe` 에는 `a`, `d`, `e`, `6`, `4` 처럼 16진수로 보이는 글자가 많다.

## PowerShell 은 하나 더 있었다

해시 비교가 `try` 안에 있어서 **불일치가 `catch` 로 흘러들어 경고로 강등되고 설치가 그대로 이어졌다.** 검사가 있으나 마나였다. `try` 범위를 해시 파일을 받는 데까지로 좁혔다.

## 검증

실제 릴리스 파일로 확인했다.

```
추출: c235af7e00479e524371bfb404a81950755ac765c25bf4909baf295388088528
대조: 해시 일치
```

비교 전에 64자 16진수인지 본다. 추출이 또 깨져도 "해시가 다르다" 가 아니라 "모양이 다르다" 로 나온다. 릴리스 파일이 깨진 것과 바이너리가 바뀐 것은 대응이 전혀 다른데 앞의 문구는 그 둘을 뭉뚱그린다.

## 릴리스는 다시 안 만든다

바이너리는 멀쩡하다. 고칠 것은 서버가 내려주는 스크립트뿐이라 `api-service` 만 다시 배포하면 된다.

## 못 한 검증

`pwsh` 가 없어 PowerShell 문법은 확인하지 못했다. Windows 실기기 검증 때 같이 봐야 한다.