### PR TITLE
feat: arm64 이미지를 내고 오라클 서버 부트스트랩을 자동화한다

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -136,16 +136,21 @@ jobs:
           echo "~/Backend 클론이 없어 모니터링 매니페스트 apply 를 건너뛴다" >&2
           fi
 
-          # Deployment 가 아직 없는 모듈(새로 추가된 서비스)은 건너뛴다.
-          # set -e 라 없는 deployment 에 set image 를 하면 나머지 배포까지 통째로 죽는다.
-          # 새 서비스는 서버에서 k8s/<모듈>.yaml 을 한 번 apply 한 뒤부터 이 루프가 관리한다.
+          # Deployment 가 없으면(빈 클러스터, 새로 추가된 서비스) 매니페스트를 먼저 apply 한다.
+          # 있으면 apply 하지 않는다. image 가 :latest 로 되돌아갔다가 아래 set image 로 다시
+          # :sha 가 되면서 롤아웃이 두 번 돌기 때문이다.
           DEPLOYED=""
           for m in $MODULES; do
-          if sudo kubectl -n "$NS" get deploy "$m" >/dev/null 2>&1; then
-          DEPLOYED="$DEPLOYED $m"
+          if ! sudo kubectl -n "$NS" get deploy "$m" >/dev/null 2>&1; then
+          if [ -d ~/Backend/.git ]; then
+          echo "deployment/$m 없음 → k8s/$m.yaml 을 apply 한다" >&2
+          git -C ~/Backend show "FETCH_HEAD:k8s/$m.yaml" | sudo kubectl apply -f -
           else
-          echo "deployment/$m 없음 → 건너뜀. k8s/$m.yaml 을 서버에서 먼저 apply 할 것" >&2
+          echo "deployment/$m 없음. ~/Backend 클론이 없어 apply 도 못 한다" >&2
+          continue
           fi
