### PR TITLE
fix: CORS 허용 출처에 새 프론트 도메인 추가

### DIFF
--- a/k8s/api-service.yaml
+++ b/k8s/api-service.yaml
@@ -59,10 +59,10 @@ spec:
               value: "edrdog"
             - name: EDRDOG_CLICKHOUSE_URL
               value: "http://clickhouse:8123"
-            # 프론트 도메인 (배포 시 실제 값으로 교체)
-            # 배포된 프론트(Vercel) + 로컬 dev 서버. 서버 실제 값과 같게 둔다.
+            # 프론트 도메인. 서버 실제 값과 같게 둔다.
+            # CorsConfig 가 setAllowedOrigins 라 정확히 일치하는 출처만 통과한다(빠지면 브라우저만 403).
             - name: CORS_ALLOWED_ORIGINS
-              value: "https://frontend1-ten-gamma.vercel.app,http://localhost:5173"
+              value: "https://edrdog.duckdns.org,https://frontend1-ten-gamma.vercel.app,http://localhost:5173"
             # 발표 환경에서만 true (데모 계정 test/1234 + 과거 7일 시드).
             # 현재 배포서버가 true 라 그대로 맞춘다. 해커톤이 끝나면 false 로 되돌린다.
             - name: DEMO_SEED


### PR DESCRIPTION
## 문제
프론트가 `https://edrdog.duckdns.org` 로 옮겨갔는데 `k8s/api-service.yaml` 의 `CORS_ALLOWED_ORIGINS` 는 옛 Vercel 주소만 갖고 있었다.

```
OPTIONS /api/tenant/install-link
  Origin: https://edrdog.duckdns.org
→ HTTP 403, Access-Control-Allow-Origin 없음
```

`CorsConfig` 가 `setAllowedOrigins` 라 문자열이 정확히 일치해야 통과한다. curl 로 200/401 이 보였던 건 curl 이 CORS 를 타지 않아서였다.

## 변경
`CORS_ALLOWED_ORIGINS` 에 `https://edrdog.duckdns.org` 추가. 옛 Vercel 주소와 `localhost:5173` 은 그대로 뒀다.

## 배포 반영 (수동 필요)
CD 는 서비스 매니페스트를 apply 하지 않는다. main 머지만으로는 서버에 반영되지 않으니 서버에서 아래를 한 번 돌려야 한다 (`k8s/README.md` 절차).

```bash
IMG=$(sudo kubectl -n edrdog get deploy/api-service -o jsonpath='{.spec.template.spec.containers[0].image}')
sudo kubectl -n edrdog apply -f k8s/api-service.yaml
sudo kubectl -n edrdog set image deployment/api-service api-service="$IMG"
sudo kubectl -n edrdog rollout status deployment/api-service
```