### PR TITLE
feat: 포테이너로 컨테이너를 보고, 운영 UI 는 전부 로그인 뒤로 넣는다

### DIFF
--- a/api-service/src/main/java/com/edrdog/apiservice/security/SwaggerAuthFilter.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/security/SwaggerAuthFilter.java
@@ -1,0 +1,52 @@
+package com.edrdog.apiservice.security;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+/**
+ * Swagger 경로를 Basic 인증으로 가린다. 판단은 SwaggerAuthPolicy(순수), 여기서는 HTTP 만 담당한다.
+ *
+ * <p>어느 필터가 401 을 냈는지 헷갈리지 않게 ApiKeyFilter 보다 먼저 돌도록 고정한다.
+ */
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE)
+public class SwaggerAuthFilter extends OncePerRequestFilter {
+
+    private final SwaggerAuthPolicy policy;
+
+    public SwaggerAuthFilter(@Value("${edrdog.swagger.user}") String user,
+                             @Value("${edrdog.swagger.password}") String password) {
+        this.policy = new SwaggerAuthPolicy(user, password);
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain)
+            throws ServletException, IOException {
+        String path = request.getRequestURI();
+        if (!policy.isProtected(path) || policy.isAuthorized(request.getHeader("Authorization"))) {
+            chain.doFilter(request, response);
+            return;
+        }
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+        if (policy.isConfigured()) {
+            // 이 헤더가 있어야 브라우저가 아이디/비번 입력창을 띄운다.
+            response.setHeader("WWW-Authenticate", "Basic realm=\"EDRdog Swagger\", charset=\"UTF-8\"");
+            response.getWriter().write("{\"error\":\"Swagger 는 로그인이 필요합니다\"}");
+        } else {
+            response.getWriter().write(
+                    "{\"error\":\"EDRDOG_SWAGGER_PASSWORD 가 설정되지 않아 Swagger 를 닫아 두었습니다\"}");
+        }
+    }
+}

--- a/api-service/src/main/java/com/edrdog/apiservice/security/SwaggerAuthPolicy.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/security/SwaggerAuthPolicy.java
@@ -1,0 +1,62 @@
+package com.edrdog.apiservice.security;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.List;
+
+/**
+ * Swagger 를 가리는 Basic 인증 판단(순수).
+ *
+ * <p>브라우저로 여는 화면이라 X-API-Key 를 붙일 수가 없어서(ApiKeyPolicy 가 예외로 둔 이유)
+ * 브라우저가 스스로 붙일 수 있는 Basic 만 본다.
+ */
+public class SwaggerAuthPolicy {
+
+    private static final List<String> PROTECTED_PREFIXES = List.of(
+            "/swagger-ui",
+            "/v3/api-docs"
+    );
+
+    private static final String SCHEME = "basic ";
+
+    private final String user;
+    private final String password;
+
+    public SwaggerAuthPolicy(String user, String password) {
+        this.user = user;
+        this.password = password;
+    }
+
+    public boolean isProtected(String path) {
+        return PROTECTED_PREFIXES.stream().anyMatch(path::startsWith);
+    }
+
+    /** 미설정이면 인증을 요구해도 답할 값이 없다. 그때 팝업을 띄우면 브라우저가 무한히 되묻는다. */
+    public boolean isConfigured() {
+        return password != null && !password.isEmpty();
+    }
+
+    /** 비번이 없으면 열어 두지 않고 전부 막는다. 열린 채로 두면 알아채기 어렵다. */
+    public boolean isAuthorized(String authorizationHeader) {
+        if (!isConfigured()) {
+            return false;
+        }
+        if (authorizationHeader == null || !authorizationHeader.toLowerCase().startsWith(SCHEME)) {
+            return false;
+        }
+        String decoded;
+        try {
+            decoded = new String(
+                    Base64.getDecoder().decode(authorizationHeader.substring(SCHEME.length()).trim()),
+                    StandardCharsets.UTF_8);
+        } catch (IllegalArgumentException e) {
+            return false;
+        }
+        // 비번에 콜론이 들어갈 수 있어 첫 콜론에서만 자른다(RFC 7617).
+        int sep = decoded.indexOf(':');
+        if (sep < 0) {
+            return false;
+        }
+        return user.equals(decoded.substring(0, sep)) && password.equals(decoded.substring(sep + 1));
+    }
+}

--- a/api-service/src/main/resources/application.yml
+++ b/api-service/src/main/resources/application.yml
@@ -46,6 +46,10 @@ edrdog:
       key-alias: ${AGENT_TLS_KEY_ALIAS:agent}
   api:
     key: ${EDRDOG_API_KEY:dev-api-key}   # 프론트가 X-API-Key 헤더로 보낼 값 (운영은 환경변수로 주입)
+  swagger:                               # Swagger 를 가리는 Basic 계정 (운영은 Infisical 주입)
+    user: ${EDRDOG_SWAGGER_USER:admin}
+    # 기본값을 두지 않는다. 레포에 박으면 그게 곧 공개 비번이다. 없으면 Swagger 는 닫힌다.
+    password: ${EDRDOG_SWAGGER_PASSWORD:}
   install:
     # 설치 링크(/i/<토큰>). 사용자가 키를 손으로 다루지 않게 하려고 둔 경로다.
     # 링크의 앞부분. 대시보드가 보여줄 명령줄을 서버가 조립하는 데 쓴다.