+          fi
+          DEPLOYED="$DEPLOYED $m"
           done
 
           for m in $DEPLOYED; do

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -71,10 +71,20 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      # arm64 도 같이 낸다. 배포서버가 오라클 Ampere A1 이라 amd64 만 올리면 이미지가
+      # 하나도 안 뜬다(exec format error). 로컬 개발 맥도 arm64 라 같은 값을 받는다.
+      #
+      # 값이 싼 이유는 Dockerfile 이 JRE 위에 jar 를 얹는 게 전부여서다. 아키텍처마다
+      # 다시 컴파일하는 것이 없고, 베이스 이미지(eclipse-temurin:21-jre)가 두 아키텍처를
+      # 다 갖고 있어 매니페스트만 하나 더 만들어진다. 인프라 이미지(kafka, clickhouse,
+      # mysql, otel-lgtm, alloy, kafka-ui)도 전부 arm64 를 지원하는 것을 확인했다.
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
           context: ${{ matrix.module }}
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: |
             ${{ steps.vars.outputs.image_base }}:${{ github.sha }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -71,13 +71,7 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      # arm64 도 같이 낸다. 배포서버가 오라클 Ampere A1 이라 amd64 만 올리면 이미지가
-      # 하나도 안 뜬다(exec format error). 로컬 개발 맥도 arm64 라 같은 값을 받는다.
-      #
-      # 값이 싼 이유는 Dockerfile 이 JRE 위에 jar 를 얹는 게 전부여서다. 아키텍처마다
-      # 다시 컴파일하는 것이 없고, 베이스 이미지(eclipse-temurin:21-jre)가 두 아키텍처를
-      # 다 갖고 있어 매니페스트만 하나 더 만들어진다. 인프라 이미지(kafka, clickhouse,
-      # mysql, otel-lgtm, alloy, kafka-ui)도 전부 arm64 를 지원하는 것을 확인했다.
+      # 배포서버가 오라클 Ampere A1 이라 amd64 만 올리면 exec format error 로 하나도 안 뜬다.
       - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v3
       - name: Build and push

--- a/scripts/bootstrap-oracle.sh
+++ b/scripts/bootstrap-oracle.sh
@@ -27,7 +27,9 @@ set -euo pipefail
 DOMAIN="${DOMAIN:-edrdog-api.duckdns.org}"
 DUCKDNS_SUBDOMAIN="${DUCKDNS_SUBDOMAIN:-${DOMAIN%%.*}}"
 NS="${NS:-edrdog}"
-REPO_DIR="${REPO_DIR:-$HOME/Backend}"
+# sudo 로 돌면 HOME 이 /root 가 된다. 클론은 원래 사용자의 홈에 있으므로 그쪽을 본다.
+SUDO_HOME="$(getent passwd "${SUDO_USER:-root}" 2>/dev/null | cut -d: -f6)"
+REPO_DIR="${REPO_DIR:-${SUDO_HOME:-$HOME}/Backend}"
 GHCR_IMAGE_BASE="${GHCR_IMAGE_BASE:-ghcr.io/edrdog/backend}"
 
 # 에이전트가 붙는 포트. Caddy 를 거치지 않는다. 에이전트가 서버 인증서를 고정해서 붙기

--- a/scripts/bootstrap-oracle.sh
+++ b/scripts/bootstrap-oracle.sh
@@ -3,8 +3,11 @@
 #
 # 새로 만든 인스턴스에서 한 번 돌린다. 여러 번 돌려도 안전하다(같은 것을 덮어쓴다).
 #
-#   sudo DUCKDNS_TOKEN=... GHCR_USER=... GHCR_TOKEN=... \
+#   sudo env DUCKDNS_TOKEN=... GHCR_USER=... GHCR_TOKEN=... \
 #     AGENT_TLS_KEYSTORE_PASSWORD=... ./scripts/bootstrap-oracle.sh
+#
+# env 를 끼우는 이유: sudo VAR=값 명령 으로 쓰면 sudoers 의 NOPASSWD 가 적용되지 않아
+# 비밀번호를 묻는다. 오라클 Ubuntu 이미지는 그 계정에 비밀번호가 없어서 답할 수가 없다.
 #
 # 하는 일:
 #   1. 호스트 방화벽을 연다 (오라클은 이걸 안 하면 콘솔에서 열어도 막힌다)

--- a/scripts/bootstrap-oracle.sh
+++ b/scripts/bootstrap-oracle.sh
@@ -1,0 +1,232 @@
+#!/usr/bin/env bash
+# 오라클 클라우드 인스턴스 하나를 EDRdog 배포서버로 만든다.
+#
+# 새로 만든 인스턴스에서 한 번 돌린다. 여러 번 돌려도 안전하다(같은 것을 덮어쓴다).
+#
+#   sudo DUCKDNS_TOKEN=... GHCR_USER=... GHCR_TOKEN=... \
+#     AGENT_TLS_KEYSTORE_PASSWORD=... ./scripts/bootstrap-oracle.sh
+#
+# 하는 일:
+#   1. 호스트 방화벽을 연다 (오라클은 이걸 안 하면 콘솔에서 열어도 막힌다)
+#   2. k3s 를 깐다
+#   3. DuckDNS 가 이 인스턴스의 공인 IP 를 가리키게 하고, 주기적으로 갱신한다
+#   4. Caddy 를 깔고 도메인 블록을 쓴다
+#   5. 에이전트 수집용 키스토어를 만들어 agent-tls Secret 으로 넣는다
+#   6. GHCR 이미지를 받을 자격증명을 넣는다
+#   7. 인프라 매니페스트를 apply 한다
+#
+# 안 하는 일(사람이 해야 한다):
+#   - 오라클 콘솔의 보안 목록(Security List) 에 80/443/30443 을 여는 것.
+#     인스턴스 밖의 설정이라 여기서 건드릴 수 없다. 아래에서 다시 알려준다.
+#   - 서비스 매니페스트 apply. 이미지가 GHCR 에 올라간 뒤에 해야 한다(맨 아래 안내).
+set -euo pipefail
+
+DOMAIN="${DOMAIN:-edrdog-api.duckdns.org}"
+DUCKDNS_SUBDOMAIN="${DUCKDNS_SUBDOMAIN:-${DOMAIN%%.*}}"
+NS="${NS:-edrdog}"
+REPO_DIR="${REPO_DIR:-$HOME/Backend}"
+GHCR_IMAGE_BASE="${GHCR_IMAGE_BASE:-ghcr.io/edrdog/backend}"
+
+# 에이전트가 붙는 포트. Caddy 를 거치지 않는다. 에이전트가 서버 인증서를 고정해서 붙기
+# 때문에 중간에서 TLS 를 다시 종단하면 등록 단계에서 실패한다.
+AGENT_PORT=30443
+API_NODEPORT=30084
+
+fail() { echo "오류: $*" >&2; exit 1; }
+step() { echo; echo "== $*"; }
+
+[[ "$(id -u)" == "0" ]] || fail "sudo 로 실행해야 한다"
+
+for v in DUCKDNS_TOKEN GHCR_USER GHCR_TOKEN AGENT_TLS_KEYSTORE_PASSWORD; do
+  [[ -n "${!v:-}" ]] || fail "$v 가 필요하다"
+done
+
+# 아키텍처를 먼저 본다. 여기서 짚어 주지 않으면 나중에 파드가 exec format error 로만
+# 죽는데, 그 메시지로는 원인이 아키텍처라는 것을 알기 어렵다.
+ARCH="$(uname -m)"
+step "0/7 확인 (arch=$ARCH)"
+case "$ARCH" in
+  aarch64) echo "  Ampere A1(arm64) 이다. 이미지가 arm64 를 포함해야 한다." ;;
+  x86_64)  echo "  x86_64 다." ;;
+  *) fail "지원하지 않는 아키텍처: $ARCH" ;;
+esac
+
+# --- 1. 호스트 방화벽 ---------------------------------------------------------
+# 오라클 이미지는 INPUT 사슬 끝에 REJECT 가 박힌 채로 나온다. 콘솔의 보안 목록만 열고
+# 여기를 안 열면 밖에서는 그냥 타임아웃으로 보인다. 원인을 짚기 가장 어려운 자리다.
+step "1/7 호스트 방화벽을 연다"
+open_port() {
+  local port=$1 proto=${2:-tcp}
+  if command -v firewall-cmd >/dev/null 2>&1 && firewall-cmd --state >/dev/null 2>&1; then
+    firewall-cmd --permanent --add-port="$port/$proto" >/dev/null
+  else
+    # 이미 있으면 넣지 않는다(-C 로 확인). 여러 번 돌려도 규칙이 쌓이지 않게.
+    iptables -C INPUT -p "$proto" --dport "$port" -j ACCEPT 2>/dev/null \
+      || iptables -I INPUT 1 -p "$proto" --dport "$port" -j ACCEPT
+  fi
+  echo "  $port/$proto"
+}
+open_port 80
+open_port 443
+open_port "$AGENT_PORT"
+
+if command -v firewall-cmd >/dev/null 2>&1 && firewall-cmd --state >/dev/null 2>&1; then
+  firewall-cmd --reload >/dev/null
+else
+  # 규칙을 저장하지 않으면 재부팅 때 사라진다. 그러면 어느 날 갑자기 안 붙는다.
+  if command -v netfilter-persistent >/dev/null 2>&1; then
+    netfilter-persistent save >/dev/null
+  else
+    DEBIAN_FRONTEND=noninteractive apt-get install -y iptables-persistent >/dev/null 2>&1 \
+      && netfilter-persistent save >/dev/null \
+      || echo "  경고: 규칙을 저장하지 못했다. 재부팅하면 사라진다" >&2
+  fi
+fi
+
+# --- 2. k3s -------------------------------------------------------------------
+step "2/7 k3s"
+if command -v k3s >/dev/null 2>&1; then
+  echo "  이미 깔려 있다."
+else
+  curl -sfL https://get.k3s.io | sh - || fail "k3s 설치 실패"
+fi
+# 이 뒤로 kubectl 을 쓰려면 kubeconfig 가 필요하다.
+export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
+kubectl get nodes >/dev/null || fail "k3s 가 응답하지 않는다"
+kubectl create namespace "$NS" --dry-run=client -o yaml | kubectl apply -f - >/dev/null
+
+# --- 3. DuckDNS ---------------------------------------------------------------
+step "3/7 DuckDNS ($DOMAIN)"
+duck_update() {
+  curl -sS "https://www.duckdns.org/update?domains=$DUCKDNS_SUBDOMAIN&token=$DUCKDNS_TOKEN&ip="
+}
+result="$(duck_update)"
+[[ "$result" == "OK" ]] || fail "DuckDNS 갱신 실패: $result"
+echo "  갱신됨."
+
+# 공인 IP 가 바뀌면(인스턴스를 껐다 켜면 바뀔 수 있다) 도메인이 엉뚱한 곳을 가리킨다.
+# 5분마다 갱신해 둔다.
+cat > /usr/local/bin/duckdns-update <<EOF
+#!/bin/sh
+curl -sS "https://www.duckdns.org/update?domains=$DUCKDNS_SUBDOMAIN&token=$DUCKDNS_TOKEN&ip=" >/dev/null
+EOF
+chmod 700 /usr/local/bin/duckdns-update   # 토큰이 들어 있다
+echo '*/5 * * * * root /usr/local/bin/duckdns-update' > /etc/cron.d/duckdns
+echo "  5분마다 갱신하도록 걸었다."
+
+# --- 4. Caddy -----------------------------------------------------------------
+step "4/7 Caddy"
+if ! command -v caddy >/dev/null 2>&1; then
+  if command -v apt-get >/dev/null 2>&1; then
+    DEBIAN_FRONTEND=noninteractive apt-get update -qq
+    DEBIAN_FRONTEND=noninteractive apt-get install -y debian-keyring debian-archive-keyring apt-transport-https curl >/dev/null
+    curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/gpg.key' \
+      | gpg --dearmor -o /usr/share/keyrings/caddy-stable-archive-keyring.gpg
+    curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/debian.deb.txt' \
+      > /etc/apt/sources.list.d/caddy-stable.list
+    DEBIAN_FRONTEND=noninteractive apt-get update -qq
+    DEBIAN_FRONTEND=noninteractive apt-get install -y caddy >/dev/null
+  else
+    dnf install -y 'dnf-command(copr)' >/dev/null && dnf copr enable -y @caddy/caddy >/dev/null && dnf install -y caddy >/dev/null
+  fi
+fi
+
+# 도메인 블록 안에서는 벗은 reverse_proxy 와 handle 을 섞을 수 없다. 라우트를 늘릴 것을
+# 생각해 처음부터 전부 handle 로 감싼다. 나중에 하나 추가하려다 기존 것까지 고치게 된다.
+cat > /etc/caddy/Caddyfile <<EOF
+$DOMAIN {
+	handle /kafka-ui* {
+		reverse_proxy localhost:30901
+	}
+	handle {
+		reverse_proxy localhost:$API_NODEPORT
+	}
+}
+EOF
+systemctl enable --now caddy >/dev/null 2>&1 || true
+systemctl reload caddy 2>/dev/null || systemctl restart caddy
+echo "  $DOMAIN -> localhost:$API_NODEPORT"
+
+# --- 5. 에이전트 수집 TLS -----------------------------------------------------
+# 에이전트는 RootCAs 만 갈아끼우고 InsecureSkipVerify 를 쓰지 않는다. 그래서 접속 주소의
+# 호스트가 인증서 SAN 과 같아야 한다. 도메인을 바꾸면 여기도 다시 만들어야 한다.
+step "5/7 agent-tls"
+command -v keytool >/dev/null 2>&1 || {
+  if command -v apt-get >/dev/null 2>&1; then
+    DEBIAN_FRONTEND=noninteractive apt-get install -y openjdk-21-jre-headless >/dev/null
+  else
+    dnf install -y java-21-openjdk-headless >/dev/null
+  fi
+}
+TLS_DIR=/etc/edrdog/agent-tls
+mkdir -p "$TLS_DIR"
+rm -f "$TLS_DIR/agent-keystore.p12"
+keytool -genkeypair -alias agent -keyalg RSA -keysize 2048 -validity 825 \
+  -dname "CN=$DOMAIN" -ext "SAN=dns:$DOMAIN,ip:127.0.0.1" \
+  -keystore "$TLS_DIR/agent-keystore.p12" -storetype PKCS12 \
+  -storepass "$AGENT_TLS_KEYSTORE_PASSWORD" -keypass "$AGENT_TLS_KEYSTORE_PASSWORD" >/dev/null
+chmod 600 "$TLS_DIR/agent-keystore.p12"
+
+# 이름이 agent-tls 여야 한다. 매니페스트가 optional:true 로 참조해서, 이름이 틀리면
+# 값이 안 들어오고 커넥터가 꺼진 채로 api-service 는 멀쩡히 뜬다. 파드는 정상인데
+# 에이전트만 한 대도 못 붙는 상태가 되는데, 그 조합이 가장 짚기 어렵다.
+kubectl -n "$NS" delete secret agent-tls --ignore-not-found >/dev/null
+kubectl -n "$NS" create secret generic agent-tls \
+  --from-file=keystore.p12="$TLS_DIR/agent-keystore.p12" \
+  --from-literal=AGENT_TLS_ENABLED=true \
+  --from-literal=AGENT_TLS_KEYSTORE_PASSWORD="$AGENT_TLS_KEYSTORE_PASSWORD" >/dev/null
+echo "  SAN=dns:$DOMAIN"
+
+# --- 6. GHCR 자격증명 ---------------------------------------------------------
+# GHCR 패키지는 기본이 비공개다. 이게 없으면 파드가 ImagePullBackOff 로 멈춘다.
+step "6/7 GHCR 자격증명"
+kubectl -n "$NS" delete secret ghcr --ignore-not-found >/dev/null
+kubectl -n "$NS" create secret docker-registry ghcr \
+  --docker-server=ghcr.io \
+  --docker-username="$GHCR_USER" \
+  --docker-password="$GHCR_TOKEN" >/dev/null
+# default 서비스어카운트에 붙여 두면 매니페스트마다 imagePullSecrets 를 적지 않아도 된다.
+kubectl -n "$NS" patch serviceaccount default \
+  -p '{"imagePullSecrets":[{"name":"ghcr"}]}' >/dev/null
+echo "  default 서비스어카운트에 붙였다."
+
+# --- 7. 인프라 매니페스트 -----------------------------------------------------
+step "7/7 인프라 매니페스트"
+if [[ -d "$REPO_DIR/.git" ]]; then
+  git -C "$REPO_DIR" fetch --quiet origin main || true
+  for f in k8s/00-namespace.yaml k8s/mysql.yaml k8s/kafka.yaml k8s/clickhouse.yaml \
+           k8s/otel-lgtm.yaml k8s/alloy.yaml k8s/kafka-ui.yaml; do
+    git -C "$REPO_DIR" show "FETCH_HEAD:$f" | kubectl apply -f - >/dev/null && echo "  $f"
+  done
+else
+  echo "  $REPO_DIR 에 레포 클론이 없어 건너뛴다." >&2
+  echo "  git clone https://github.com/EDRdog/Backend.git $REPO_DIR 뒤에 다시 돌려라." >&2
+fi
+
+cat <<EOF
+
+준비 끝. 남은 것은 사람이 해야 한다.
+
+1) 오라클 콘솔에서 포트를 연다 (인스턴스 밖 설정이라 여기서 못 한다)
+   네트워킹 > 가상 클라우드 네트워크 > 서브넷 > 보안 목록 > 수신 규칙 추가
+     0.0.0.0/0  TCP  80
+     0.0.0.0/0  TCP  443
+     0.0.0.0/0  TCP  $AGENT_PORT      <- 에이전트가 붙는 포트
+
+2) 이미지를 GHCR 에 올린다
+   레포를 옮기면서 패키지가 따라오지 않아 지금 $GHCR_IMAGE_BASE 는 비어 있다.
+   main 에 푸시하면 CD 가 빌드해서 올린다. arm64 를 포함해 올라간다.
+
+3) 서비스 매니페스트를 apply 한다 (이미지가 올라간 뒤에)
+   for f in k8s/{detector,responder,archiver,api,alert,collector}-service.yaml; do
+     git -C $REPO_DIR show "FETCH_HEAD:\$f" | kubectl apply -f -
+   done
+
+4) 확인
+   kubectl -n $NS get pods
+   curl -sS https://$DOMAIN/actuator/health
+   openssl s_client -connect $DOMAIN:$AGENT_PORT </dev/null 2>/dev/null | head -3
+
+kubectl 을 그냥 쓰려면:
+   echo 'export KUBECONFIG=/etc/rancher/k3s/k3s.yaml' >> ~/.bashrc
+EOF

