### PR TITLE
chore: 배포 도메인을 edrdog.duckdns.org 로 바꾼다

### DIFF
--- a/api-service/src/main/resources/application.yml
+++ b/api-service/src/main/resources/application.yml
@@ -55,7 +55,7 @@ edrdog:
     # 별도 TLS 포트로 붙기 때문이다(server.agent.tls.port).
     agent-server: ${INSTALL_AGENT_SERVER:}
     # 에이전트 바이너리를 받는 곳. CI 가 릴리스에 올린다(.github/workflows/agent-release.yml).
-    download-base: ${INSTALL_DOWNLOAD_BASE:https://github.com/2026-Siheung-Bootcamp-Team-I/Backend/releases/latest/download}
+    download-base: ${INSTALL_DOWNLOAD_BASE:https://github.com/EDRdog/Backend/releases/latest/download}
     # 설치 링크의 수명. 짧게 두는 이유는 링크가 새면 그 시간 동안 남의 기기가 우리 테넌트로
     # 붙을 수 있어서다. 여러 대에 쓸 수 있으므로 한 번에 여러 대 까는 데는 지장이 없다.
     token-ttl-hours: ${INSTALL_TOKEN_TTL_HOURS:24}

--- a/k8s/api-service.yaml
+++ b/k8s/api-service.yaml
@@ -85,9 +85,9 @@ spec:
             # 뒤는 안 거친다(에이전트가 붙는 곳). 에이전트가 서버 인증서를 고정해서 붙기
             # 때문에 중간에서 TLS 를 다시 종단하면 등록 단계에서 실패한다.
             - name: INSTALL_PUBLIC_BASE
-              value: "https://edrdog-i-team.duckdns.org"
+              value: "https://edrdog.duckdns.org"
             - name: INSTALL_AGENT_SERVER
-              value: "edrdog-i-team.duckdns.org:30443"
+              value: "edrdog.duckdns.org:30443"
           readinessProbe:
             httpGet:
               path: /actuator/health

--- a/k8s/api-service.yaml
+++ b/k8s/api-service.yaml
@@ -85,9 +85,9 @@ spec:
             # 뒤는 안 거친다(에이전트가 붙는 곳). 에이전트가 서버 인증서를 고정해서 붙기
             # 때문에 중간에서 TLS 를 다시 종단하면 등록 단계에서 실패한다.
             - name: INSTALL_PUBLIC_BASE
-              value: "https://edrdog.duckdns.org"
+              value: "https://edrdog-api.duckdns.org"
             - name: INSTALL_AGENT_SERVER
-              value: "edrdog.duckdns.org:30443"
+              value: "edrdog-api.duckdns.org:30443"
           readinessProbe:
             httpGet:
               path: /actuator/health


### PR DESCRIPTION
설치 링크가 쓰는 두 값(`INSTALL_PUBLIC_BASE`, `INSTALL_AGENT_SERVER`)을 새 도메인으로 바꾼다. 레포에서 도메인이 나오는 곳은 여기뿐이다.

## 인증서를 같이 바꿔야 한다

에이전트는 `RootCAs` 만 갈아끼우고 `InsecureSkipVerify` 를 쓰지 않는다(`agent/internal/config/config.go:105`). 그래서 **Go 가 접속 주소의 호스트를 서버 인증서의 SAN 과 대조한다.** 안 맞으면 등록 단계에서 TLS 핸드셰이크부터 실패한다.

키스토어를 새 도메인으로 다시 만들어야 한다.

```bash
AGENT_TLS_KEYSTORE_PASSWORD=<비번> ./scripts/gen-dev-keystore.sh ./dev-tls edrdog.duckdns.org
```

## 서버 쪽에서 같이 해야 할 것

- [ ] DuckDNS 에 `edrdog` 서브도메인 등록
- [ ] Caddyfile 의 도메인 블록 교체
- [ ] `agent-tls` Secret 을 새 SAN 키스토어로 재생성