--- a/api-service/src/test/java/com/edrdog/apiservice/security/SwaggerAuthFilterTest.java
+++ b/api-service/src/test/java/com/edrdog/apiservice/security/SwaggerAuthFilterTest.java
@@ -1,0 +1,84 @@
+package com.edrdog.apiservice.security;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * 필터가 HTTP 로 옮기는 부분: 어떤 상태코드를 내고, 브라우저에 로그인창을 띄우고, 뒤로 넘기는지.
+ */
+class SwaggerAuthFilterTest {
+
+    private static String basic(String user, String password) {
+        return "Basic " + Base64.getEncoder()
+                .encodeToString((user + ":" + password).getBytes(StandardCharsets.UTF_8));
+    }
+
+    private static MockHttpServletRequest request(String path, String authorization) {
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", path);
+        request.setRequestURI(path);
+        if (authorization != null) {
+            request.addHeader("Authorization", authorization);
+        }
+        return request;
+    }
+
+    @Test
+    void 자격증명이_없으면_401_과_함께_로그인창을_띄운다() throws Exception {
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+
+        new SwaggerAuthFilter("admin", "s3cret")
+                .doFilter(request("/swagger-ui/index.html", null), response, chain);
+
+        assertEquals(401, response.getStatus());
+        assertNotNull(response.getHeader("WWW-Authenticate"));
+        assertNull(chain.getRequest(), "뒤로 넘어가면 안 된다");
+    }
+
+    @Test
+    void 자격증명이_맞으면_뒤로_넘긴다() throws Exception {
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+
+        new SwaggerAuthFilter("admin", "s3cret")
+                .doFilter(request("/v3/api-docs", basic("admin", "s3cret")), response, chain);
+
+        assertEquals(200, response.getStatus());
+        assertNotNull(chain.getRequest(), "뒤로 넘어가야 한다");
+    }
+
+    @Test
+    void 비번이_미설정이면_로그인창을_띄우지_않는다() throws Exception {
+        // 띄워봤자 맞는 값이 없어서 브라우저가 무한히 되묻는다.
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+
+        new SwaggerAuthFilter("admin", "")
+                .doFilter(request("/swagger-ui.html", null), response, chain);
+
+        assertEquals(401, response.getStatus());
+        assertNull(response.getHeader("WWW-Authenticate"));
+        assertNull(chain.getRequest());
+    }
+
+    @Test
+    void 프론트_경로는_건드리지_않는다() throws Exception {
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+
+        new SwaggerAuthFilter("admin", "s3cret")
+                .doFilter(request("/api/events", null), response, chain);
+
+        assertEquals(200, response.getStatus());
+        assertNotNull(chain.getRequest());
+    }
+}

--- a/api-service/src/test/java/com/edrdog/apiservice/security/SwaggerAuthPolicyTest.java
+++ b/api-service/src/test/java/com/edrdog/apiservice/security/SwaggerAuthPolicyTest.java
@@ -1,0 +1,90 @@
+package com.edrdog.apiservice.security;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Swagger 를 가리는 Basic 인증의 판단 로직(순수): 어떤 경로를 막고, 어떤 헤더를 통과시키는지.
+ */
+class SwaggerAuthPolicyTest {
+
+    private final SwaggerAuthPolicy policy = new SwaggerAuthPolicy("admin", "s3cret");
+
+    private static String basic(String user, String password) {
+        String raw = user + ":" + password;
+        return "Basic " + Base64.getEncoder().encodeToString(raw.getBytes(StandardCharsets.UTF_8));
+    }
+
+    @Test
+    void swagger_와_api_docs_는_보호_대상() {
+        assertTrue(policy.isProtected("/swagger-ui.html"));
+        assertTrue(policy.isProtected("/swagger-ui/index.html"));
+        assertTrue(policy.isProtected("/v3/api-docs"));
+        assertTrue(policy.isProtected("/v3/api-docs/swagger-config"));
+    }
+
+    @Test
+    void 프론트와_헬스체크_경로는_보호_대상이_아니다() {
+        assertFalse(policy.isProtected("/api/events"));
+        assertFalse(policy.isProtected("/api/auth/login"));
+        assertFalse(policy.isProtected("/actuator/health"));
+        assertFalse(policy.isProtected("/i/abc123"));
+    }
+
+    @Test
+    void 계정이_맞으면_통과() {
+        assertTrue(policy.isAuthorized(basic("admin", "s3cret")));
+    }
+
+    @Test
+    void 스킴은_대소문자를_가리지_않는다() {
+        assertTrue(policy.isAuthorized(basic("admin", "s3cret").replace("Basic", "basic")));
+    }
+
+    @Test
+    void 비번이나_아이디가_틀리면_거부() {
+        assertFalse(policy.isAuthorized(basic("admin", "wrong")));
+        assertFalse(policy.isAuthorized(basic("root", "s3cret")));
+    }
+
+    @Test
+    void 헤더가_없거나_Basic_이_아니면_거부() {
+        assertFalse(policy.isAuthorized(null));
+        assertFalse(policy.isAuthorized(""));
+        assertFalse(policy.isAuthorized("Bearer eyJhbGciOi"));
+    }
+
+    @Test
+    void 깨진_base64_나_구분자가_없으면_거부() {
+        assertFalse(policy.isAuthorized("Basic !!!not-base64!!!"));
+        assertFalse(policy.isAuthorized("Basic " + Base64.getEncoder()
+                .encodeToString("구분자없음".getBytes(StandardCharsets.UTF_8))));
+    }
+
+    @Test
+    void 비번이_비어_있으면_아무도_통과하지_못한다() {
+        // Infisical 이 값을 못 주면 열린 채로 두지 않고 전부 막는다.
+        SwaggerAuthPolicy 미설정 = new SwaggerAuthPolicy("admin", "");
+        assertFalse(미설정.isAuthorized(basic("admin", "")));
+        assertFalse(미설정.isAuthorized(basic("admin", "아무거나")));
+    }
+
+    @Test
+    void 비번이_설정됐는지_따로_알려준다() {
+        // 미설정이면 인증을 요구해도 답할 방법이 없다. 그때 팝업을 띄우면 브라우저가 무한히 되묻는다.
+        assertTrue(policy.isConfigured());
+        assertFalse(new SwaggerAuthPolicy("admin", "").isConfigured());
+        assertFalse(new SwaggerAuthPolicy("admin", null).isConfigured());
+    }
+
+    @Test
+    void 비번에_콜론이_있어도_뒤쪽_전부를_비번으로_본다() {
+        SwaggerAuthPolicy 콜론 = new SwaggerAuthPolicy("admin", "a:b:c");
+        assertTrue(콜론.isAuthorized(basic("admin", "a:b:c")));
+    }
+}

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -149,6 +149,33 @@ sudo kubectl -n edrdog logs deploy/api-service | grep 'GeoIP DB 로드'
 4번이 `GeoIP DB 로드(파일)` 이면 성공이다. `(클래스패스)` 면 볼륨의 파일을 못 읽어 jar 번들로
 넘어간 것이고, 그 상태로 mmdb 없는 이미지가 배포되면 지도가 빈다.
 