--- a/scripts/bootstrap-oracle.sh
+++ b/scripts/bootstrap-oracle.sh
@@ -89,10 +89,19 @@ fi
 
 # --- 2. k3s -------------------------------------------------------------------
 step "2/7 k3s"
+# traefik 을 끄고 깐다. k3s 는 기본으로 traefik 을 깔고 그게 호스트 80/443 을 잡는데,
+# 그러면 Caddy 가 "address already in use" 로 못 뜬다. 우리는 Caddy 로 프록시한다.
 if command -v k3s >/dev/null 2>&1; then
   echo "  이미 깔려 있다."
 else
-  curl -sfL https://get.k3s.io | sh - || fail "k3s 설치 실패"
+  curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC="--disable=traefik" sh - || fail "k3s 설치 실패"
+fi
+export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
+# 이미 깔린 뒤에 이 스크립트를 돌리는 경우가 있다. 그때도 traefik 은 걷어낸다.
+if kubectl -n kube-system get helmchart traefik >/dev/null 2>&1; then
+  echo "  traefik 을 걷어낸다 (Caddy 와 80/443 을 다툰다)"
+  kubectl -n kube-system delete helmchart traefik traefik-crd --ignore-not-found >/dev/null
+  kubectl -n kube-system delete deploy traefik --ignore-not-found >/dev/null
 fi
 export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
 kubectl get nodes >/dev/null || fail "k3s 가 응답하지 않는다"
