### PR TITLE
release: API 키 거부 401 에 CORS 헤더 누락 수정

### DIFF
--- a/api-service/src/main/java/com/edrdog/apiservice/security/ApiKeyFilter.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/security/ApiKeyFilter.java
@@ -5,6 +5,8 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
@@ -14,8 +16,14 @@ import java.io.IOException;
 /**
  * 모든 요청 앞단에서 X-API-Key 헤더를 검증한다. 헬스체크·Swagger 는 예외(ApiKeyPolicy).
  * 판단 로직은 ApiKeyPolicy(순수)에 있고, 여기서는 HTTP 연결만 담당한다.
+ *
+ * <p>순서를 명시하는 이유: 이게 없으면 등록 순서가 스캔 순서에 좌우돼 환경마다 달라진다.
+ * CorsFilter 보다 앞서면 여기서 낸 401 에 CORS 헤더가 안 붙고, 브라우저는 본문을 못 읽어
+ * "유효한 X-API-Key 가 필요합니다" 대신 정체불명의 네트워크 오류만 받는다. 키를 잘못 맞춘
+ * 배포자가 원인을 찾을 방법이 사라진다. 로컬 테스트는 통과하는데 배포에서만 그랬다.
  */
 @Component
+@Order(Ordered.HIGHEST_PRECEDENCE + 10)
 public class ApiKeyFilter extends OncePerRequestFilter {
 
     private static final String HEADER = "X-API-Key";

--- a/api-service/src/test/java/com/edrdog/apiservice/security/CorsFilterOrderTest.java
+++ b/api-service/src/test/java/com/edrdog/apiservice/security/CorsFilterOrderTest.java
@@ -1,0 +1,91 @@
+package com.edrdog.apiservice.security;
+
+import jakarta.servlet.Filter;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.web.filter.CorsFilter;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * CorsFilter 가 ApiKeyFilter 보다 먼저 도는지 확인한다.
+ *
+ * <p>순서가 뒤집히면 ApiKeyFilter 의 401 에 CORS 헤더가 안 붙고, 브라우저는 본문을 못 읽어
+ * 정체불명의 네트워크 오류만 받는다. 키를 잘못 맞춘 배포자가 원인을 찾을 방법이 사라진다.
+ *
+ * <p>순서를 값으로 직접 확인하는 이유: 순서를 안 박아 두면 스캔 순서에 좌우돼 환경마다 달라진다.
+ * 그래서 요청을 쏘는 테스트는 로컬에서 통과하는데 배포에서만 깨졌다. 실제로 그렇게 당했다.
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.ANY)
+@TestPropertySource(properties = {
+        "spring.kafka.listener.auto-startup=false",
+        "edrdog.cors.allowed-origins=http://localhost:5173"
+})
+class CorsFilterOrderTest {
+
+    private static final String ORIGIN = "http://localhost:5173";
+
+    @Autowired
+    private TestRestTemplate rest;
+
+    @Autowired
+    private ConfigurableApplicationContext ctx;
+
+    @Test
+    void CorsFilter_가_ApiKeyFilter_보다_먼저_등록된다() {
+        assertThat(orderOf(CorsFilter.class)).isLessThan(orderOf(ApiKeyFilter.class));
+    }
+
+    @Test
+    void ApiKeyFilter_는_순서를_명시해_둔다() {
+        // 빠지면 기본값(LOWEST_PRECEDENCE)이 아니라 등록 순서에 맡겨져 환경마다 달라진다.
+        assertThat(ctx.getBeanFactory().findAnnotationOnBean("apiKeyFilter", Order.class)).isNotNull();
+    }
+
+    @Test
+    void API키_거부_401_에도_허용_출처_헤더가_붙는다() {
+        ResponseEntity<String> res = call("/api/tenant/install-link", HttpMethod.POST);
+
+        assertThat(res.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+        assertThat(res.getHeaders().getAccessControlAllowOrigin()).isEqualTo(ORIGIN);
+    }
+
+    @Test
+    void 인증_필터가_내는_401_에도_허용_출처_헤더가_붙는다() {
+        // API 키 예외 경로라 ApiKeyFilter 를 지나 토큰 검증에서 막힌다.
+        ResponseEntity<String> res = call("/api/hosts", HttpMethod.GET);
+
+        assertThat(res.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+        assertThat(res.getHeaders().getAccessControlAllowOrigin()).isEqualTo(ORIGIN);
+    }
+
+    private ResponseEntity<String> call(String path, HttpMethod method) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.set(HttpHeaders.ORIGIN, ORIGIN);
+        return rest.exchange(path, method, new HttpEntity<>(headers), String.class);
+    }
+
+    /** Spring Boot 가 필터를 줄 세울 때 쓰는 것과 같은 값(@Order)을 읽는다. */
+    private int orderOf(Class<? extends Filter> type) {
+        Map<String, ? extends Filter> beans = ctx.getBeansOfType(type);
+        assertThat(beans).hasSize(1);
+        String name = beans.keySet().iterator().next();
+        Order order = ctx.getBeanFactory().findAnnotationOnBean(name, Order.class);
+        assertThat(order).as("%s 에 @Order 가 없다", name).isNotNull();
+        return order.value();
+    }
+}

--- a/api-service/src/test/java/com/edrdog/apiservice/security/CorsIntegrationTest.java
+++ b/api-service/src/test/java/com/edrdog/apiservice/security/CorsIntegrationTest.java
@@ -10,6 +10,7 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.options;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -88,6 +89,16 @@ class CorsIntegrationTest {
     void 실제_요청_응답에도_허용_출처_헤더가_붙는다() throws Exception {
         // 토큰이 없어 401 이지만, 브라우저가 응답을 읽으려면 CORS 헤더는 붙어 있어야 한다.
         mvc.perform(get("/api/alerts").header("Origin", "http://localhost:5173"))
+                .andExpect(header().string("Access-Control-Allow-Origin", "http://localhost:5173"));
+    }
+
+    @Test
+    void API키_거부_401_에도_허용_출처_헤더가_붙는다() throws Exception {
+        // 헤더가 없으면 브라우저는 본문을 못 읽고 네트워크 오류로만 받는다. 그러면 화면에
+        // "유효한 X-API-Key 가 필요합니다" 대신 정체불명의 연결 실패가 뜨고, 키를 잘못 맞춘
+        // 배포자가 원인을 찾을 방법이 사라진다. 실제로 배포에서 그 일이 있었다.
+        mvc.perform(post("/api/tenant/install-link").header("Origin", "http://localhost:5173"))
+                .andExpect(status().isUnauthorized())
                 .andExpect(header().string("Access-Control-Allow-Origin", "http://localhost:5173"));
     }
 }


### PR DESCRIPTION
dev 를 main 에 반영합니다. CD 가 돌아 새 이미지가 빌드되고 서버에 롤링됩니다.

- #154 fix: API 키 거부 401 에 CORS 헤더가 빠지던 문제

`ApiKeyFilter` 에 순서 지정이 없어 등록 순서가 환경마다 달라졌습니다. `CorsFilter` 보다 앞서면 401 에 CORS 헤더가 안 붙고, 브라우저는 본문을 못 읽어 `서버에 연결하지 못했습니다` 만 보게 됩니다. `@Order(HIGHEST_PRECEDENCE + 10)` 으로 고정했습니다.

지금 도는 이미지는 `c8395de` 라 그 뒤 커밋들도 함께 반영됩니다.