### PR TITLE
fix: API 키 거부 401 에 CORS 헤더가 빠지던 문제

### DIFF
--- a/api-service/src/main/java/com/edrdog/apiservice/security/ApiKeyFilter.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/security/ApiKeyFilter.java
@@ -5,6 +5,8 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
@@ -14,8 +16,14 @@ import java.io.IOException;
 /**
  * 모든 요청 앞단에서 X-API-Key 헤더를 검증한다. 헬스체크·Swagger 는 예외(ApiKeyPolicy).
  * 판단 로직은 ApiKeyPolicy(순수)에 있고, 여기서는 HTTP 연결만 담당한다.
+ *
+ * <p>순서를 명시하는 이유: 이게 없으면 등록 순서가 스캔 순서에 좌우돼 환경마다 달라진다.
+ * CorsFilter 보다 앞서면 여기서 낸 401 에 CORS 헤더가 안 붙고, 브라우저는 본문을 못 읽어
+ * "유효한 X-API-Key 가 필요합니다" 대신 정체불명의 네트워크 오류만 받는다. 키를 잘못 맞춘
+ * 배포자가 원인을 찾을 방법이 사라진다. 로컬 테스트는 통과하는데 배포에서만 그랬다.
  */
 @Component
+@Order(Ordered.HIGHEST_PRECEDENCE + 10)
 public class ApiKeyFilter extends OncePerRequestFilter {
 
     private static final String HEADER = "X-API-Key";

--- a/api-service/src/test/java/com/edrdog/apiservice/security/CorsFilterOrderTest.java
+++ b/api-service/src/test/java/com/edrdog/apiservice/security/CorsFilterOrderTest.java
@@ -1,0 +1,91 @@
+package com.edrdog.apiservice.security;
+
+import jakarta.servlet.Filter;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.web.filter.CorsFilter;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * CorsFilter 가 ApiKeyFilter 보다 먼저 도는지 확인한다.
+ *
+ * <p>순서가 뒤집히면 ApiKeyFilter 의 401 에 CORS 헤더가 안 붙고, 브라우저는 본문을 못 읽어
+ * 정체불명의 네트워크 오류만 받는다. 키를 잘못 맞춘 배포자가 원인을 찾을 방법이 사라진다.
+ *
+ * <p>순서를 값으로 직접 확인하는 이유: 순서를 안 박아 두면 스캔 순서에 좌우돼 환경마다 달라진다.
+ * 그래서 요청을 쏘는 테스트는 로컬에서 통과하는데 배포에서만 깨졌다. 실제로 그렇게 당했다.
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.ANY)
+@TestPropertySource(properties = {
+        "spring.kafka.listener.auto-startup=false",
+        "edrdog.cors.allowed-origins=http://localhost:5173"
+})
+class CorsFilterOrderTest {
+
+    private static final String ORIGIN = "http://localhost:5173";
+
+    @Autowired
+    private TestRestTemplate rest;
+
+    @Autowired
+    private ConfigurableApplicationContext ctx;
+
+    @Test
+    void CorsFilter_가_ApiKeyFilter_보다_먼저_등록된다() {
+        assertThat(orderOf(CorsFilter.class)).isLessThan(orderOf(ApiKeyFilter.class));
+    }
+
+    @Test
+    void ApiKeyFilter_는_순서를_명시해_둔다() {
+        // 빠지면 기본값(LOWEST_PRECEDENCE)이 아니라 등록 순서에 맡겨져 환경마다 달라진다.
+        assertThat(ctx.getBeanFactory().findAnnotationOnBean("apiKeyFilter", Order.class)).isNotNull();
+    }
+
+    @Test
+    void API키_거부_401_에도_허용_출처_헤더가_붙는다() {
+        ResponseEntity<String> res = call("/api/tenant/install-link", HttpMethod.POST);
+
+        assertThat(res.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+        assertThat(res.getHeaders().getAccessControlAllowOrigin()).isEqualTo(ORIGIN);
+    }
+
+    @Test
+    void 인증_필터가_내는_401_에도_허용_출처_헤더가_붙는다() {
+        // API 키 예외 경로라 ApiKeyFilter 를 지나 토큰 검증에서 막힌다.
+        ResponseEntity<String> res = call("/api/hosts", HttpMethod.GET);
+
+        assertThat(res.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+        assertThat(res.getHeaders().getAccessControlAllowOrigin()).isEqualTo(ORIGIN);
+    }
+
+    private ResponseEntity<String> call(String path, HttpMethod method) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.set(HttpHeaders.ORIGIN, ORIGIN);
+        return rest.exchange(path, method, new HttpEntity<>(headers), String.class);
+    }
+
+    /** Spring Boot 가 필터를 줄 세울 때 쓰는 것과 같은 값(@Order)을 읽는다. */
+    private int orderOf(Class<? extends Filter> type) {
+        Map<String, ? extends Filter> beans = ctx.getBeansOfType(type);
+        assertThat(beans).hasSize(1);
+        String name = beans.keySet().iterator().next();
+        Order order = ctx.getBeanFactory().findAnnotationOnBean(name, Order.class);
+        assertThat(order).as("%s 에 @Order 가 없다", name).isNotNull();
+        return order.value();
+    }
+}

--- a/api-service/src/test/java/com/edrdog/apiservice/security/CorsIntegrationTest.java
+++ b/api-service/src/test/java/com/edrdog/apiservice/security/CorsIntegrationTest.java
@@ -10,6 +10,7 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.options;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -88,6 +89,16 @@ class CorsIntegrationTest {
     void 실제_요청_응답에도_허용_출처_헤더가_붙는다() throws Exception {
         // 토큰이 없어 401 이지만, 브라우저가 응답을 읽으려면 CORS 헤더는 붙어 있어야 한다.
         mvc.perform(get("/api/alerts").header("Origin", "http://localhost:5173"))
+                .andExpect(header().string("Access-Control-Allow-Origin", "http://localhost:5173"));
+    }
+
+    @Test
+    void API키_거부_401_에도_허용_출처_헤더가_붙는다() throws Exception {
+        // 헤더가 없으면 브라우저는 본문을 못 읽고 네트워크 오류로만 받는다. 그러면 화면에
+        // "유효한 X-API-Key 가 필요합니다" 대신 정체불명의 연결 실패가 뜨고, 키를 잘못 맞춘
+        // 배포자가 원인을 찾을 방법이 사라진다. 실제로 배포에서 그 일이 있었다.
+        mvc.perform(post("/api/tenant/install-link").header("Origin", "http://localhost:5173"))
+                .andExpect(status().isUnauthorized())
                 .andExpect(header().string("Access-Control-Allow-Origin", "http://localhost:5173"));
     }
 }


### PR DESCRIPTION
## 무슨 일이 있었나

배포 환경에서 프론트가 `/api/tenant/install-link` 를 부르면 화면에 `서버에 연결하지 못했습니다` 만 떴습니다. 실제 원인은 `VITE_API_KEY` 와 `EDRDOG_API_KEY` 불일치였는데, 그 메시지가 브라우저까지 도달하지 못했습니다.

```
POST /api/tenant/install-link   Origin: https://edrdog.duckdns.org   X-API-Key: <틀린 키>
→ 401, access-control-allow-origin 없음        ← 브라우저가 본문을 못 읽음

GET  /api/hosts                 Origin: https://edrdog.duckdns.org
→ 401, access-control-allow-origin 있음        ← 이쪽은 정상
```

CORS 헤더가 없으니 `fetch` 가 `TypeError: Failed to fetch` 로 죽고, 프론트는 그걸 네트워크 오류로 바꿔 보여줍니다. 그래서 CORS 설정, DNS, 인증서를 차례로 의심하며 시간을 버렸습니다.

## 원인

`ApiKeyFilter` 에 순서 지정이 없었습니다. `CorsConfig` 만 `@Order(HIGHEST_PRECEDENCE)` 를 갖고 있고, `ApiKeyFilter` 는 `@Component` 뿐이라 등록 순서가 스캔 순서에 좌우됩니다. 로컬(클래스 디렉터리)과 배포(jar)에서 결과가 갈립니다.

`ApiKeyFilter` 안에 preflight 예외 처리가 따로 들어 있는 것(`7727b7e`)도 같은 증상을 겪고 덧댄 흔적으로 보입니다. 그때는 preflight 만 막아서 그 경로만 뚫었고, 본 요청의 401 은 그대로 남았습니다.

## 고친 것

`ApiKeyFilter` 에 `@Order(Ordered.HIGHEST_PRECEDENCE + 10)` 을 박아 `CorsFilter` 다음으로 고정합니다. preflight 예외 처리는 안전망으로 그대로 둡니다.

## 테스트

**요청만 쏘는 테스트로는 이걸 못 잡습니다.** 로컬에서는 순서가 우연히 맞아 통과하고, jar 로 말아 배포하면 뒤집힙니다. 기존 `CorsIntegrationTest` 가 초록불이었던 이유입니다.

그래서 순서 자체를 값으로 확인하는 테스트를 `CorsFilterOrderTest` 에 뒀습니다. 실서블릿 컨테이너(`RANDOM_PORT`)로 띄웁니다.

| 테스트 | @Order 없을 때 | 있을 때 |
|---|---|---|
| `CorsFilter_가_ApiKeyFilter_보다_먼저_등록된다` | FAIL | ok |
| `ApiKeyFilter_는_순서를_명시해_둔다` | FAIL | ok |
| `API키_거부_401_에도_허용_출처_헤더가_붙는다` | ok (로컬은 우연히 통과) | ok |
| `인증_필터가_내는_401_에도_허용_출처_헤더가_붙는다` | ok | ok |

`@Order` 를 뺐다가 되돌려 위 표를 실제로 확인했습니다. `CorsIntegrationTest` 에도 같은 경로의 회귀 케이스를 하나 추가했습니다.

`./gradlew :api-service:test` 310개 전부 통과합니다.

## 배포 메모

지금 도는 이미지는 `c8395de` 라 이 수정이 안 들어 있습니다. 반영하려면 새 이미지 빌드가 필요합니다.