@@ -118,6 +127,14 @@ echo "  5분마다 갱신하도록 걸었다."
 
 # --- 4. Caddy -----------------------------------------------------------------
 step "4/7 Caddy"
+# 80 을 다른 웹서버가 잡고 있으면 Caddy 가 "address already in use" 로 못 뜬다.
+# 실제 인스턴스에 nginx 가 올라와 있었다. 그 상태로는 아래 restart 가 조용히 실패한다.
+for other in nginx apache2 httpd; do
+  if systemctl is-active --quiet "$other" 2>/dev/null; then
+    echo "  $other 가 80 을 잡고 있어 내린다"
+    systemctl disable --now "$other" >/dev/null 2>&1 || true
+  fi
+done
 if ! command -v caddy >/dev/null 2>&1; then
   if command -v apt-get >/dev/null 2>&1; then
     DEBIAN_FRONTEND=noninteractive apt-get update -qq

--- a/scripts/bootstrap-oracle.sh
+++ b/scripts/bootstrap-oracle.sh
@@ -41,8 +41,7 @@ for v in DUCKDNS_TOKEN GHCR_USER GHCR_TOKEN AGENT_TLS_KEYSTORE_PASSWORD; do
   [[ -n "${!v:-}" ]] || fail "$v 가 필요하다"
 done
 