+## 운영 UI (Portainer / Kafka UI / Swagger)
+
+배포서버 전용이다. 셋 다 Caddy 뒤에 있고 NodePort 를 방화벽에 열지 않으므로 Caddy 를 통해서만 들어간다.
+
+| 대상 | 주소 | 인증 | NodePort |
+|---|---|---|---|
+| Portainer | `https://portainer.<도메인>` | Portainer 자체 로그인 | 30777 |
+| Kafka UI | `https://<도메인>/kafka-ui` | 없음 | 30901 |
+| Swagger | `https://<도메인>/swagger-ui.html` | 없음 | (api 30084) |
+
+### Portainer
+
+`k8s/portainer.yaml`. 첫 접속에서 관리자 계정을 만든다. **파드가 뜨고 5분 안에 안 만들면 스스로 잠근다.**
+
+```bash
+sudo kubectl -n portainer rollout restart deploy/portainer   # 잠겼을 때 다시 여는 법
+```
+
+- 이 계정은 `cluster-admin` 이라 `edrdog` 네임스페이스의 Secret(Infisical 이 동기화한 API 키, DB 비번)까지
+  전부 보인다. 비번을 세게 건다.
+- 서브패스(`/portainer`)가 아니라 서브도메인인 이유: 서브패스로 서비스하려면 `--base-url` 과 프록시의
+  prefix strip 이 정확히 한 번씩 맞아야 하고, 어긋나면 화면은 뜨는데 로그인이 안 된다.
+  DuckDNS 는 하위 도메인이 전부 같은 IP 로 와서 서브도메인이 공짜다.
+- `--trusted-origins` 가 없으면 Caddy 뒤에서 로그인할 때 `Origin invalid` 로 막힌다. 도메인을 바꾸면
+  매니페스트의 이 값도 같이 바꿔야 한다.
+- 계정과 설정은 PVC 에 있다(k3s `local-path`). 지우면 관리자 계정부터 다시 만들어야 한다.
+
 ## 시크릿 (Infisical)
 
 매니페스트에 평문으로 박혀 있던 값(`DB_PASSWORD`, `CLICKHOUSE_PASSWORD` 등)을 Infisical 로 옮긴다.

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -155,7 +155,7 @@ sudo kubectl -n edrdog logs deploy/api-service | grep 'GeoIP DB 로드'
 
 | 대상 | 주소 | 인증 | Infisical 키 | NodePort |
 |---|---|---|---|---|
-| Portainer | `https://portainer.<도메인>` | 자체 로그인 | (첫 접속에서 직접 생성) | 30777 |
+| Portainer | `https://portainer.<도메인>` | 자체 로그인 (`admin`) | `PORTAINER_ADMIN_PASSWORD` | 30777 |
 | Kafka UI | `https://<도메인>/kafka-ui` | 자체 로그인 폼 | `KAFKA_UI_USER` / `KAFKA_UI_PASSWORD` | 30901 |
 | Swagger | `https://<도메인>/swagger-ui.html` | Basic (`SwaggerAuthFilter`) | `EDRDOG_SWAGGER_USER` / `EDRDOG_SWAGGER_PASSWORD` | (api 30084) |
 
@@ -163,8 +163,9 @@ sudo kubectl -n edrdog logs deploy/api-service | grep 'GeoIP DB 로드'
 basic auth 를 걸면 비번이 Infisical 과 호스트 파일 두 군데로 갈라지고, Infisical 에서 바꿔도 호스트의
 Caddyfile 은 그대로라 반영되지 않는다.
 
-- **Kafka UI 는 키가 없으면 파드가 뜨지 않는다** (`secretKeyRef` 에 `optional` 을 안 줬다). 인증이 꺼진 채로
-  멀쩡히 떠 있는 것보다 멈추는 편이 낫다. 키를 넣은 뒤 `kubectl -n edrdog rollout restart deploy/kafka-ui`.
+- **Kafka UI 와 Portainer 는 키가 없으면 파드가 뜨지 않는다** (`optional` 을 안 줬다). 인증이 꺼진 채로
+  멀쩡히 떠 있는 것보다 멈추는 편이 낫다. 키를 넣은 뒤
+  `kubectl -n edrdog rollout restart deploy/kafka-ui deploy/portainer`.
   `/kafka-ui/actuator/health` 는 로그인 없이 200 이라 readinessProbe 는 그대로 통과한다.
 - **Swagger 는 비번이 없으면 열리는 게 아니라 닫힌다.** `application.yml` 에 기본값을 두지 않았다.
   레포에 박아 두면 그게 곧 공개 비번이라서다. 로컬에서 보려면 `EDRDOG_SWAGGER_PASSWORD` 를 넣고 띄운다.
@@ -173,20 +174,20 @@ Caddyfile 은 그대로라 반영되지 않는다.
 
 ### Portainer
 
-`k8s/portainer.yaml`. 첫 접속에서 관리자 계정을 만든다. **파드가 뜨고 5분 안에 안 만들면 스스로 잠근다.**
+`k8s/portainer.yaml`. `admin` / `PORTAINER_ADMIN_PASSWORD` 로 로그인한다. 계정은 `--admin-password-file` 로
+파드가 뜨면서 자동 생성되므로 사람이 먼저 접속할 필요가 없다(원래는 5분 안에 안 만들면 스스로 잠근다).
 
