### PR TITLE
ci: PR 에서 Go 에이전트도 검사한다

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,3 +29,35 @@ jobs:
         env:
           MAXMIND_LICENSE_KEY: ${{ secrets.MAXMIND_LICENSE_KEY }}
         run: ./gradlew build
+
+  # 에이전트(Go)는 Gradle 밖이라 위의 build 잡이 손도 대지 않는다. 이 잡이 없으면
+  # 엔드포인트에서 root 로 도는 코드가 CI 를 한 번도 거치지 않고 머지된다(실제로 그렇게 갔다).
+  #
+  # macOS 러너에서 도는 이유는 darwin 쪽이 cgo 라서다. eslogger 센서와 kill 과 BPF 캡처가
+  # libproc 을 C 로 부른다. 리눅스에서는 컴파일 자체가 안 된다.
+  # 퍼블릭 레포라 macOS 러너 시간이 무료다.
+  agent:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: agent/go.mod
+          cache-dependency-path: agent/go.sum
+      - name: Test (darwin)
+        run: go test ./...
+        working-directory: agent
+      - name: Vet (darwin)
+        run: go vet ./...
+        working-directory: agent
+      # Windows 쪽은 러너에서 실행할 수 없으니 빌드와 vet 으로 갈음한다. 순수 로직 테스트는
+      # 위의 go test 가 이미 돌렸다(플랫폼에 매인 파일만 빌드 태그로 갈라져 있다).
+      # 두 아키텍처를 다 보는 이유는 릴리스가 둘 다 내보내기 때문이다.
+      - name: Build + vet (windows)
+        working-directory: agent
+        run: |
+          set -euo pipefail
+          for arch in amd64 arm64; do
+            GOOS=windows GOARCH="$arch" go vet ./...
+            GOOS=windows GOARCH="$arch" go build -o /dev/null ./cmd/edrdog-agent
+          done


### PR DESCRIPTION
지금까지 CI 는 `./gradlew build` 만 돌렸고 `agent/` 는 Gradle 밖이라 **손도 대지 않았다.** 엔드포인트에서 root 로 도는 코드가 CI 를 한 번도 안 거치고 머지된다. #138 의 26커밋이 그렇게 갔다.

릴리스 워크플로에 `go test` 가 있긴 한데 그건 태그를 밀 때만 돈다. 문제를 알게 되는 시점이 이미 머지된 뒤다.

## 무엇을 도나

| 단계 | 대상 |
|---|---|
| `go test ./...` | darwin (네이티브) |
| `go vet ./...` | darwin |
| `go vet` + `go build` | windows amd64, arm64 |

## macOS 러너인 이유

darwin 쪽이 cgo 다. eslogger 센서와 kill 과 BPF 캡처가 libproc 을 C 로 부르므로 **리눅스에서는 컴파일 자체가 안 된다.** 릴리스 워크플로를 만들 때 리눅스에서 `CGO_ENABLED=0` 으로 빌드해 보고 알았다(`selfPID` 부터 undefined 로 죽는다).

퍼블릭 레포라 macOS 러너 시간은 무료다.

Windows 는 러너에서 실행할 수 없으니 빌드와 vet 으로 갈음한다. 순수 로직 테스트는 darwin 에서 이미 돌았다. 플랫폼에 매인 파일만 빌드 태그로 갈라져 있다.

## 검증

네 단계를 로컬에서 그대로 돌렸다. 전부 통과한다.

```
ok  .../agent/internal/sensor
ok  .../agent/internal/packet
...
windows/amd64 OK
windows/arm64 OK
```