### PR TITLE
fix: CD 가 새 매니페스트를 알아서 올리고, DB 데이터가 파드 재시작에 안 날아가게 한다

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -112,28 +112,37 @@ jobs:
           set -euo pipefail
           MODULES="detector-service responder-service archiver-service api-service alert-service collector-service"
 
-          # 모니터링 스택과 Kafka UI 만 매니페스트로 apply 한다.
-          # 서비스 5개 매니페스트는 손대지 않는다. apply 하면 image 가 :latest 로 되돌아갔다가
-          # 아래 set image 로 다시 :sha 가 되면서 롤아웃이 두 번 돌기 때문이다.
-          # (레포 api-service Service 가 ClusterIP 라 apply 하면 NodePort 30084 가 벗겨져 사이트가
-          #  죽던 문제는 매니페스트를 실제 상태에 맞추면서 해소됐다. 매니페스트 변경 반영은
-          #  k8s/README.md 의 수동 apply 절차를 따른다.)
+          # 인프라 매니페스트는 목록을 적지 않고 k8s/ 를 훑어서 전부 적용한다.
+          # 파일을 추가할 때마다 여기도 같이 고쳐야 하면 잊게 되고, 그러면 서버에만 빠진 채로
+          # 조용히 지나간다(실제로 portainer.yaml 이 그랬다).
+          #   빼는 것: *-service.yaml 은 아래에서 이미지 태그까지 맞춰 따로 다룬다. 여기서 apply 하면
+          #            image 가 :latest 로 되돌아갔다가 set image 로 다시 :sha 가 되어 롤아웃이 두 번 돈다.
+          #            kind-cluster.yaml 은 로컬 kind 설정이라 apply 대상이 아니고,
+          #            infisical.yaml 은 CRD 가 있을 때만 적용한다(바로 아래).
           # 서버 브랜치를 건드리지 않으려고 FETCH_HEAD 에서 파일만 꺼내 적용한다.
+          INFRA_FAILED=""
           if [ -d ~/Backend/.git ]; then
           git -C ~/Backend fetch --quiet origin main
-          for f in k8s/otel-lgtm.yaml k8s/alloy.yaml k8s/kafka-ui.yaml; do
-          git -C ~/Backend show "FETCH_HEAD:$f" | sudo kubectl apply -f -
+          INFRA_DEPLOYS=""
+          for f in $(git -C ~/Backend ls-tree --name-only FETCH_HEAD k8s/ | grep '\.yaml$'); do
+          case "$(basename "$f" .yaml)" in *-service|kind-cluster|infisical) continue ;; esac
+          echo "apply $f" >&2
+          APPLIED=$(git -C ~/Backend show "FETCH_HEAD:$f" | sudo kubectl apply -f - -o name)
+          echo "$APPLIED" >&2
+          INFRA_DEPLOYS="$INFRA_DEPLOYS $(echo "$APPLIED" | grep '^deployment' || true)"
           done
           # Infisical 연동은 Operator 가 깔려 있을 때만. 없으면 CRD 가 없어 apply 가 실패하고
           # set -e 때문에 서비스 롤링까지 같이 죽는다.
           if sudo kubectl get crd infisicalsecrets.secrets.infisical.com >/dev/null 2>&1; then
           git -C ~/Backend show "FETCH_HEAD:k8s/infisical.yaml" | sudo kubectl apply -f -
           fi
-          sudo kubectl -n "$NS" rollout status deployment/otel-lgtm --timeout=300s
-          sudo kubectl -n "$NS" rollout status deployment/alloy --timeout=180s
-          sudo kubectl -n "$NS" rollout status deployment/kafka-ui --timeout=180s
+          # 인프라가 안 떠도 여기서 멈추지 않는다. kafka-ui·portainer 는 시크릿이 없으면 일부러
+          # 안 뜨는데, 운영 UI 때문에 앱 배포가 막히면 곤란하다. 대신 맨 끝에서 CD 를 실패시킨다.
+          for d in $INFRA_DEPLOYS; do
+          sudo kubectl -n "$NS" rollout status "$d" --timeout=300s || INFRA_FAILED="$INFRA_FAILED $d"
+          done
           else
-          echo "~/Backend 클론이 없어 모니터링 매니페스트 apply 를 건너뛴다" >&2
+          echo "~/Backend 클론이 없어 인프라 매니페스트 apply 를 건너뛴다" >&2
           fi
 
           # Deployment 가 없으면(빈 클러스터, 새로 추가된 서비스) 매니페스트를 먼저 apply 한다.
