### PR TITLE
release: ClickHouse 비번 통일 + Infisical 설정 정리

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -129,8 +129,15 @@ jobs:
           INFRA_DEPLOYS="$INFRA_DEPLOYS $(echo "$APPLIED" | grep '^deployment' || true)"
           done
           # Infisical 연동은 Operator 가 깔려 있을 때만 한다. 없으면 CRD 가 없어 apply 가 실패하고 set -e 때문에 서비스 롤링까지 같이 죽는다.
+          # 슬러그가 플레이스홀더면 apply 하지 않는다. 그대로 밀면 서버에 제대로 들어가 있던 설정을 덮어써서
+          # Operator 가 인증을 못 하게 되고, 시크릿이 조용히 낡아간다(실제로 하루 동안 그랬다).
           if sudo kubectl get crd infisicalsecrets.secrets.infisical.com >/dev/null 2>&1; then
-          git -C ~/Backend show "FETCH_HEAD:k8s/infisical.yaml" | sudo kubectl apply -f -
+          INFISICAL_YAML=$(git -C ~/Backend show "FETCH_HEAD:k8s/infisical.yaml")
+          if echo "$INFISICAL_YAML" | grep -q REPLACE_WITH_INFISICAL_PROJECT_SLUG; then
+          echo "k8s/infisical.yaml 의 projectSlug 가 아직 플레이스홀더라 apply 를 건너뛴다" >&2
+          else
+          echo "$INFISICAL_YAML" | sudo kubectl apply -f -
+          fi
           fi
           # 인프라가 안 떠도 여기서 멈추지 않는다. kafka-ui·portainer 는 시크릿이 없으면 일부러 안 뜨는데, 운영 UI 때문에 앱 배포가 막히면 곤란해서 대신 맨 끝에서 CD 를 실패시킨다.
           for d in $INFRA_DEPLOYS; do

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -209,7 +209,14 @@ Operator 가 Infisical 을 읽어 `edrdog-secrets` k8s Secret 으로 동기화�
 설치와 연결 절차는 `k8s/infisical.yaml` 주석에 있다. 요약하면 Operator 설치 1회,
 Machine Identity 자격증명 Secret 생성 1회, `kubectl apply -f k8s/infisical.yaml`, 서비스에 `envFrom` patch.
 
-- 릴리스된 Operator(v0.11.5)에는 문서에 나오는 v1beta1 CRD 가 아직 없다. 실제로 도는 건 v1alpha1 `InfisicalSecret` 이다.
+- 실제로 도는 건 v1alpha1 `InfisicalSecret` 이다. 문서에 나오는 v1beta1 은 v0.11.6 부터 들어왔다.
+- **Operator 이미지를 `:latest` 로 두지 않는다.** 설치 매니페스트 기본값이 `:latest` 라 Infisical 이 릴리스할 때마다
+  서버가 조용히 갈아탄다. CRD 는 그대로인데 Operator 만 올라가면 시작하자마자 죽고(`no matches for kind
+  "InfisicalConnection"`), 시크릿이 며칠씩 낡은 줄도 모르고 지나간다. 설치 뒤 반드시 태그를 고정한다:
+  ```
+  kubectl -n infisical-operator-system set image \
+    deploy/infisical-operator-controller-manager manager=infisical/kubernetes-operator:v0.11.6
+  ```
 - Deployment 에 같은 이름의 env 가 직접 박혀 있으면 그쪽이 `envFrom` 을 이긴다. Infisical 값을 쓰려면
   `kubectl -n edrdog set env deployment/<이름> <키>-` 로 기존 env 를 먼저 지운다.
 - CD 는 `infisicalsecrets` CRD 가 있을 때만 이 파일을 apply 한다. Operator 가 없으면 건너뛴다.

--- a/k8s/archiver-service.yaml
+++ b/k8s/archiver-service.yaml
@@ -21,6 +21,10 @@ spec:
           image: ghcr.io/2026-siheung-bootcamp-team-i/backend/archiver-service:latest
           ports:
             - containerPort: 8083
+          # CLICKHOUSE_PASSWORD 를 여기서 안 받으면 코드 기본값으로 붙는다. 지금은 그 값이 우연히 맞아서 돌아갈 뿐이다.
+          envFrom:
+            - secretRef:
+                name: edrdog-secrets
           env:
             - name: SPRING_KAFKA_BOOTSTRAP_SERVERS
               value: "kafka:9094"

--- a/k8s/clickhouse.yaml
+++ b/k8s/clickhouse.yaml
@@ -71,8 +71,13 @@ spec:
               value: edrdog
             - name: CLICKHOUSE_USER
               value: edrdog
+            # 평문으로 두면 edrdog-secrets 를 받는 api-service 와 값이 갈려 인증이 깨진다(실제로 alerts 테이블이 안 만들어졌다).
+            # 이 비번은 CH 데이터 디렉터리 첫 생성 때만 반영되므로, 값을 바꾸려면 PVC 를 지워야 한다.
             - name: CLICKHOUSE_PASSWORD
-              value: edrdog
+              valueFrom:
+                secretKeyRef:
+                  name: edrdog-secrets
+                  key: CLICKHOUSE_PASSWORD
             - name: CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT
               value: "1"
           readinessProbe:

--- a/k8s/infisical.yaml
+++ b/k8s/infisical.yaml
@@ -45,7 +45,7 @@ spec:
         secretNamespace: edrdog
       secretsScope:
         # 프로젝트 슬러그는 Infisical 프로젝트 Settings 에서 확인한다. 비밀값이 아니다.