-```bash
-sudo kubectl -n portainer rollout restart deploy/portainer   # 잠겼을 때 다시 여는 법
-```
-
-- 이 계정은 `cluster-admin` 이라 `edrdog` 네임스페이스의 Secret(Infisical 이 동기화한 API 키, DB 비번)까지
-  전부 보인다. 비번을 세게 건다.
+- **`PORTAINER_ADMIN_PASSWORD` 는 첫 기동에만 먹는다.** Portainer 가 자기 DB(PVC)에 복사하기 때문에,
+  계정이 생긴 뒤 Infisical 값을 바꿔도 비번은 안 바뀐다. 바꾸려면 Portainer UI 에서 바꾸거나 PVC 를 지운다.
+  Kafka UI·Swagger 와 달리 Infisical 이 계속 진짜 소스인 구조가 아니다.
+- 네임스페이스가 `portainer` 가 아니라 `edrdog` 인 이유: k8s Secret 은 네임스페이스를 넘지 못한다.
+  `edrdog-secrets` 를 마운트하려면 같은 네임스페이스여야 한다.
+- 이 계정은 `cluster-admin` 이라 `edrdog` 의 Secret(API 키, DB 비번)까지 전부 보인다. 비번을 세게 잡는다.
 - 서브패스(`/portainer`)가 아니라 서브도메인인 이유: 서브패스로 서비스하려면 `--base-url` 과 프록시의
   prefix strip 이 정확히 한 번씩 맞아야 하고, 어긋나면 화면은 뜨는데 로그인이 안 된다.
-  DuckDNS 는 하위 도메인이 전부 같은 IP 로 와서 서브도메인이 공짜다.
 - `--trusted-origins` 가 없으면 Caddy 뒤에서 로그인할 때 `Origin invalid` 로 막힌다. 도메인을 바꾸면
   매니페스트의 이 값도 같이 바꿔야 한다.
-- 계정과 설정은 PVC 에 있다(k3s `local-path`). 지우면 관리자 계정부터 다시 만들어야 한다.
+- 계정과 설정은 PVC 에 있다(k3s `local-path`). 지우면 다음 기동에서 Infisical 값으로 다시 만들어진다.
 
 ## 시크릿 (Infisical)
 

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -153,11 +153,23 @@ sudo kubectl -n edrdog logs deploy/api-service | grep 'GeoIP DB 로드'
 
 배포서버 전용이다. 셋 다 Caddy 뒤에 있고 NodePort 를 방화벽에 열지 않으므로 Caddy 를 통해서만 들어간다.
 
-| 대상 | 주소 | 인증 | NodePort |
-|---|---|---|---|
-| Portainer | `https://portainer.<도메인>` | Portainer 자체 로그인 | 30777 |
-| Kafka UI | `https://<도메인>/kafka-ui` | 없음 | 30901 |
-| Swagger | `https://<도메인>/swagger-ui.html` | 없음 | (api 30084) |
+| 대상 | 주소 | 인증 | Infisical 키 | NodePort |
+|---|---|---|---|---|
+| Portainer | `https://portainer.<도메인>` | 자체 로그인 | (첫 접속에서 직접 생성) | 30777 |
+| Kafka UI | `https://<도메인>/kafka-ui` | 자체 로그인 폼 | `KAFKA_UI_USER` / `KAFKA_UI_PASSWORD` | 30901 |
+| Swagger | `https://<도메인>/swagger-ui.html` | Basic (`SwaggerAuthFilter`) | `EDRDOG_SWAGGER_USER` / `EDRDOG_SWAGGER_PASSWORD` | (api 30084) |
+
+**Caddy 는 인증을 하지 않는다.** 셋 다 자기 안에서 막고 계정은 `edrdog-secrets` 에서 받는다. Caddy 에
+basic auth 를 걸면 비번이 Infisical 과 호스트 파일 두 군데로 갈라지고, Infisical 에서 바꿔도 호스트의
+Caddyfile 은 그대로라 반영되지 않는다.
+
+- **Kafka UI 는 키가 없으면 파드가 뜨지 않는다** (`secretKeyRef` 에 `optional` 을 안 줬다). 인증이 꺼진 채로
+  멀쩡히 떠 있는 것보다 멈추는 편이 낫다. 키를 넣은 뒤 `kubectl -n edrdog rollout restart deploy/kafka-ui`.
+  `/kafka-ui/actuator/health` 는 로그인 없이 200 이라 readinessProbe 는 그대로 통과한다.
+- **Swagger 는 비번이 없으면 열리는 게 아니라 닫힌다.** `application.yml` 에 기본값을 두지 않았다.
+  레포에 박아 두면 그게 곧 공개 비번이라서다. 로컬에서 보려면 `EDRDOG_SWAGGER_PASSWORD` 를 넣고 띄운다.
+- Swagger 가 `ApiKeyPolicy` 의 인증 예외로 남아 있는 건 그대로다. 브라우저로 여는 화면이라 `X-API-Key`
+  헤더를 붙일 수가 없어서, API 키 대신 Basic 으로 막는다.
 
 ### Portainer
 

--- a/k8s/kafka-ui.yaml
+++ b/k8s/kafka-ui.yaml
@@ -31,6 +31,20 @@ spec:
               value: "kafka.edrdog.svc.cluster.local:9094"
             - name: SERVER_SERVLET_CONTEXT_PATH
               value: "/kafka-ui"
+            # 없으면 주소만 알아도 토픽 메시지(수집 원본)를 읽고 produce·토픽 삭제까지 된다.
+            - name: AUTH_TYPE
+              value: "LOGIN_FORM"
+            # optional 을 주지 않는다. 키가 없으면 인증이 꺼진 채로 뜨는 대신 파드가 멈춘다.
+            - name: SPRING_SECURITY_USER_NAME
+              valueFrom:
+                secretKeyRef:
+                  name: edrdog-secrets
+                  key: KAFKA_UI_USER
+            - name: SPRING_SECURITY_USER_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: edrdog-secrets
+                  key: KAFKA_UI_PASSWORD
             - name: JAVA_OPTS
               value: "-Xms128M -Xmx512M"
           readinessProbe:

--- a/k8s/portainer.yaml
+++ b/k8s/portainer.yaml
@@ -2,28 +2,18 @@
 # 배포서버에서는 Caddy 가 https://portainer.<도메인> 으로 프록시한다.
 #   Caddyfile 예:  portainer.edrdog-api.duckdns.org { reverse_proxy localhost:30777 }
 #