-# 아키텍처를 먼저 본다. 여기서 짚어 주지 않으면 나중에 파드가 exec format error 로만
-# 죽는데, 그 메시지로는 원인이 아키텍처라는 것을 알기 어렵다.
+# 여기서 안 짚으면 나중에 파드가 exec format error 로만 죽는다.
 ARCH="$(uname -m)"
 step "0/7 확인 (arch=$ARCH)"
 case "$ARCH" in
@@ -90,7 +89,6 @@ if command -v k3s >/dev/null 2>&1; then
 else
   curl -sfL https://get.k3s.io | sh - || fail "k3s 설치 실패"
 fi
-# 이 뒤로 kubectl 을 쓰려면 kubeconfig 가 필요하다.
 export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
 kubectl get nodes >/dev/null || fail "k3s 가 응답하지 않는다"
 kubectl create namespace "$NS" --dry-run=client -o yaml | kubectl apply -f - >/dev/null
@@ -104,8 +102,7 @@ result="$(duck_update)"
 [[ "$result" == "OK" ]] || fail "DuckDNS 갱신 실패: $result"
 echo "  갱신됨."
 
-# 공인 IP 가 바뀌면(인스턴스를 껐다 켜면 바뀔 수 있다) 도메인이 엉뚱한 곳을 가리킨다.
-# 5분마다 갱신해 둔다.
+# 인스턴스를 껐다 켜면 공인 IP 가 바뀐다.
 cat > /usr/local/bin/duckdns-update <<EOF
 #!/bin/sh
 curl -sS "https://www.duckdns.org/update?domains=$DUCKDNS_SUBDOMAIN&token=$DUCKDNS_TOKEN&ip=" >/dev/null