@@ -159,4 +168,11 @@ jobs:
           for m in $DEPLOYED; do
           sudo kubectl -n "$NS" rollout status "deployment/$m" --timeout=120s
           done
+
+          # 앱은 다 올린 뒤에 인프라 실패를 알린다. 여기서 죽어야 CD 가 초록으로 안 끝난다.
+          if [ -n "$INFRA_FAILED" ]; then
+          echo "인프라 롤아웃 실패:$INFRA_FAILED" >&2
+          echo "kafka-ui·portainer 라면 edrdog-secrets 에 계정 키가 없는 것이다(k8s/README.md)." >&2
+          exit 1
+          fi
           REMOTE

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -95,9 +95,21 @@ curl -sk https://localhost:8443/api/agent/enroll -H 'Content-Type: application/j
   다시 만들고 Secret 을 갱신한 뒤 엔드포인트의 PEM 까지 교체해야 한다.
 ### 매니페스트 변경을 배포서버에 반영하기
 
-CD 는 서비스 5개 매니페스트를 apply 하지 않는다(apply 하면 image 가 `:latest` 로 되돌아갔다가
-`set image` 로 다시 `:sha` 가 되면서 롤아웃이 두 번 돈다). 그래서 `k8s/api-service.yaml` 을 고쳤으면
-서버에서 한 번 수동으로 적용한다. 지금 떠 있는 이미지 태그를 지키면서 적용하는 순서:
+**인프라 매니페스트는 CD 가 알아서 올린다.** 목록을 적어 두지 않고 `k8s/` 를 훑어서 적용하므로,
+파일을 새로 추가해도 워크플로를 같이 고칠 필요가 없다. 제외 대상은 셋뿐이다.
+
+| 파일 | 왜 빼는가 |
+|---|---|
+| `*-service.yaml` | 아래처럼 이미지 태그까지 맞춰 따로 다룬다 |
+| `kind-cluster.yaml` | 로컬 kind 설정이라 apply 대상이 아니다 |
+| `infisical.yaml` | CRD 가 있을 때만 적용한다 |
+
+인프라가 안 떠도 앱 배포는 막지 않고, 대신 CD 가 맨 끝에서 실패한다. `kafka-ui`·`portainer` 는
+시크릿이 없으면 일부러 안 뜨는데 그것 때문에 앱 배포가 멈추면 곤란해서다.
+
+서비스 매니페스트만 손으로 적용한다. CD 가 apply 하면 image 가 `:latest` 로 되돌아갔다가
+`set image` 로 다시 `:sha` 가 되면서 롤아웃이 두 번 돈다. `k8s/api-service.yaml` 을 고쳤으면
+지금 떠 있는 이미지 태그를 지키면서 적용한다:
 
 ```bash
 IMG=$(sudo kubectl -n edrdog get deploy/api-service -o jsonpath='{.spec.template.spec.containers[0].image}')

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -49,7 +49,7 @@ curl "http://localhost:3000/api/datasources/proxy/uid/loki/loki/api/v1/label/ser
 ## 종료
 
 ```bash
-kind delete cluster --name edrdog    # 클러스터째 삭제 (데이터 emptyDir 라 함께 소멸)
+kind delete cluster --name edrdog    # 클러스터째 삭제 (PVC 도 노드 안에 있어 함께 소멸)
 ```
 
 ## 에이전트 수집 포트 (api-service 8443 / NodePort 30443)
@@ -216,7 +216,10 @@ Machine Identity 자격증명 Secret 생성 1회, `kubectl apply -f k8s/infisica
 
 ## 메모
 
-- 개발용이라 **영속성 없음**(emptyDir). 파드 재시작 시 데이터 소멸.
+- **MySQL·ClickHouse 는 PVC 를 쓴다.** 파드가 갈려도 가입 계정과 이벤트 이력이 남는다.
+  볼륨이 없던 때는 노드 재부팅이나 OOM 한 번에 계정이 전부 사라져 로그인이 안 됐다.
+  PVC 가 `ReadWriteOnce` 라 둘 다 `strategy: Recreate` 다. 롤링으로 두면 새 파드가 볼륨을 못 잡는다.
+- **Kafka 는 영속성이 없다.** 남는 게 아직 소비 안 된 메시지뿐이고 토픽은 init Job 이 다시 만든다.
 - ClickHouse `edrdog.events` **테이블은 archiver 부팅 시 자동 생성**(`CREATE TABLE IF NOT EXISTS`). 여기선 `edrdog` DB 만 준비.
 - watchdog 클러스터와 호스트 포트(9092/8123/9000)가 겹치므로 **동시 실행 불가**.
 - `extraPortMappings` 는 **클러스터 생성 시에만** 반영된다. 이미 만들어 둔 클러스터에 3000/4317/4318 을 뚫으려면