-# 서브패스(/portainer)가 아니라 서브도메인인 이유: Portainer 를 서브패스로 서비스하려면
-# --base-url 과 프록시의 prefix strip 이 정확히 한 번씩만 맞아야 하고, 어긋나면 화면은 뜨는데
-# 로그인이 안 된다(자산 경로가 /portainer/portainer/ 로 겹친다). DuckDNS 는 하위 도메인이
-# 전부 같은 IP 로 오므로 서브도메인이 공짜다.
+# 서브도메인인 이유: 서브패스로 서비스하려면 --base-url 과 프록시의 prefix strip 이 정확히 한 번씩
+# 맞아야 하고, 어긋나면 화면은 뜨는데 로그인이 안 된다. DuckDNS 는 하위 도메인이 전부 같은 IP 로 온다.
 #
-# 첫 접속에서 관리자 계정을 만든다. 파드가 뜨고 5분 안에 안 만들면 Portainer 가 스스로 잠그고,
-# 그때는 파드를 재시작해야 다시 열린다.
-#   kubectl -n portainer rollout restart deploy/portainer
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: portainer
----
+# 네임스페이스가 edrdog 인 이유: k8s Secret 은 네임스페이스를 넘지 못한다. 관리자 비번을
+# edrdog-secrets 에서 받으려면 같은 네임스페이스에 있어야 한다.
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: portainer
-  namespace: portainer
+  namespace: edrdog
 ---
-# Portainer 가 k8s 를 관리하려면 cluster-admin 이 필요하다(공식 매니페스트도 같다).
-# 즉 이 UI 에 로그인한 사람은 edrdog 네임스페이스의 Secret(Infisical 이 동기화한 API 키,
-# DB 비번)까지 전부 읽을 수 있다. 첫 접속 때 관리자 비번을 세게 걸어야 한다.
+# 공식 매니페스트와 같다. 이 UI 에 로그인한 사람은 edrdog 의 Secret 도 전부 읽을 수 있다.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -35,15 +25,14 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: portainer
-    namespace: portainer
+    namespace: edrdog
 ---
-# 계정과 설정이 여기 들어간다. emptyDir 로 두면 파드가 재시작될 때마다 관리자 계정을
-# 처음부터 다시 만들어야 한다. k3s 는 local-path 가 기본 StorageClass 라 그대로 바인딩된다.
+# 계정과 설정이 여기 들어간다. emptyDir 면 재시작마다 계정이 초기화된다.
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: portainer
-  namespace: portainer
+  namespace: edrdog
 spec:
   accessModes:
     - ReadWriteOnce
@@ -55,7 +44,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: portainer
-  namespace: portainer
+  namespace: edrdog
   labels:
     app: portainer
 spec:
@@ -79,15 +68,21 @@ spec:
           args:
             # Caddy 가 TLS 를 끊고 평문으로 넘기므로 9000(HTTP)으로 받는다.
             - --http-enabled
-            # 이게 없으면 Caddy 뒤에서 로그인할 때 "Origin invalid" 로 막힌다.
-            # Portainer 가 보는 요청은 http 인데 브라우저가 보낸 Origin 은 https 라서다.
+            # 없으면 Caddy 뒤에서 로그인이 Origin invalid 로 막힌다(요청은 http, Origin 은 https).
             - --trusted-origins=portainer.edrdog-api.duckdns.org
+            # 첫 기동에만 먹는다. 계정이 생긴 뒤 Infisical 값을 바꿔도 비번은 안 바뀐다.
+            # 대신 5분 안에 사람이 계정을 만들어야 하는 잠금이 사라진다.
+            # /run/secrets/portainer 는 쓰지 않는다. Portainer 가 거기를 DB 암호화 키 파일로 먼저 읽는다.
+            - --admin-password-file=/etc/portainer/admin-password
           ports:
             - containerPort: 9000
             - containerPort: 9443
           volumeMounts:
             - name: data
               mountPath: /data
+            - name: admin-password
+              mountPath: /etc/portainer
+              readOnly: true
           readinessProbe:
             httpGet:
               path: /
@@ -112,15 +107,20 @@ spec:
         - name: data
           persistentVolumeClaim:
             claimName: portainer
+        # optional 을 주지 않는다. 키가 없으면 비번 없이 뜨는 대신 파드가 멈춘다.
+        - name: admin-password
+          secret:
+            secretName: edrdog-secrets
+            items:
+              - key: PORTAINER_ADMIN_PASSWORD
+                path: admin-password
 ---
-# NodePort 30777 — 호스트에서 도는 Caddy 가 localhost:30777 로 프록시한다.
-# 오라클 보안 목록과 호스트 방화벽에 30777 을 열지 않으므로 외부에서 직접은 못 들어오고
-# Caddy(=basic auth 없이 Portainer 자체 로그인) 경유만 가능하다.
+# NodePort 30777 — Caddy 가 localhost:30777 로 프록시한다. 방화벽에 열지 않으므로 직접은 못 들어온다.
 apiVersion: v1
 kind: Service
 metadata:
   name: portainer
-  namespace: portainer
+  namespace: edrdog
   labels:
     app: portainer
 spec:

