### PR TITLE
fix: alert-service 가 INTERNAL_API_KEY 를 못 받아 api-service 에 401 나던 문제

### DIFF
--- a/k8s/README.md
+++ b/k8s/README.md
@@ -108,8 +108,20 @@ curl -sk https://localhost:8443/api/agent/enroll -H 'Content-Type: application/j
 시크릿이 없으면 일부러 안 뜨는데 그것 때문에 앱 배포가 멈추면 곤란해서다.
 
 서비스 매니페스트만 손으로 적용한다. CD 가 apply 하면 image 가 `:latest` 로 되돌아갔다가
-`set image` 로 다시 `:sha` 가 되면서 롤아웃이 두 번 돈다. `k8s/api-service.yaml` 을 고쳤으면
-지금 떠 있는 이미지 태그를 지키면서 적용한다:
+`set image` 로 다시 `:sha` 가 되면서 롤아웃이 두 번 돈다.
+
+⚠️ **그래서 `k8s/<서비스>.yaml` 의 `env`·`envFrom` 을 고쳐도 배포로는 서버에 안 간다.** CD 는
+Deployment 가 이미 있으면 `set image` 만 하고 매니페스트를 apply 하지 않는다. 머지도 CD 도 초록불인데
+서버만 옛 설정인 채로 남고, 짝이 되는 다른 변경(예: ClickHouse 비번)만 반영되면 그때 터진다.
+실제로 `archiver-service` 의 `envFrom` 이 이렇게 누락돼 CrashLoopBackOff 가 났다.
+아래 절차를 밟거나, env 만 바꾸는 거면 patch 가 더 안전하다:
+
+```bash
+sudo kubectl -n edrdog patch deployment alert-service --type=strategic \
+  -p '{"spec":{"template":{"spec":{"containers":[{"name":"alert-service","envFrom":[{"secretRef":{"name":"edrdog-secrets"}}]}]}}}}'
+```
+
+`k8s/api-service.yaml` 처럼 매니페스트 전체를 적용해야 하면 지금 떠 있는 이미지 태그를 지키면서 적용한다:
 
 ```bash
 IMG=$(sudo kubectl -n edrdog get deploy/api-service -o jsonpath='{.spec.template.spec.containers[0].image}')

--- a/k8s/alert-service.yaml
+++ b/k8s/alert-service.yaml
@@ -21,6 +21,10 @@ spec:
           image: ghcr.io/2026-siheung-bootcamp-team-i/backend/alert-service:latest
           ports:
             - containerPort: 8083
+          # INTERNAL_API_KEY 를 여기서 안 받으면 코드 기본값(dev-internal-key)으로 붙어, api-service 가 401 을 낸다.
+          envFrom:
+            - secretRef:
+                name: edrdog-secrets
           env:
             - name: SPRING_KAFKA_BOOTSTRAP_SERVERS
               value: "kafka:9094"


### PR DESCRIPTION
## 무엇을

`alert-service` 에 `envFrom: edrdog-secrets` 를 추가하고, 같은 유형이 또 나오지 않게 `k8s/README.md` 를 보강한다.

## 왜

`alert-service` 는 api-service 의 내부 엔드포인트를 `X-Internal-Key` 로 부른다.

- `TenantWebhookClient` -> 테넌트 Slack webhook 조회
- `HostTargetClient` -> host 소유자 알림 목적지 조회

그런데 `envFrom` 이 없어서 코드 기본값으로 붙는다.

| | `INTERNAL_API_KEY` |
|---|---|
| alert-service | `dev-internal-key` (기본값) |
| api-service | Infisical 값 (`envFrom` 있음) |

값이 달라 api-service 가 `유효한 X-Internal-Key 가 필요합니다` 로 401 을 낸다. 아직 수집 전이라 알림이 흐른 적이 없어서 로그에는 안 잡혔지만, 첫 알림이 나가는 순간 터졌을 상태였다.

`detector-service` 도 `envFrom` 이 없지만 그쪽은 OTEL 값만 쓰고 매니페스트에 평문 env 로 들어 있어 문제 없다. 그대로 둔다.

## README 보강

이번에 `archiver-service` 가 CrashLoopBackOff 로 죽은 원인이 여기 있다. 나는 `k8s/archiver-service.yaml` 에 `envFrom` 을 넣고 머지했는데, CD 는 **Deployment 가 이미 있으면 매니페스트를 apply 하지 않고 `set image` 만 한다.** 그래서 그 변경이 서버에 가지 않았다.

문서에는 그 사실이 "롤아웃이 두 번 돈다"는 불편함 위주로 적혀 있어서, **조용히 누락된다**는 게 진짜 위험이라는 점이 드러나지 않았다. 짝이 되는 다른 변경(ClickHouse 비번)만 반영되면서 어긋났다. 그 실패 모드를 명시하고 patch 예시를 넣었다.

## 서버 반영

이미 patch 로 적용해뒀다. 이 PR 은 매니페스트를 서버 상태와 맞추는 것이다.

```
kubectl -n edrdog patch deployment alert-service --type=strategic \
  -p '{"spec":{"template":{"spec":{"containers":[{"name":"alert-service","envFrom":[{"secretRef":{"name":"edrdog-secrets"}}]}]}}}}'
```

## 검증

`kubectl apply --dry-run=client` 통과. 매니페스트의 `envFrom` 이 서버에 건 patch 와 같은지 파싱해서 대조했다.