@@ -131,8 +128,7 @@ if ! command -v caddy >/dev/null 2>&1; then
   fi
 fi
 
-# 도메인 블록 안에서는 벗은 reverse_proxy 와 handle 을 섞을 수 없다. 라우트를 늘릴 것을
-# 생각해 처음부터 전부 handle 로 감싼다. 나중에 하나 추가하려다 기존 것까지 고치게 된다.
+# 도메인 블록 안에서 벗은 reverse_proxy 와 handle 은 섞을 수 없다. 처음부터 전부 감싼다.
 cat > /etc/caddy/Caddyfile <<EOF
 $DOMAIN {
 	handle /kafka-ui* {
@@ -148,8 +144,7 @@ systemctl reload caddy 2>/dev/null || systemctl restart caddy
 echo "  $DOMAIN -> localhost:$API_NODEPORT"
 
 # --- 5. 에이전트 수집 TLS -----------------------------------------------------
-# 에이전트는 RootCAs 만 갈아끼우고 InsecureSkipVerify 를 쓰지 않는다. 그래서 접속 주소의
-# 호스트가 인증서 SAN 과 같아야 한다. 도메인을 바꾸면 여기도 다시 만들어야 한다.
+# 에이전트가 호스트명을 SAN 과 대조한다. 도메인을 바꾸면 여기도 다시 만들어야 한다.
 step "5/7 agent-tls"
 command -v keytool >/dev/null 2>&1 || {
   if command -v apt-get >/dev/null 2>&1; then
@@ -167,9 +162,8 @@ keytool -genkeypair -alias agent -keyalg RSA -keysize 2048 -validity 825 \
   -storepass "$AGENT_TLS_KEYSTORE_PASSWORD" -keypass "$AGENT_TLS_KEYSTORE_PASSWORD" >/dev/null
 chmod 600 "$TLS_DIR/agent-keystore.p12"
 
-# 이름이 agent-tls 여야 한다. 매니페스트가 optional:true 로 참조해서, 이름이 틀리면
-# 값이 안 들어오고 커넥터가 꺼진 채로 api-service 는 멀쩡히 뜬다. 파드는 정상인데
-# 에이전트만 한 대도 못 붙는 상태가 되는데, 그 조합이 가장 짚기 어렵다.
+# 이름이 agent-tls 여야 한다. 매니페스트가 optional:true 로 참조해서, 틀리면 커넥터가
+# 꺼진 채로 파드는 멀쩡히 뜬다. 정상으로 보이는데 에이전트만 못 붙는다.
 kubectl -n "$NS" delete secret agent-tls --ignore-not-found >/dev/null
 kubectl -n "$NS" create secret generic agent-tls \
   --from-file=keystore.p12="$TLS_DIR/agent-keystore.p12" \


### PR DESCRIPTION
배포서버를 오라클 Ampere A1 으로 옮긴다.

## arm64 이미지가 없으면 아무것도 안 뜬다

지금 CD 는 amd64 만 올린다. Ampere A1 은 arm64 라 그대로 배포하면 파드가 전부 `exec format error` 로 죽는다. 그 메시지만 봐서는 원인이 아키텍처라는 걸 알기 어렵다.

멀티아키가 싸다. `Dockerfile` 이 JRE 위에 jar 를 얹는 게 전부라 아키텍처마다 다시 컴파일하는 것이 없다.

인프라 이미지 일곱 개도 `docker manifest inspect` 로 arm64 를 확인했다.

| 이미지 | arm64 |
|---|---|
| `clickhouse/clickhouse-server:24.8` | O |
| `apache/kafka:3.9.0` | O |
| `mysql:8.0` | O |
| `grafana/alloy:v1.18.0` | O |
| `grafana/otel-lgtm:0.29.2` | O |
| `ghcr.io/kafbat/kafka-ui:v1.5.0` | O |
| `eclipse-temurin:21-jre` | O |

## 부트스트랩 스크립트

새 인스턴스에서 한 번 돌리면 배포서버가 된다. 여러 번 돌려도 안전하다.

```bash
sudo DUCKDNS_TOKEN=... GHCR_USER=... GHCR_TOKEN=... \
  AGENT_TLS_KEYSTORE_PASSWORD=... ./scripts/bootstrap-oracle.sh
```

방화벽, k3s, DuckDNS(+5분 갱신), Caddy, `agent-tls`, GHCR 자격증명, 인프라 매니페스트까지 한다.

**호스트 방화벽을 여는 것이 이 스크립트가 있는 가장 큰 이유다.** 오라클 이미지는 INPUT 사슬 끝에 REJECT 가 박힌 채로 나온다. 콘솔의 보안 목록만 열고 호스트를 안 열면 밖에서는 그냥 타임아웃으로 보인다. 규칙 저장도 같이 한다. 안 하면 재부팅한 어느 날 갑자기 안 붙는다.

## 확인해 둔 것

**GHCR 이 비어 있다.** 레포를 `EDRdog` 로 옮기면서 패키지가 따라오지 않았다.

```
$ gh api /orgs/EDRdog/packages?package_type=container
[]
```

`main` 에 푸시해야 채워진다. 그리고 기본이 비공개라 서버에 pull secret 이 필요하다. 스크립트가 넣는다.

## 스크립트가 안 하는 것

오라클 콘솔의 보안 목록(80/443/30443)은 인스턴스 밖 설정이라 건드릴 수 없다. 못 한다고 적고 무엇을 열어야 하는지 알려준다.