-        projectSlug: REPLACE_WITH_INFISICAL_PROJECT_SLUG
+        projectSlug: edrdog-a9kj
         envSlug: prod        # Infisical 의 Production 환경 슬러그
         secretsPath: /
 

--- a/k8s/infisical.yaml
+++ b/k8s/infisical.yaml
@@ -4,8 +4,11 @@
 # 문서에는 v1beta1(InfisicalConnection/InfisicalAuth/InfisicalStaticSecret)이 나오지만
 # 릴리스된 Operator(v0.11.5)에는 아직 그 CRD 가 없다. 실제로 도는 건 v1alpha1 InfisicalSecret 이다.
 #
-# 1) Operator 설치 (1회)
-#   kubectl apply -f https://raw.githubusercontent.com/Infisical/kubernetes-operator/infisical-k8-operator/v0.11.5/kubectl-install/install-secrets-operator.yaml
+# 1) Operator 설치 (1회). 설치 매니페스트 기본 이미지가 :latest 라 그대로 두면 릴리스마다 서버가 갈아타고
+#    CRD 와 어긋나 죽는다(실제로 v0.11.6 이 나오면서 하루 동안 동기화가 멈췄다). 설치 뒤 태그를 고정한다.
+#   kubectl apply -f https://raw.githubusercontent.com/Infisical/kubernetes-operator/infisical-k8-operator/v0.11.6/kubectl-install/install-secrets-operator.yaml
+#   kubectl -n infisical-operator-system set image \
+#     deploy/infisical-operator-controller-manager manager=infisical/kubernetes-operator:v0.11.6
 #
 # 2) Machine Identity 자격증명 (1회, 값이 비밀이라 레포에 두지 않는다)
 #    Infisical > Access Control > Identities 에서 Universal Auth 로 발급하고

--- a/k8s/infisical.yaml
+++ b/k8s/infisical.yaml
@@ -2,7 +2,7 @@
 # 매니페스트에 비밀번호를 평문으로 박아두던 걸(DB_PASSWORD, CLICKHOUSE_PASSWORD 등) 여기로 옮기는 게 목적이다.
 #
 # 문서에는 v1beta1(InfisicalConnection/InfisicalAuth/InfisicalStaticSecret)이 나오지만
-# 릴리스된 Operator(v0.11.5)에는 아직 그 CRD 가 없다. 실제로 도는 건 v1alpha1 InfisicalSecret 이다.
+# 실제로 도는 건 v1alpha1 InfisicalSecret 이다. v1beta1 CRD 는 v0.11.6 부터 들어왔다.
 #
 # 1) Operator 설치 (1회). 설치 매니페스트 기본 이미지가 :latest 라 그대로 두면 릴리스마다 서버가 갈아타고
 #    CRD 와 어긋나 죽는다(실제로 v0.11.6 이 나오면서 하루 동안 동기화가 멈췄다). 설치 뒤 태그를 고정한다.


### PR DESCRIPTION
## 담긴 것

- #157 ClickHouse 비번이 서비스와 갈려 인증이 깨지던 문제
- #159 Infisical projectSlug 실제 값 + Operator 이미지 태그 고정 문서

## 왜

배포된 api-service 가 alerts 테이블을 못 만들고 있었다. 예외를 삼키게 돼 있어 앱은 멀쩡히 떠 있었지만 판정기록이 하나도 안 쌓인다.

```
403 Forbidden: Code: 516. edrdog: Authentication failed
```

ClickHouse 서버는 매니페스트에 평문 `edrdog` 를 박아 쓰고, api-service 는 `envFrom` 으로 `edrdog-secrets` 의 `CLICKHOUSE_PASSWORD` 를 받는다. 서비스 쪽만 시크릿으로 옮기고 서버 쪽을 안 옮겨서 값이 어긋나 있었다.

## 배포 후 서버에서 1회 (중요)

ClickHouse 는 **데이터 디렉터리를 처음 만들 때만** 비번을 반영한다. 지금 PVC 는 `edrdog` 로 초기화돼 있어 매니페스트만 바꾸면 안 먹는다. 수집 전이라 지울 데이터가 없다.

```bash
sudo kubectl -n edrdog scale deploy/clickhouse --replicas=0
sudo kubectl -n edrdog delete pvc clickhouse
git -C ~/Backend fetch origin main
git -C ~/Backend show FETCH_HEAD:k8s/clickhouse.yaml | sudo kubectl apply -f -
sudo kubectl -n edrdog rollout restart deploy/api-service deploy/archiver-service
```

이 사이 잠깐 `archiver-service` 가 CrashLoopBackOff 로 돈다. archiver 는 CH 연결 실패 시 부팅을 실패시켜서(예외를 안 삼킨다) PVC 를 비우기 전까지 재시작을 반복한다. 위 순서를 마치면 정상으로 돌아온다.

확인:
```bash
sudo kubectl -n edrdog exec deploy/clickhouse -- clickhouse-client --user edrdog \
  --password "$(sudo kubectl -n edrdog get secret edrdog-secrets -o jsonpath='{.data.CLICKHOUSE_PASSWORD}' | base64 -d)" \
  -q "SHOW CREATE TABLE edrdog.alerts"
```
`TTL toDateTime(created_at) + toIntervalDay(90)` 이 보이면 끝이다.