### PR TITLE
feat: 설치 링크 만드는 쪽에서도 키를 없앤다

### DIFF
--- a/agent/README.md
+++ b/agent/README.md
@@ -333,10 +333,34 @@ level=ERROR msg="패킷 캡처를 열지 못해 dns/l7 수집을 건너뛴다" e
 
 키를 사람 손에 쥐여 주면 채팅방에 붙고 스크린샷에 남는다. 그래서 링크 쪽이 편의만의 문제가 아니다.
 
+**링크를 만드는 쪽도 키를 다루지 않는다.** 스크립트가 로그인부터 발급까지 한 번에 한다.
+
 ```bash
-# 관리자: 링크 발급 (로그인 토큰 필요)
+./scripts/install-link.sh me@example.com
+```
+
+```
+비밀번호:
+
+macOS — 터미널에 붙여넣는다:
+
+  curl -fsSL https://edr.example.com/i/AbC123 | sudo bash
+
+Windows — 관리자 권한 PowerShell 에 붙여넣는다:
+
+  irm https://edr.example.com/i/AbC123.ps1 | iex
+```
+
+대시보드에 "기기 추가" 버튼이 생기면 그쪽이 이 자리를 대신한다. 그때까지 쓰는 것이다.
+
+직접 부르려면 이렇게 한다. `X-API-Key` 는 필요 없다. 이 경로는 Bearer 로만 인증한다
+(`ApiKeyPolicy.EXEMPT_PATHS`). 접두어가 아니라 정확히 이 경로만 여는데, `/api/tenant` 아래에
+enroll secret 과 webhook 이 같이 있어서다. 설치 링크는 만료되지만 enroll secret 은 테넌트당
+하나에 만료가 없어 한 번 새면 되돌리기 어렵다.
+
+```bash
 curl -X POST https://edr.example.com/api/tenant/install-link \
-  -H "Authorization: Bearer <로그인 토큰>" -H "X-API-Key: <프론트 키>"
+  -H "Authorization: Bearer <로그인 토큰>"
 ```
 
 ```json

--- a/api-service/src/main/java/com/edrdog/apiservice/security/ApiKeyPolicy.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/security/ApiKeyPolicy.java
@@ -23,6 +23,20 @@ public class ApiKeyPolicy {
                            // curl 한 줄로 받아야 해서 헤더를 붙일 수가 없다. 대신 토큰을 짧게 살린다.
     );
 
+    /**
+     * 정확히 이 경로일 때만 예외인 것들.
+     *
+     * <p>접두어로 두지 않는 이유는 {@code /api/tenant} 아래에 enroll secret 과 webhook 이 같이
+     * 있어서다. 접두어로 열면 그 둘까지 딸려 열린다. 설치 링크는 만료되지만 enroll secret 은
+     * 테넌트당 하나에 만료가 없어서, 한 번 새면 되돌릴 방법이 마땅치 않다.
+     */
+    private static final List<String> EXEMPT_PATHS = List.of(
+            // 대시보드(또는 그 대신 쓰는 스크립트)가 부르고 Bearer 로 이미 인증한다. API 키까지
+            // 요구하면 기기 하나 추가하려고 사람이 키 두 개를 손에 쥐어야 한다. 설치하는 사람에게서
+            // 키를 없애 놓고 만드는 사람에게 남겨 두면 절반만 한 것이다.
+            "/api/tenant/install-link"
+    );
+
     private final String configuredKey;
 
     public ApiKeyPolicy(String configuredKey) {
@@ -41,7 +55,7 @@ public class ApiKeyPolicy {
 
     /** 헬스체크·Swagger 등 인증 없이 열어두는 경로. */
     public boolean isExempt(String path) {
-        return EXEMPT_PREFIXES.stream().anyMatch(path::startsWith);
+        return EXEMPT_PATHS.contains(path) || EXEMPT_PREFIXES.stream().anyMatch(path::startsWith);
     }
 
     /** 제공된 키가 설정 키와 정확히 일치하면 통과. null/빈 값은 거부. */

--- a/api-service/src/test/java/com/edrdog/apiservice/security/ApiKeyPolicyTest.java
+++ b/api-service/src/test/java/com/edrdog/apiservice/security/ApiKeyPolicyTest.java
@@ -49,6 +49,27 @@ class ApiKeyPolicyTest {
     }
 
     @Test
+    void 설치_링크_발급은_세션_Bearer_예외() {
+        // 이걸 부르는 건 대시보드(또는 그 대신 쓰는 스크립트)뿐이고 Bearer 로 이미 인증한다.
+        // API 키까지 요구하면 기기 하나 추가하려고 사람이 키 두 개를 손에 쥐어야 한다.
+        // 설치하는 사람에게서 키를 없애 놓고 만드는 사람에게 남겨 두면 절반만 한 것이다.
+        assertTrue(policy.isExempt("/api/tenant/install-link"));
+    }
+
+    @Test
+    void 나머지_tenant_경로는_여전히_API키가_필요하다() {
+        // enroll secret 은 그 자체가 배포 자격증명이고 webhook 은 알림이 나가는 곳이다.
+        // 설치 링크와 달리 한 번 새면 되돌릴 방법이 마땅치 않아 문을 더 좁게 둔다.
+        assertFalse(policy.isExempt("/api/tenant/enroll-secret"));
+        assertFalse(policy.isExempt("/api/tenant/webhook"));
+    }
+
+    @Test
+    void 설치_링크_접두어만_같은_경로는_예외가_아님() {
+        assertFalse(policy.isExempt("/api/tenant/install-links-all"));
+    }
+
+    @Test
     void auth_접두어만_같은_경로는_예외가_아님() {
         assertFalse(policy.isExempt("/api/authz"));
         assertFalse(policy.isExempt("/api/auth-logs"));

--- a/scripts/install-link.sh
+++ b/scripts/install-link.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# 엔드포인트에 붙여넣을 설치 명령을 만든다.
+#
+#   ./scripts/install-link.sh me@example.com
+#
+# 로그인해서 설치 링크를 받는 것까지 한 번에 한다. 대시보드에 "기기 추가" 버튼이 생기면
+# 그쪽이 이 자리를 대신한다. 그때까지 쓰는 것이다.
+#
+# 받는 쪽은 아무것도 다루지 않는다. 나온 한 줄을 붙여넣으면 끝난다.
+set -euo pipefail
+
+SERVER="${SERVER:-https://edrdog-api.duckdns.org}"
+EMAIL="${1:-}"
+
+fail() { echo "오류: $*" >&2; exit 1; }
+
+[[ -n "$EMAIL" ]] || fail "사용법: $0 <이메일>   (서버를 바꾸려면 SERVER=https://... )"
+[[ -r /dev/tty ]] || fail "비밀번호를 물어야 해서 터미널에서 실행해야 한다"
+
+# 값에 " 나 \ 가 들어 있으면 그냥 이어 붙인 본문은 깨진 JSON 이 되고, 서버는 그걸 로그인
+# 실패로 돌려준다. 비밀번호가 맞는데 안 되는 것만큼 붙잡기 어려운 것이 없다.
+json_string() {
+  local s=$1
+  s=${s//\\/\\\\}
+  s=${s//\"/\\\"}
+  printf '"%s"' "$s"
+}
+
+# 콜론 둘레의 공백을 허용한다. 지금 서버(Jackson)는 공백 없이 내보내지만, 앞에 프록시가
+# 하나 끼어 본문을 다시 찍으면 값이 조용히 빈 문자열이 된다.
+json_field() {
+  sed -n "s/.*\"$1\"[[:space:]]*:[[:space:]]*\"\([^\"]*\)\".*/\1/p"
+}
+
+read -rsp "비밀번호: " PASSWORD < /dev/tty
+echo
+[[ -n "$PASSWORD" ]] || fail "비밀번호가 비었다"
+
+TOKEN="$(curl -fsS -X POST "$SERVER/api/auth/login" \
+  -H 'Content-Type: application/json' \
+  -d "$(printf '{"email":%s,"password":%s}' "$(json_string "$EMAIL")" "$(json_string "$PASSWORD")")" \
+  | json_field token)" || fail "로그인 실패"
+[[ -n "$TOKEN" ]] || fail "로그인 응답에 토큰이 없다"
+
+# X-API-Key 를 안 보낸다. 이 경로는 Bearer 로만 인증한다(ApiKeyPolicy.EXEMPT_PATHS).
+RESPONSE="$(curl -fsS -X POST "$SERVER/api/tenant/install-link" \
+  -H "Authorization: Bearer $TOKEN")" || fail "설치 링크 발급 실패"
+
+MACOS="$(json_field macosCommand <<<"$RESPONSE")"
+WINDOWS="$(json_field windowsCommand <<<"$RESPONSE")"
+EXPIRES="$(json_field expiresAt <<<"$RESPONSE")"
+[[ -n "$MACOS" ]] || fail "응답에 설치 명령이 없다: $RESPONSE"
+
+cat <<EOF
+
+macOS — 터미널에 붙여넣는다:
+
+  $MACOS
+
+Windows — 관리자 권한 PowerShell 에 붙여넣는다:
+
+  $WINDOWS
+
+이 링크는 $EXPIRES 까지 쓸 수 있고, 그 안에는 여러 대에 써도 된다.
+EOF


### PR DESCRIPTION
설치하는 사람에게서 키를 없애 놓고 **링크를 만드는 사람에게는 남겨 뒀다.** 절반만 한 것이었다. 기기 하나 추가하려고 로그인 토큰과 프론트 API 키를 손으로 받아 붙여야 했다.

## 이렇게 된다

```
$ ./scripts/install-link.sh me@example.com
비밀번호:

macOS — 터미널에 붙여넣는다:

  curl -fsSL https://edrdog-api.duckdns.org/i/AbC123 | sudo bash

Windows — 관리자 권한 PowerShell 에 붙여넣는다:

  irm https://edrdog-api.duckdns.org/i/AbC123.ps1 | iex

이 링크는 2026-08-01T05:20:00Z 까지 쓸 수 있고, 그 안에는 여러 대에 써도 된다.
```

## X-API-Key 를 뺀다

`/api/hosts`, `/api/alerts`, `/api/events` 는 전부 Bearer 만으로 되게 예외로 두면서 `/api/tenant` 만 빠져 있었다. 일관성이 없었다.

**접두어가 아니라 정확히 그 경로만 연다.** `/api/tenant` 아래에는 enroll secret 과 webhook 이 같이 있어서, 접두어로 열면 그 둘까지 딸려 열린다. 설치 링크는 24시간이면 죽지만 enroll secret 은 테넌트당 하나에 만료가 없어 한 번 새면 되돌리기 어렵다. 그래서 `EXEMPT_PATHS` 를 따로 뒀다.

## 확인

배포된 서버에 대고 실제로 확인했다.

```
로그인 OK (토큰 43자)
install-link, Bearer 만: 401
```

없애려는 마찰이 실제로 거기 있다는 뜻이다. 이게 배포되면 200 이 되어야 한다.

응답 파싱도 실제 응답 모양으로 확인했다. 값에 공백과 `|` 가 들어 있어도 제대로 꺼낸다.

## 참고

작업 트리에 커밋 안 된 swagger basic auth 작업(`SwaggerAuthFilter`, `SwaggerAuthPolicy`, `k8s/kafka-ui.yaml` 로그인 폼)이 섞여 있었다. 이 PR 에는 넣지 않았다.