--- a/k8s/clickhouse.yaml
+++ b/k8s/clickhouse.yaml
@@ -1,7 +1,21 @@
-# ClickHouse — 이벤트 저장·조회(archiver/api-server). 개발용, 영속성 없음(emptyDir).
-# 스키마(테이블)는 이후 이슈에서. 여기서는 edrdog DB 만 준비.
+# ClickHouse — 이벤트 저장·조회(archiver/api-server).
+# 테이블은 archiver 가 부팅할 때 만든다(CREATE TABLE IF NOT EXISTS). 여기서는 edrdog DB 만 준비.
 #   HTTP   8123 -> host localhost:8123
 #   native 9000 -> host localhost:9000
+#
+# 볼륨이 없으면 파드가 갈릴 때마다 이벤트·알림 이력이 전부 사라져 대시보드가 빈다.
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: clickhouse
+  namespace: edrdog
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -9,6 +23,9 @@ metadata:
   namespace: edrdog
 spec:
   replicas: 1
+  # RWO 라 롤링으로 두면 새 파드가 볼륨을 못 잡고 매달린다.
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app: clickhouse
@@ -44,6 +61,13 @@ spec:
               memory: 512Mi
             limits:
               memory: 2Gi
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/clickhouse
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: clickhouse
 ---
 apiVersion: v1
 kind: Service

--- a/k8s/kafka.yaml
+++ b/k8s/kafka.yaml
@@ -1,4 +1,5 @@
-# Kafka (KRaft, 단일 노드) — 개발용. 영속성 없음(emptyDir).
+# Kafka (KRaft, 단일 노드) — 영속성 없음. mysql·clickhouse 와 달리 볼륨을 안 주는 이유는
+# 여기 남는 게 아직 소비되지 않은 메시지뿐이고, 토픽은 아래 init Job 이 다시 만들기 때문이다.
 # 리스너 2개:
 #   INTERNAL(9094) : 클러스터 내부용 -> kafka.edrdog.svc.cluster.local:9094
 #   EXTERNAL(9092) : 호스트용 (localhost:9092), NodePort 30092 로 노출

--- a/k8s/mysql.yaml
+++ b/k8s/mysql.yaml
@@ -1,5 +1,20 @@
-# MySQL — 회원가입/로그인용 유저·조직 저장. 개발용, 영속성 없음(emptyDir 없음).
+# MySQL — 회원가입/로그인용 유저·조직 저장.
 #   TCP 3306 -> host localhost:3306 (HTTP 아님)
+#
+# 볼륨이 없으면 파드가 갈릴 때마다 가입한 계정이 전부 사라진다. 배포를 안 건드려도
+# 노드 재부팅이나 OOM 한 번이면 로그인이 안 되는 상태가 된다.
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: mysql
+  namespace: edrdog
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -7,6 +22,9 @@ metadata:
   namespace: edrdog
 spec:
   replicas: 1
+  # RWO 라 롤링으로 두면 새 파드가 볼륨을 못 잡고 매달린다.
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app: mysql
@@ -43,6 +61,13 @@ spec:
               memory: 512Mi
             limits:
               memory: 1Gi
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/mysql
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: mysql
 ---
 apiVersion: v1
 kind: Service

--- a/scripts/bootstrap-oracle.sh
+++ b/scripts/bootstrap-oracle.sh
@@ -247,8 +247,12 @@ fi
 step "8/8 인프라 매니페스트"
 if [[ -d "$REPO_DIR/.git" ]]; then
   git -C "$REPO_DIR" fetch --quiet origin main || true
