### PR TITLE
fix: ClickHouse 비번이 서비스와 갈려 인증이 깨지던 문제

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -129,8 +129,15 @@ jobs:
           INFRA_DEPLOYS="$INFRA_DEPLOYS $(echo "$APPLIED" | grep '^deployment' || true)"
           done
           # Infisical 연동은 Operator 가 깔려 있을 때만 한다. 없으면 CRD 가 없어 apply 가 실패하고 set -e 때문에 서비스 롤링까지 같이 죽는다.
+          # 슬러그가 플레이스홀더면 apply 하지 않는다. 그대로 밀면 서버에 제대로 들어가 있던 설정을 덮어써서
+          # Operator 가 인증을 못 하게 되고, 시크릿이 조용히 낡아간다(실제로 하루 동안 그랬다).
           if sudo kubectl get crd infisicalsecrets.secrets.infisical.com >/dev/null 2>&1; then
-          git -C ~/Backend show "FETCH_HEAD:k8s/infisical.yaml" | sudo kubectl apply -f -
+          INFISICAL_YAML=$(git -C ~/Backend show "FETCH_HEAD:k8s/infisical.yaml")
+          if echo "$INFISICAL_YAML" | grep -q REPLACE_WITH_INFISICAL_PROJECT_SLUG; then
+          echo "k8s/infisical.yaml 의 projectSlug 가 아직 플레이스홀더라 apply 를 건너뛴다" >&2
+          else
+          echo "$INFISICAL_YAML" | sudo kubectl apply -f -
+          fi
           fi
           # 인프라가 안 떠도 여기서 멈추지 않는다. kafka-ui·portainer 는 시크릿이 없으면 일부러 안 뜨는데, 운영 UI 때문에 앱 배포가 막히면 곤란해서 대신 맨 끝에서 CD 를 실패시킨다.
           for d in $INFRA_DEPLOYS; do

--- a/k8s/archiver-service.yaml
+++ b/k8s/archiver-service.yaml
@@ -21,6 +21,10 @@ spec:
           image: ghcr.io/2026-siheung-bootcamp-team-i/backend/archiver-service:latest
           ports:
             - containerPort: 8083
+          # CLICKHOUSE_PASSWORD 를 여기서 안 받으면 코드 기본값으로 붙는다. 지금은 그 값이 우연히 맞아서 돌아갈 뿐이다.
+          envFrom:
+            - secretRef:
+                name: edrdog-secrets
           env:
             - name: SPRING_KAFKA_BOOTSTRAP_SERVERS
               value: "kafka:9094"

--- a/k8s/clickhouse.yaml
+++ b/k8s/clickhouse.yaml
@@ -71,8 +71,13 @@ spec:
               value: edrdog
             - name: CLICKHOUSE_USER
               value: edrdog
+            # 평문으로 두면 edrdog-secrets 를 받는 api-service 와 값이 갈려 인증이 깨진다(실제로 alerts 테이블이 안 만들어졌다).
+            # 이 비번은 CH 데이터 디렉터리 첫 생성 때만 반영되므로, 값을 바꾸려면 PVC 를 지워야 한다.
             - name: CLICKHOUSE_PASSWORD
-              value: edrdog
+              valueFrom:
+                secretKeyRef:
+                  name: edrdog-secrets
+                  key: CLICKHOUSE_PASSWORD
             - name: CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT
               value: "1"
           readinessProbe:


### PR DESCRIPTION
## 증상

배포된 api-service 가 alerts 테이블을 못 만들고 있었다. 예외를 삼키게 돼 있어 앱은 멀쩡히 떠 있었지만 판정기록이 하나도 안 쌓인다.

```
WARN c.e.a.alert.AlertClickHouseWriter : ClickHouse alerts 스키마 준비 실패
403 Forbidden: Code: 516. DB::Exception: edrdog: Authentication failed:
password is incorrect, or there is no user with such name.
```

## 원인

비번이 두 군데로 갈라져 있다.

| | 출처 | 값 |
|---|---|---|
| ClickHouse 서버 | `k8s/clickhouse.yaml` 평문 | `edrdog` |
| api-service | `envFrom: edrdog-secrets` | Infisical 의 `CLICKHOUSE_PASSWORD` |

서비스 쪽만 시크릿으로 옮기고 ClickHouse 서버 쪽을 안 옮긴 상태였다.

`archiver-service` 는 `envFrom` 이 없어서 코드 기본값 `edrdog` 로 붙고, 그게 마침 서버 값과 같아 살아있었다. 우연히 돌아간 것이라 같이 정리한다.

## 고친 것

- **`clickhouse.yaml`**: `CLICKHOUSE_PASSWORD` 를 `edrdog-secrets` 에서 받는다. 양쪽이 같은 값이 된다
- **`archiver-service.yaml`**: `envFrom: edrdog-secrets` 추가. 다른 서비스와 같게 맞춘다
- **`cd.yml`**: `projectSlug` 가 플레이스홀더면 `infisical.yaml` 을 apply 하지 않는다

세 번째가 이 사고의 진짜 뿌리다. 레포의 `k8s/infisical.yaml` 은 `projectSlug: REPLACE_WITH_INFISICAL_PROJECT_SLUG` 인데 CD 가 그걸 그대로 서버에 민다. 서버에 제대로 들어가 있던 설정이 덮이면서 Operator 가 인증을 잃었고, 그 뒤로 Infisical 에 추가한 키가 클러스터로 안 내려왔다.

```
message: "unable to authenticate [err=no authentication method provided]"
lastTransitionTime: "2026-07-30T20:02:55Z"
```

`KAFKA_UI_USER`/`KAFKA_UI_PASSWORD`/`PORTAINER_ADMIN_PASSWORD` 가 Infisical 에는 있는데 `edrdog-secrets` 에는 없던 이유가 이것이고, kafka-ui·portainer 가 못 뜨던 것도 여기서 나왔다.

## 배포 순서 (중요)

ClickHouse 는 **데이터 디렉터리를 처음 만들 때만** 비번을 반영한다. 지금 PVC 는 `edrdog` 로 초기화돼 있어서 매니페스트만 바꾸면 안 먹는다. 머지 후 서버에서 PVC 를 한 번 비운다(수집 전이라 지울 데이터가 없다).

```bash
sudo kubectl -n edrdog scale deploy/clickhouse --replicas=0
sudo kubectl -n edrdog delete pvc clickhouse
git -C ~/Backend fetch origin main
git -C ~/Backend show FETCH_HEAD:k8s/clickhouse.yaml | sudo kubectl apply -f -
sudo kubectl -n edrdog rollout restart deploy/api-service deploy/archiver-service
```

이 사이 잠깐 `archiver-service` 가 CrashLoopBackOff 로 돌 수 있다. archiver 는 CH 연결 실패 시 부팅이 실패하도록 돼 있어서(예외를 안 삼킨다) PVC 를 비우기 전까지 재시작을 반복한다. 위 순서를 마치면 정상으로 돌아온다.

## 검증

- `cd.yml` YAML 파싱 + deploy 잡 `run` 블록 `bash -n` 통과
- 가드 로직을 실제로 실행해 양쪽 확인: 플레이스홀더면 건너뛰고, 슬러그를 채우면 apply 한다
- `clickhouse.yaml`·`archiver-service.yaml` `kubectl apply --dry-run=client` 통과

## 남는 것

`k8s/infisical.yaml` 의 `projectSlug` 는 아직 플레이스홀더다. 비밀값이 아니니 실제 슬러그를 채워두면 CD 가 알아서 적용한다. 이 PR 의 가드 덕분에 채우기 전까지는 서버 설정을 건드리지 않는다.