--- a/k8s/portainer.yaml
+++ b/k8s/portainer.yaml
@@ -1,0 +1,133 @@
+# Portainer CE — 브라우저에서 클러스터의 파드/컨테이너 상태와 로그를 보는 관리 UI.
+# 배포서버에서는 Caddy 가 https://portainer.<도메인> 으로 프록시한다.
+#   Caddyfile 예:  portainer.edrdog-api.duckdns.org { reverse_proxy localhost:30777 }
+#
+# 서브패스(/portainer)가 아니라 서브도메인인 이유: Portainer 를 서브패스로 서비스하려면
+# --base-url 과 프록시의 prefix strip 이 정확히 한 번씩만 맞아야 하고, 어긋나면 화면은 뜨는데
+# 로그인이 안 된다(자산 경로가 /portainer/portainer/ 로 겹친다). DuckDNS 는 하위 도메인이
+# 전부 같은 IP 로 오므로 서브도메인이 공짜다.
+#
+# 첫 접속에서 관리자 계정을 만든다. 파드가 뜨고 5분 안에 안 만들면 Portainer 가 스스로 잠그고,
+# 그때는 파드를 재시작해야 다시 열린다.
+#   kubectl -n portainer rollout restart deploy/portainer
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: portainer
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: portainer
+  namespace: portainer
+---
+# Portainer 가 k8s 를 관리하려면 cluster-admin 이 필요하다(공식 매니페스트도 같다).
+# 즉 이 UI 에 로그인한 사람은 edrdog 네임스페이스의 Secret(Infisical 이 동기화한 API 키,
+# DB 비번)까지 전부 읽을 수 있다. 첫 접속 때 관리자 비번을 세게 걸어야 한다.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: portainer
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+  - kind: ServiceAccount
+    name: portainer
+    namespace: portainer
+---
+# 계정과 설정이 여기 들어간다. emptyDir 로 두면 파드가 재시작될 때마다 관리자 계정을
+# 처음부터 다시 만들어야 한다. k3s 는 local-path 가 기본 StorageClass 라 그대로 바인딩된다.
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: portainer
+  namespace: portainer
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 2Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: portainer
+  namespace: portainer
+  labels:
+    app: portainer
+spec:
+  replicas: 1
+  # PVC 가 ReadWriteOnce 라 롤링으로 두면 새 파드가 볼륨을 못 잡고 매달린다.
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: portainer
+  template:
+    metadata:
+      labels:
+        app: portainer
+    spec:
+      serviceAccountName: portainer
+      containers:
+        - name: portainer
+          # 배포서버가 오라클 Ampere A1(arm64) 이다. 이 태그는 arm64 를 포함한다.
+          image: portainer/portainer-ce:2.39.5
+          args:
+            # Caddy 가 TLS 를 끊고 평문으로 넘기므로 9000(HTTP)으로 받는다.
+            - --http-enabled
+            # 이게 없으면 Caddy 뒤에서 로그인할 때 "Origin invalid" 로 막힌다.
+            # Portainer 가 보는 요청은 http 인데 브라우저가 보낸 Origin 은 https 라서다.
+            - --trusted-origins=portainer.edrdog-api.duckdns.org
+          ports:
+            - containerPort: 9000
+            - containerPort: 9443
+          volumeMounts:
+            - name: data
+              mountPath: /data
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 9443
+              scheme: HTTPS
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 9443
+              scheme: HTTPS
+            initialDelaySeconds: 30
+            periodSeconds: 20
+          resources:
+            requests:
+              cpu: 50m
+              memory: 128Mi
+            limits:
+              memory: 512Mi
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: portainer
+---
+# NodePort 30777 — 호스트에서 도는 Caddy 가 localhost:30777 로 프록시한다.
+# 오라클 보안 목록과 호스트 방화벽에 30777 을 열지 않으므로 외부에서 직접은 못 들어오고
+# Caddy(=basic auth 없이 Portainer 자체 로그인) 경유만 가능하다.
+apiVersion: v1
+kind: Service
+metadata:
+  name: portainer
+  namespace: portainer
+  labels:
+    app: portainer
+spec:
+  type: NodePort
+  selector:
+    app: portainer
+  ports:
+    - port: 9000
+      targetPort: 9000
+      nodePort: 30777

--- a/scripts/bootstrap-oracle.sh
+++ b/scripts/bootstrap-oracle.sh
@@ -38,6 +38,7 @@ GHCR_IMAGE_BASE="${GHCR_IMAGE_BASE:-ghcr.io/edrdog/backend}"
 # 때문에 중간에서 TLS 를 다시 종단하면 등록 단계에서 실패한다.
 AGENT_PORT=30443
 API_NODEPORT=30084
+KAFKA_UI_NODEPORT=30901
 PORTAINER_NODEPORT=30777
 
 fail() { echo "오류: $*" >&2; exit 1; }
@@ -154,10 +155,15 @@ if ! command -v caddy >/dev/null 2>&1; then
 fi
 
 # 도메인 블록 안에서 벗은 reverse_proxy 와 handle 은 섞을 수 없다. 처음부터 전부 감싼다.
+#
+# Caddy 는 인증을 하지 않는다. 운영 UI 세 개가 각자 자기 로그인을 갖고 있고, 그 계정은
+# Infisical 이 넣는다(Kafka UI 는 AUTH_TYPE=LOGIN_FORM, Swagger 는 api-service 의
+# SwaggerAuthFilter, Portainer 는 자체 로그인). 여기서 또 막으면 비번이 두 군데로 갈라지고,
+# Infisical 에서 비번을 바꿔도 호스트의 이 파일은 그대로라 반영이 안 된다.
 cat > /etc/caddy/Caddyfile <<EOF
 $DOMAIN {
 	handle /kafka-ui* {
-		reverse_proxy localhost:30901
+		reverse_proxy localhost:$KAFKA_UI_NODEPORT
 	}
 	handle {
 		reverse_proxy localhost:$API_NODEPORT
@@ -287,14 +293,25 @@ cat <<EOF
    CD 가 arm64 를 포함해 이미지를 올리고, 서비스 매니페스트 apply 와 롤아웃까지 한다.
    Deployment 가 없으면 CD 가 알아서 apply 하므로 여기서 손으로 할 것은 없다.
 
-3) Portainer 관리자 계정을 만든다 (https://portainer.$DOMAIN)
+3) Infisical 에 운영 UI 계정을 넣는다 (prod 환경)
+     KAFKA_UI_USER / KAFKA_UI_PASSWORD              <- Kafka UI 로그인
+     EDRDOG_SWAGGER_USER / EDRDOG_SWAGGER_PASSWORD  <- Swagger 로그인
+   넣은 뒤 edrdog-secrets 를 다시 만든다(위 7단계의 명령). 그리고:
+     kubectl -n $NS rollout restart deploy/kafka-ui
+   kafka-ui 는 이 키가 없으면 파드가 뜨지 않는다. 인증이 꺼진 채로 떠 있으면
+   토픽 메시지가 그대로 공개돼서, 멈추는 편이 낫다고 보고 일부러 그렇게 뒀다.
+   Swagger 는 비번이 없으면 열리는 게 아니라 닫힌다.
+
+4) Portainer 관리자 계정을 만든다 (https://portainer.$DOMAIN)
    파드가 뜨고 5분 안에 안 만들면 Portainer 가 스스로 잠근다. 그때는 아래로 다시 연다.
      kubectl -n portainer rollout restart deploy/portainer
    이 계정은 cluster-admin 이라 edrdog 네임스페이스의 Secret 까지 다 보인다. 비번을 세게 건다.
 
-4) 확인
+5) 확인
    kubectl -n $NS get pods
    curl -sS https://$DOMAIN/actuator/health