-  for f in k8s/00-namespace.yaml k8s/mysql.yaml k8s/kafka.yaml k8s/clickhouse.yaml \
-           k8s/otel-lgtm.yaml k8s/alloy.yaml k8s/kafka-ui.yaml k8s/portainer.yaml; do
+  # 목록을 적지 않고 k8s/ 를 훑는다. 파일을 추가할 때 여기도 같이 고쳐야 하면 잊게 되고,
+  # 그러면 서버에만 빠진 채로 지나간다. CD 도 같은 규칙으로 고른다(.github/workflows/cd.yml).
+  #   빼는 것: *-service.yaml 은 CD 가 이미지 태그까지 맞춰 올리고, kind-cluster.yaml 은
+  #            로컬 kind 설정이며, infisical.yaml 은 Operator 가 있어야 apply 된다.
+  for f in $(git -C "$REPO_DIR" ls-tree --name-only FETCH_HEAD k8s/ | grep '\.yaml$'); do
+    case "$(basename "$f" .yaml)" in *-service|kind-cluster|infisical) continue ;; esac
     git -C "$REPO_DIR" show "FETCH_HEAD:$f" | kubectl apply -f - >/dev/null && echo "  $f"
   done
 else


### PR DESCRIPTION
## 1. CD 가 새 인프라 매니페스트를 알아서 올린다

적용할 파일 목록을 워크플로에 적어 두고 있었다. 직전 PR 에서 `portainer.yaml` 을 추가했더니 CD 가 모르는 채로 지나가서, 서버에 붙어 손으로 apply 해야 했다. **파일을 추가할 때마다 워크플로도 같이 고쳐야 하면 반드시 잊는다.**

목록 대신 `k8s/` 를 훑는다. 빼는 것은 셋뿐이다.

| 파일 | 왜 빼는가 |
|---|---|
| `*-service.yaml` | 이미지 태그까지 맞춰 따로 다룬다. 여기서 apply 하면 `:latest` 로 되돌아갔다가 `set image` 로 다시 `:sha` 가 되어 롤아웃이 두 번 돈다 |
| `kind-cluster.yaml` | 로컬 kind 설정이라 매니페스트가 아니다 |
| `infisical.yaml` | CRD 가 있어야 apply 된다 |

인프라 롤아웃 실패는 **앱 배포를 막지 않고 맨 끝에서 CD 를 실패시킨다.** `kafka-ui`·`portainer` 는 시크릿이 없으면 일부러 안 뜨는데, 운영 UI 때문에 앱 배포가 멈추면 곤란하다. 그렇다고 조용히 넘어가면 안 뜬 걸 아무도 모른다.

부트스트랩 스크립트도 같은 규칙으로 고른다. 두 곳이 다른 목록을 들고 있으면 또 갈라진다.

## 2. MySQL·ClickHouse 에 볼륨을 준다

볼륨 선언이 **아예 없었다.** `emptyDir` 조차 없어서 데이터가 컨테이너 쓰기 레이어에 있었다. 파드가 새로 뜨면 MySQL 의 가입 계정과 ClickHouse 의 이벤트 이력이 전부 사라진다. 배포를 안 건드려도 노드 재부팅이나 OOM 한 번이면 로그인이 안 되는 상태가 된다.

k3s·kind 둘 다 기본 StorageClass 가 있어 PVC 선언만으로 바인딩된다. `ReadWriteOnce` 라 `strategy: Recreate` 를 같이 준다(롤링이면 새 파드가 볼륨을 못 잡고 매달린다).

Kafka 는 그대로 둔다. 남는 게 아직 소비 안 된 메시지뿐이고 토픽은 init Job 이 다시 만든다.

## 검증

kind 클러스터를 띄워서 확인했다.

- **PVC 실제 동작**: MySQL 에 행을 넣고 파드를 삭제한 뒤, 새로 뜬 파드에서 조회하니 그대로 남아 있었다.
- **fail-closed 동작**: `edrdog-secrets` 없이 `portainer.yaml` 을 apply 하면 `FailedMount ... secret "edrdog-secrets" not found` 로 멈춘다. 원인이 이벤트에 그대로 찍힌다.
- **CD 제어 흐름**: `set -e` 아래에서 인프라 롤아웃이 실패해도 앱 배포 단계까지 진행되고, 맨 끝에서 종료코드 1 로 끝나는 것을 재현해 확인했다.
- **파일 선별**: 실제 `k8s/` 기준으로 8개 apply / 8개 skip 이 의도대로 갈리는 것을 확인했다.
- 워크플로의 원격 스크립트를 추출해 `bash -n`, 매니페스트 `--dry-run=client` 통과.

실서버에는 아직 적용하지 않았다.

## 주의

**이 PR 이 배포되는 순간 MySQL·ClickHouse 파드가 한 번 갈린다.** 볼륨을 새로 붙이는 전환이라 지금 서버에 있는 계정·이벤트는 그때 사라진다. 그 뒤부터는 남는다. 데모 계정은 `DEMO_SEED=true` 라 다시 만들어진다.