### PR TITLE
release: 배포 SSH 끊김 수정 + 디스크 TTL·보관정책

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -103,7 +103,9 @@ jobs:
           chmod 600 ~/.ssh/deploy_key
           # GHCR 는 소문자 경로만 받으므로 repo 이름을 소문자로 바꿔 원격에 넘긴다.
           REPO_LC="${REPO,,}"
+          # ServerAliveInterval 이 없으면 rollout status 로 몇 분 조용히 기다리는 동안 세션이 Broken pipe 로 끊긴다(실제로 배포가 서비스 롤링 직전에 죽었다).
           ssh -o StrictHostKeyChecking=no -o ConnectTimeout=20 \
+            -o ServerAliveInterval=30 -o ServerAliveCountMax=10 \
             -i ~/.ssh/deploy_key "$SSH_USER@$SSH_HOST" \
             "REPO='$REPO_LC' SHA='$SHA' NS=edrdog bash -s" <<'REMOTE'
           set -euo pipefail
@@ -132,7 +134,8 @@ jobs:
           fi
           # 인프라가 안 떠도 여기서 멈추지 않는다. kafka-ui·portainer 는 시크릿이 없으면 일부러 안 뜨는데, 운영 UI 때문에 앱 배포가 막히면 곤란해서 대신 맨 끝에서 CD 를 실패시킨다.
           for d in $INFRA_DEPLOYS; do
-          sudo kubectl -n "$NS" rollout status "$d" --timeout=300s || INFRA_FAILED="$INFRA_FAILED $d"
+          # 60s 인 이유: 못 뜰 인프라를 5분씩 기다려봐야 결론이 같고, 그만큼 서비스 배포만 늦어진다.
+          sudo kubectl -n "$NS" rollout status "$d" --timeout=60s || INFRA_FAILED="$INFRA_FAILED $d"
           done
           else
           echo "~/Backend 클론이 없어 인프라 매니페스트 apply 를 건너뛴다" >&2


### PR DESCRIPTION
## 무엇을

직전 CD(`30603470598`)가 서비스 롤링 직전에 죽어서 **서비스 이미지 6개가 배포되지 않았다.** 그걸 고쳐 다시 배포한다.

- #153 배포가 서비스 롤링 직전에 SSH 끊김으로 죽던 문제
- #152 디스크 고갈 방지 TTL·보관정책 + 주석 정리 (인프라 매니페스트는 직전 배포에서 이미 적용됐고, 서비스 이미지만 남았다)

## 이번 배포에서 확인할 것

`Deploy over SSH` 로그가 인프라 롤아웃을 지나 `set image` 구간까지 도달해야 한다.

```
deployment "portainer" ...        <- 60s 뒤 넘어가야 함 (기존 300s 침묵 -> Broken pipe)
...
deployment/api-service ... set image
```

여기까지 가면 archiver-service·api-service 에 events 7일 / alerts 90일 TTL 이 반영된다.

## 알려진 남은 문제

`kafka-ui`·`portainer` 는 여전히 서버에서 안 뜬다. 이번 변경은 그것들이 앱 배포를 막지 못하게만 한 것이고, CD 는 맨 끝에서 여전히 실패로 끝난다(의도된 동작). 원인은 따로 파는 중이다.