+   curl -sS -o /dev/null -w '%{http_code}\n' https://$DOMAIN/kafka-ui/          # -> 302 (로그인으로)
+   curl -sS -o /dev/null -w '%{http_code}\n' https://$DOMAIN/swagger-ui.html    # -> 401
    openssl s_client -connect $DOMAIN:$AGENT_PORT </dev/null 2>/dev/null | head -3
 
 kubectl 을 그냥 쓰려면:

--- a/scripts/bootstrap-oracle.sh
+++ b/scripts/bootstrap-oracle.sh
@@ -38,6 +38,7 @@ GHCR_IMAGE_BASE="${GHCR_IMAGE_BASE:-ghcr.io/edrdog/backend}"
 # 때문에 중간에서 TLS 를 다시 종단하면 등록 단계에서 실패한다.
 AGENT_PORT=30443
 API_NODEPORT=30084
+PORTAINER_NODEPORT=30777
 
 fail() { echo "오류: $*" >&2; exit 1; }
 step() { echo; echo "== $*"; }
@@ -162,10 +163,20 @@ $DOMAIN {
 		reverse_proxy localhost:$API_NODEPORT
 	}
 }
+
+# Portainer. DuckDNS 는 하위 도메인이 전부 같은 IP 로 오므로 레코드를 따로 만들 필요가 없고,
+# Caddy 가 이 이름으로 인증서를 알아서 받는다(80 이 열려 있어야 받는다).
+portainer.$DOMAIN {
+	reverse_proxy localhost:$PORTAINER_NODEPORT
+}
 EOF
+# 설정이 틀리면 reload 가 조용히 실패하고 사이트가 옛 설정으로 남거나 죽는다. 여기서 잡는다.
+caddy validate --config /etc/caddy/Caddyfile --adapter caddyfile >/dev/null 2>&1 \
+  || fail "Caddyfile 이 잘못됐다: caddy validate --config /etc/caddy/Caddyfile --adapter caddyfile"
 systemctl enable --now caddy >/dev/null 2>&1 || true
 systemctl reload caddy 2>/dev/null || systemctl restart caddy
 echo "  $DOMAIN -> localhost:$API_NODEPORT"
+echo "  portainer.$DOMAIN -> localhost:$PORTAINER_NODEPORT"
 
 # --- 5. 에이전트 수집 TLS -----------------------------------------------------
 # 에이전트가 호스트명을 SAN 과 대조한다. 도메인을 바꾸면 여기도 다시 만들어야 한다.
@@ -231,7 +242,7 @@ step "8/8 인프라 매니페스트"
 if [[ -d "$REPO_DIR/.git" ]]; then
   git -C "$REPO_DIR" fetch --quiet origin main || true
   for f in k8s/00-namespace.yaml k8s/mysql.yaml k8s/kafka.yaml k8s/clickhouse.yaml \
-           k8s/otel-lgtm.yaml k8s/alloy.yaml k8s/kafka-ui.yaml; do
+           k8s/otel-lgtm.yaml k8s/alloy.yaml k8s/kafka-ui.yaml k8s/portainer.yaml; do
     git -C "$REPO_DIR" show "FETCH_HEAD:$f" | kubectl apply -f - >/dev/null && echo "  $f"
   done
 else
@@ -276,7 +287,12 @@ cat <<EOF
    CD 가 arm64 를 포함해 이미지를 올리고, 서비스 매니페스트 apply 와 롤아웃까지 한다.
    Deployment 가 없으면 CD 가 알아서 apply 하므로 여기서 손으로 할 것은 없다.
 
-3) 확인
+3) Portainer 관리자 계정을 만든다 (https://portainer.$DOMAIN)
+   파드가 뜨고 5분 안에 안 만들면 Portainer 가 스스로 잠근다. 그때는 아래로 다시 연다.
+     kubectl -n portainer rollout restart deploy/portainer
+   이 계정은 cluster-admin 이라 edrdog 네임스페이스의 Secret 까지 다 보인다. 비번을 세게 건다.
+
+4) 확인
    kubectl -n $NS get pods
    curl -sS https://$DOMAIN/actuator/health
    openssl s_client -connect $DOMAIN:$AGENT_PORT </dev/null 2>/dev/null | head -3

--- a/scripts/bootstrap-oracle.sh
+++ b/scripts/bootstrap-oracle.sh
@@ -296,23 +296,24 @@ cat <<EOF
 3) Infisical 에 운영 UI 계정을 넣는다 (prod 환경)
      KAFKA_UI_USER / KAFKA_UI_PASSWORD              <- Kafka UI 로그인
      EDRDOG_SWAGGER_USER / EDRDOG_SWAGGER_PASSWORD  <- Swagger 로그인
+     PORTAINER_ADMIN_PASSWORD                       <- Portainer 관리자 (아이디는 admin 고정)
    넣은 뒤 edrdog-secrets 를 다시 만든다(위 7단계의 명령). 그리고:
