### PR TITLE
fix: 배포가 서비스 롤링 직전에 SSH 끊김으로 죽던 문제

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -103,7 +103,9 @@ jobs:
           chmod 600 ~/.ssh/deploy_key
           # GHCR 는 소문자 경로만 받으므로 repo 이름을 소문자로 바꿔 원격에 넘긴다.
           REPO_LC="${REPO,,}"
+          # ServerAliveInterval 이 없으면 rollout status 로 몇 분 조용히 기다리는 동안 세션이 Broken pipe 로 끊긴다(실제로 배포가 서비스 롤링 직전에 죽었다).
           ssh -o StrictHostKeyChecking=no -o ConnectTimeout=20 \
+            -o ServerAliveInterval=30 -o ServerAliveCountMax=10 \
             -i ~/.ssh/deploy_key "$SSH_USER@$SSH_HOST" \
             "REPO='$REPO_LC' SHA='$SHA' NS=edrdog bash -s" <<'REMOTE'
           set -euo pipefail
@@ -132,7 +134,8 @@ jobs:
           fi
           # 인프라가 안 떠도 여기서 멈추지 않는다. kafka-ui·portainer 는 시크릿이 없으면 일부러 안 뜨는데, 운영 UI 때문에 앱 배포가 막히면 곤란해서 대신 맨 끝에서 CD 를 실패시킨다.
           for d in $INFRA_DEPLOYS; do
-          sudo kubectl -n "$NS" rollout status "$d" --timeout=300s || INFRA_FAILED="$INFRA_FAILED $d"
+          # 60s 인 이유: 못 뜰 인프라를 5분씩 기다려봐야 결론이 같고, 그만큼 서비스 배포만 늦어진다.
+          sudo kubectl -n "$NS" rollout status "$d" --timeout=60s || INFRA_FAILED="$INFRA_FAILED $d"
           done
           else
           echo "~/Backend 클론이 없어 인프라 매니페스트 apply 를 건너뛴다" >&2


### PR DESCRIPTION
## 증상

`main` 머지 후 CD 가 실패한다. 인프라 매니페스트는 다 적용되는데 **서비스 이미지 6개가 안 올라간다.**

```
deployment "otel-lgtm" successfully rolled out
Waiting for deployment "portainer" rollout to finish: 0 of 1 ...
client_loop: send disconnect: Broken pipe     <- 4분 15초 침묵 후
##[error]Process completed with exit code 255
```

## 원인

인프라가 안 떠도 서비스 배포는 계속하도록 이미 `|| INFRA_FAILED="..."` 로 짜여 있다(133번 줄 주석). 그런데 그 의도가 안 먹었다.

`rollout status --timeout=300s` 가 출력 없이 5분을 기다리는 동안 **SSH 세션 자체가 Broken pipe 로 끊긴다.** 스크립트가 실패한 게 아니라 연결이 죽은 거라, `set image` 구간에 도달하지 못하고 통째로 끝난다.

## 고친 것

- `ssh` 에 `ServerAliveInterval=30 ServerAliveCountMax=10`. 침묵 중에도 keepalive 가 오가 세션이 산다
- 인프라 롤아웃 타임아웃 `300s -> 60s`. 못 뜰 인프라를 5분 기다려도 결론은 같고 서비스 배포만 늦어진다

## 검증

- `cd.yml` YAML 파싱 OK
- deploy 잡의 `run` 블록을 뽑아 `bash -n` 통과

실제 확인은 머지 후 CD 실행으로 한다. 서비스 롤링까지 도달하면 성공이다.

## 남는 것 (이 PR 밖)

`kafka-ui` 와 `portainer` 가 서버에서 안 뜨는 것 자체는 그대로다. 이 PR 은 그것들이 앱 배포를 막지 못하게만 한다. 원인은 따로 파는 중이다.