### PR TITLE
chore: Infisical projectSlug 실제 값 + Operator 이미지 태그 고정 문서

### DIFF
--- a/k8s/README.md
+++ b/k8s/README.md
@@ -209,7 +209,14 @@ Operator 가 Infisical 을 읽어 `edrdog-secrets` k8s Secret 으로 동기화�
 설치와 연결 절차는 `k8s/infisical.yaml` 주석에 있다. 요약하면 Operator 설치 1회,
 Machine Identity 자격증명 Secret 생성 1회, `kubectl apply -f k8s/infisical.yaml`, 서비스에 `envFrom` patch.
 
-- 릴리스된 Operator(v0.11.5)에는 문서에 나오는 v1beta1 CRD 가 아직 없다. 실제로 도는 건 v1alpha1 `InfisicalSecret` 이다.
+- 실제로 도는 건 v1alpha1 `InfisicalSecret` 이다. 문서에 나오는 v1beta1 은 v0.11.6 부터 들어왔다.
+- **Operator 이미지를 `:latest` 로 두지 않는다.** 설치 매니페스트 기본값이 `:latest` 라 Infisical 이 릴리스할 때마다
+  서버가 조용히 갈아탄다. CRD 는 그대로인데 Operator 만 올라가면 시작하자마자 죽고(`no matches for kind
+  "InfisicalConnection"`), 시크릿이 며칠씩 낡은 줄도 모르고 지나간다. 설치 뒤 반드시 태그를 고정한다:
+  ```
+  kubectl -n infisical-operator-system set image \
+    deploy/infisical-operator-controller-manager manager=infisical/kubernetes-operator:v0.11.6
+  ```
 - Deployment 에 같은 이름의 env 가 직접 박혀 있으면 그쪽이 `envFrom` 을 이긴다. Infisical 값을 쓰려면
   `kubectl -n edrdog set env deployment/<이름> <키>-` 로 기존 env 를 먼저 지운다.
 - CD 는 `infisicalsecrets` CRD 가 있을 때만 이 파일을 apply 한다. Operator 가 없으면 건너뛴다.

--- a/k8s/infisical.yaml
+++ b/k8s/infisical.yaml
@@ -45,7 +45,7 @@ spec:
         secretNamespace: edrdog
       secretsScope:
         # 프로젝트 슬러그는 Infisical 프로젝트 Settings 에서 확인한다. 비밀값이 아니다.
-        projectSlug: REPLACE_WITH_INFISICAL_PROJECT_SLUG
+        projectSlug: edrdog-a9kj
         envSlug: prod        # Infisical 의 Production 환경 슬러그
         secretsPath: /
 

--- a/k8s/infisical.yaml
+++ b/k8s/infisical.yaml
@@ -4,8 +4,11 @@
 # 문서에는 v1beta1(InfisicalConnection/InfisicalAuth/InfisicalStaticSecret)이 나오지만
 # 릴리스된 Operator(v0.11.5)에는 아직 그 CRD 가 없다. 실제로 도는 건 v1alpha1 InfisicalSecret 이다.
 #
-# 1) Operator 설치 (1회)
-#   kubectl apply -f https://raw.githubusercontent.com/Infisical/kubernetes-operator/infisical-k8-operator/v0.11.5/kubectl-install/install-secrets-operator.yaml
+# 1) Operator 설치 (1회). 설치 매니페스트 기본 이미지가 :latest 라 그대로 두면 릴리스마다 서버가 갈아타고
+#    CRD 와 어긋나 죽는다(실제로 v0.11.6 이 나오면서 하루 동안 동기화가 멈췄다). 설치 뒤 태그를 고정한다.
+#   kubectl apply -f https://raw.githubusercontent.com/Infisical/kubernetes-operator/infisical-k8-operator/v0.11.6/kubectl-install/install-secrets-operator.yaml
+#   kubectl -n infisical-operator-system set image \
+#     deploy/infisical-operator-controller-manager manager=infisical/kubernetes-operator:v0.11.6
 #
 # 2) Machine Identity 자격증명 (1회, 값이 비밀이라 레포에 두지 않는다)
 #    Infisical > Access Control > Identities 에서 Universal Auth 로 발급하고

--- a/k8s/infisical.yaml
+++ b/k8s/infisical.yaml
@@ -2,7 +2,7 @@
 # 매니페스트에 비밀번호를 평문으로 박아두던 걸(DB_PASSWORD, CLICKHOUSE_PASSWORD 등) 여기로 옮기는 게 목적이다.
 #
 # 문서에는 v1beta1(InfisicalConnection/InfisicalAuth/InfisicalStaticSecret)이 나오지만
-# 릴리스된 Operator(v0.11.5)에는 아직 그 CRD 가 없다. 실제로 도는 건 v1alpha1 InfisicalSecret 이다.
+# 실제로 도는 건 v1alpha1 InfisicalSecret 이다. v1beta1 CRD 는 v0.11.6 부터 들어왔다.
 #
 # 1) Operator 설치 (1회). 설치 매니페스트 기본 이미지가 :latest 라 그대로 두면 릴리스마다 서버가 갈아타고
 #    CRD 와 어긋나 죽는다(실제로 v0.11.6 이 나오면서 하루 동안 동기화가 멈췄다). 설치 뒤 태그를 고정한다.


### PR DESCRIPTION
#157 이 첫 커밋만 담긴 채로 머지돼서, 나머지 3개를 따로 올린다.

## 1. `projectSlug` 를 실제 값으로

`REPLACE_WITH_INFISICAL_PROJECT_SLUG` -> `edrdog-a9kj`

#157 의 가드가 "플레이스홀더면 apply 안 함" 이라, 이 값을 채우기 전까지 CD 는 `infisical.yaml` 을 서버에 반영하지 않는다. 슬러그는 비밀값이 아니라 레포에 둔다.

## 2. Operator 이미지를 `:latest` 로 두지 말 것 (문서)

설치 매니페스트 기본 이미지가 `:latest` 인데, v0.11.6 이 나오면서 서버가 조용히 갈아탔다. 새 Operator 는 `v1beta1` CRD(`InfisicalConnection`/`InfisicalAuth`)를 요구하는데 클러스터엔 `v1alpha1` 만 있어서 시작하자마자 죽었다.

```
image "infisical/kubernetes-operator:latest"
no matches for kind "InfisicalConnection" in version "secrets.infisical.com/v1beta1"
CrashLoopBackOff  82 (14s ago)  9h
```

9시간 동안 시크릿 동기화가 멈춘 줄 아무도 몰랐다. Infisical 에 새로 넣은 `KAFKA_UI_*`·`PORTAINER_ADMIN_PASSWORD` 가 클러스터로 안 내려왔고, 그게 kafka-ui·portainer 가 못 뜨던 원인이었다.

`k8s/infisical.yaml` 주석과 `k8s/README.md` 에 설치 후 태그 고정 절차를 적었다.

```
kubectl -n infisical-operator-system set image \
  deploy/infisical-operator-controller-manager manager=infisical/kubernetes-operator:v0.11.6
```

## 검증

`k8s/infisical.yaml` YAML 파싱 OK. 가드 로직을 양쪽으로 실행해 확인했다: 플레이스홀더면 건너뛰고, 이 PR 처럼 슬러그가 채워져 있으면 apply 한다.