-     kubectl -n $NS rollout restart deploy/kafka-ui
-   kafka-ui 는 이 키가 없으면 파드가 뜨지 않는다. 인증이 꺼진 채로 떠 있으면
+     kubectl -n $NS rollout restart deploy/kafka-ui deploy/portainer
+   kafka-ui 와 portainer 는 이 키가 없으면 파드가 뜨지 않는다. 인증이 꺼진 채로 떠 있으면
    토픽 메시지가 그대로 공개돼서, 멈추는 편이 낫다고 보고 일부러 그렇게 뒀다.
    Swagger 는 비번이 없으면 열리는 게 아니라 닫힌다.
+   PORTAINER_ADMIN_PASSWORD 는 첫 기동에만 먹는다. 계정이 생긴 뒤에 바꾸려면 Portainer UI 에서 바꾼다.
 
-4) Portainer 관리자 계정을 만든다 (https://portainer.$DOMAIN)
-   파드가 뜨고 5분 안에 안 만들면 Portainer 가 스스로 잠근다. 그때는 아래로 다시 연다.
-     kubectl -n portainer rollout restart deploy/portainer
-   이 계정은 cluster-admin 이라 edrdog 네임스페이스의 Secret 까지 다 보인다. 비번을 세게 건다.
-
-5) 확인
+4) 확인
    kubectl -n $NS get pods
    curl -sS https://$DOMAIN/actuator/health
    curl -sS -o /dev/null -w '%{http_code}\n' https://$DOMAIN/kafka-ui/          # -> 302 (로그인으로)
    curl -sS -o /dev/null -w '%{http_code}\n' https://$DOMAIN/swagger-ui.html    # -> 401
+   curl -sS -o /dev/null -w '%{http_code}\n' https://portainer.$DOMAIN/api/users/admin/check  # -> 204 (계정 생성됨)
    openssl s_client -connect $DOMAIN:$AGENT_PORT </dev/null 2>/dev/null | head -3
+
+   Portainer 는 admin / PORTAINER_ADMIN_PASSWORD 로 로그인한다.
+   이 계정은 cluster-admin 이라 edrdog 의 Secret 까지 다 보인다. 비번을 세게 잡는다.
 
 kubectl 을 그냥 쓰려면:
    echo 'export KUBECONFIG=/etc/rancher/k3s/k3s.yaml' >> ~/.bashrc


### PR DESCRIPTION
## 무엇을

브라우저에서 컨테이너 상태를 보려고 Portainer 를 띄우고, 그참에 열려 있던 운영 UI 두 개를 막는다.

- **Portainer** — `https://portainer.<도메인>` (NodePort 30777, Caddy 프록시)
- **Kafka UI** — 인증이 아예 없어서 주소만 알면 토픽 메시지가 그대로 보였다. 수집 원본(호스트명·프로세스 커맨드라인·IP)이고 produce·토픽 삭제까지 됐다.
- **Swagger** — `ApiKeyPolicy` 가 인증 예외로 열어 둔 경로라 API 목록이 공개였다.

## 어떻게

셋 다 **자기 안에서** 막고 계정은 `edrdog-secrets`(Infisical)에서 받는다.

| 대상 | 인증 | Infisical 키 |
|---|---|---|
| Portainer | 자체 로그인 (`admin`) | `PORTAINER_ADMIN_PASSWORD` |
| Kafka UI | `AUTH_TYPE=LOGIN_FORM` | `KAFKA_UI_USER` / `KAFKA_UI_PASSWORD` |
| Swagger | `SwaggerAuthFilter` (Basic) | `EDRDOG_SWAGGER_USER` / `EDRDOG_SWAGGER_PASSWORD` |

Caddy 에 basic auth 를 걸지 않는다. Caddy 는 호스트의 systemd 서비스라 k8s Secret 을 못 읽어서 비번을 부트스트랩 env 로 받아야 하는데, 그러면 비번이 Infisical 과 호스트 파일 두 군데로 갈라지고 Infisical 에서 바꿔도 반영이 안 된다.

**값이 없으면 열리지 않고 닫힌다.** kafka-ui·portainer 는 `secretKeyRef`/볼륨에 `optional` 을 주지 않아 파드가 멈추고, Swagger 는 비번 기본값이 없어 전부 401 이다. 인증이 꺼진 채로 멀쩡히 떠 있는 편이 알아채기 더 어렵다.

## 결정한 것

- **서브도메인**(`portainer.<도메인>`). 서브패스는 `--base-url` 과 프록시 prefix strip 이 정확히 맞아야 하고 어긋나면 화면은 뜨는데 로그인이 안 된다. DuckDNS 는 하위 도메인이 전부 같은 IP 로 온다.
- **네임스페이스 `edrdog`**. k8s Secret 은 네임스페이스를 넘지 못해서, `portainer` 로 따로 두면 동기화 CR 을 하나 더 만들어야 한다.
- **`--admin-password-file`** 로 관리자 계정을 자동 생성한다. 5분 안에 사람이 접속해야 하는 잠금이 사라진다. 다만 **첫 기동에만 먹는다** (계정 생성 후 Infisical 값을 바꿔도 비번은 안 바뀐다). `k8s/README.md` 에 적어 뒀다.

## 검증

- `SwaggerAuthPolicyTest` 9개 + `SwaggerAuthFilterTest` 4개 신규. TDD 로 실패 확인 후 구현. api-service 전체 스위트 통과.
- Kafka UI 를 실제로 띄워 확인: 미인증 302(로그인으로), 로그인 후 200, 틀린 비번 재로그인. **`/kafka-ui/actuator/health` 는 로그인 없이 200 이라 readinessProbe 가 안 막힌다.**
- Portainer 를 실제로 띄워 확인: 세 플래그 동시 적용 정상 기동, `/api/users/admin/check` 204, 로그인 200, 틀린 비번 422. 마운트 경로는 `/run/secrets/portainer` 를 피했다(Portainer 가 그 경로를 DB 암호화 키 파일로 먼저 읽어 기동 로그에 에러가 남는다).
- 생성되는 Caddyfile 을 caddy 로 `validate` 통과. 스크립트에도 reload 전 `caddy validate` 를 넣었다.
- 매니페스트 `--dry-run=client`, 스크립트 문법 검사 통과.

실서버에는 아직 적용하지 않았다.