### PR TITLE
chore: CD 를 매니페스트 apply + 변경 감지로 바꾼다

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -230,10 +230,28 @@ jobs:
           sudo kubectl -n "$NS" rollout status "deployment/$m" --timeout=120s
           done
 
+          # rollout status 는 파드가 떴는지만 본다. api-service 는 ClickHouse 연결이 깨져도 예외를 삼키고
+          # /actuator/health 는 그대로 UP 이라(CH 항목이 없다) 판정기록이 하나도 안 쌓이는 채로 배포가
+          # 초록으로 끝난다. 실제로 비번이 갈려 alerts 테이블이 안 만들어진 걸 몇 시간 뒤에야 알았다.
+          # 그래서 부팅했으면 반드시 참이어야 할 사실 하나를 직접 확인한다.
+          SMOKE_FAILED=""
+          case " $DEPLOYED " in *" api-service "*)
+          CHPW=$(sudo kubectl -n "$NS" get secret edrdog-secrets -o jsonpath='{.data.CLICKHOUSE_PASSWORD}' 2>/dev/null | base64 -d 2>/dev/null || true)
+          [ -n "$CHPW" ] || CHPW=edrdog
+          if ! sudo kubectl -n "$NS" exec deploy/clickhouse -- \
+          clickhouse-client --user edrdog --password "$CHPW" -q "EXISTS TABLE edrdog.alerts" 2>/dev/null | grep -qx 1; then
+          SMOKE_FAILED="api-service 가 떴는데 edrdog.alerts 테이블이 없다. ClickHouse 인증/연결을 확인한다(로그: ClickHouse alerts 스키마 준비 실패)."
+          fi
+          ;;
+          esac
+
           # 앱은 다 올린 뒤에 인프라 실패를 알린다. 여기서 죽어야 CD 가 초록으로 안 끝난다.
-          if [ -n "$INFRA_FAILED" ]; then
-          echo "인프라 롤아웃 실패:$INFRA_FAILED" >&2
-          echo "kafka-ui·portainer 라면 edrdog-secrets 에 계정 키가 없는 것이다(k8s/README.md)." >&2
+          if [ -n "$SMOKE_FAILED" ]; then
+          echo "배포 후 점검 실패: $SMOKE_FAILED" >&2
+          fi
+          if [ -n "$INFRA_FAILED" ] || [ -n "$SMOKE_FAILED" ]; then
+          [ -z "$INFRA_FAILED" ] || echo "인프라 롤아웃 실패:$INFRA_FAILED" >&2
+          [ -z "$INFRA_FAILED" ] || echo "kafka-ui·portainer 라면 edrdog-secrets 에 계정 키가 없는 것이다(k8s/README.md)." >&2
           exit 1
           fi
           REMOTE

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -5,7 +5,48 @@ on:
     branches: [main]
 
 jobs:
+  # 어느 모듈을 다시 구울지 고른다. 이미지 빌드가 QEMU 멀티아치라 모듈당 수 분씩 드는데,
+  # README 한 줄 고친 배포에도 6개를 다 굽고 있었다. 배포(apply)는 전부 하되 굽는 것만 줄인다.
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      modules: ${{ steps.list.outputs.modules }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            shared: &shared
+              - 'build.gradle'
+              - 'settings.gradle'
+              - 'gradle/**'
+              - 'gradlew'
+              - '.github/workflows/cd.yml'
+            detector-service:
+              - *shared
+              - 'detector-service/**'
+            responder-service:
+              - *shared
+              - 'responder-service/**'
+            archiver-service:
+              - *shared
+              - 'archiver-service/**'
+            api-service:
+              - *shared
+              - 'api-service/**'
+            alert-service:
+              - *shared
+              - 'alert-service/**'
+            collector-service:
+              - *shared
+              - 'collector-service/**'
+      # shared 는 "전 모듈 공통" 을 앵커로 재사용하려고 만든 항목이라 모듈이 아니다. matrix 에서 뺀다.
+      - id: list
+        run: echo "modules=$(jq -cn --argjson c '${{ steps.filter.outputs.changes }}' '$c - ["shared"]')" >> "$GITHUB_OUTPUT"
+
   # 빌드 + 최소 테스트 후 boot jar 를 다음 잡으로 넘긴다 (전 모듈)
+  # 굽는 건 바뀐 모듈만이어도, 테스트는 전 모듈을 돌린다. 모듈 간 깨짐을 잡을 그물이 여기뿐이다.
   build:
     runs-on: ubuntu-latest
     steps:
@@ -41,9 +82,10 @@ jobs:
             alert-service/build/libs/*.jar
             collector-service/build/libs/*.jar
 
-  # 이미지 빌드 + GHCR 푸시 (모듈별 matrix)
+  # 이미지 빌드 + GHCR 푸시 (바뀐 모듈만)
   image:
-    needs: build
+    needs: [changes, build]
+    if: needs.changes.outputs.modules != '[]'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -52,7 +94,7 @@ jobs:
       # 한 모듈이 실패해도 나머지는 계속 빌드한다. Docker Hub 에서 베이스 이미지를 받다가 네트워크 타임아웃이 나면(실제로 발생했다) fail-fast 가 멀쩡한 모듈까지 취소시킨다.
       fail-fast: false
       matrix:
-        module: [detector-service, responder-service, archiver-service, api-service, alert-service, collector-service]
+        module: ${{ fromJSON(needs.changes.outputs.modules) }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4
@@ -77,23 +119,26 @@ jobs:
           context: ${{ matrix.module }}
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: |
-            ${{ steps.vars.outputs.image_base }}:${{ github.sha }}
-            ${{ steps.vars.outputs.image_base }}:latest
+          # :latest 는 안 민다. 배포는 :sha 로만 하는데 :latest 가 같이 있으면, 손배포하는 사람이
+          # 그걸 집어 자기도 모르게 다른 버전을 띄운다(Infisical Operator 가 :latest 드리프트로 죽어 있었다).
+          tags: ${{ steps.vars.outputs.image_base }}:${{ github.sha }}
 
-  # EC2(k3s) 에 SSH 로 접속해 모니터링 매니페스트를 apply 하고 서비스는 새 이미지(:SHA)로 롤링.
-  # k3s API 를 외부에 노출하지 않는다.
+  # EC2(k3s) 에 SSH 로 접속해 k8s/ 매니페스트를 통째로 apply 한다. k3s API 를 외부에 노출하지 않는다.
   # 필요한 secret: EC2_HOST(도메인/공인IP), EC2_SSH_KEY(개인키). 선택: EC2_USER(기본 ubuntu).
-  # 서비스 매니페스트는 apply 하지 않는다(레포와 서버 상태가 어긋나 있어 실서비스가 죽는다).
   # 서비스 환경변수(OTEL_EXPORTER_OTLP_ENDPOINT 등)는 Infisical 로 주입한다.
+  #
+  # 바뀐 모듈이 없으면 image 잡이 skip 되는데, needs 만 두면 deploy 까지 딸려 skip 된다.
+  # 매니페스트만 고친 배포도 서버에 가야 하므로 image 가 "실패" 했을 때만 멈춘다.
   deploy:
-    needs: image
+    needs: [changes, build, image]
+    if: ${{ !cancelled() && needs.build.result == 'success' && needs.image.result != 'failure' }}
     runs-on: ubuntu-latest
     steps:
       - name: Deploy over SSH
         env:
           REPO: ${{ github.repository }}
           SHA: ${{ github.sha }}
+          BUILT_JSON: ${{ needs.changes.outputs.modules }}
           SSH_HOST: ${{ secrets.EC2_HOST }}
           SSH_USER: ${{ secrets.EC2_USER || 'ubuntu' }}
           SSH_KEY: ${{ secrets.EC2_SSH_KEY }}
@@ -103,17 +148,18 @@ jobs:
           chmod 600 ~/.ssh/deploy_key
           # GHCR 는 소문자 경로만 받으므로 repo 이름을 소문자로 바꿔 원격에 넘긴다.
           REPO_LC="${REPO,,}"
+          # 이번에 실제로 구운 모듈. 나머지는 지금 떠 있는 태그를 그대로 유지한다.
+          BUILT=$(jq -r 'join(" ")' <<<"$BUILT_JSON")
           # ServerAliveInterval 이 없으면 rollout status 로 몇 분 조용히 기다리는 동안 세션이 Broken pipe 로 끊긴다(실제로 배포가 서비스 롤링 직전에 죽었다).
           ssh -o StrictHostKeyChecking=no -o ConnectTimeout=20 \
             -o ServerAliveInterval=30 -o ServerAliveCountMax=10 \
             -i ~/.ssh/deploy_key "$SSH_USER@$SSH_HOST" \
-            "REPO='$REPO_LC' SHA='$SHA' NS=edrdog bash -s" <<'REMOTE'
+            "REPO='$REPO_LC' SHA='$SHA' BUILT='$BUILT' NS=edrdog bash -s" <<'REMOTE'
           set -euo pipefail
           MODULES="detector-service responder-service archiver-service api-service alert-service collector-service"
 
           # 인프라 매니페스트는 목록을 적지 않고 k8s/ 를 훑어서 전부 적용한다. 파일을 추가할 때마다 여기도 같이 고쳐야 하면 잊게 되고, 그러면 서버에만 빠진 채로 조용히 지나간다(실제로 portainer.yaml 이 그랬다).
-          #   빼는 것: *-service.yaml 은 아래에서 이미지 태그까지 맞춰 따로 다룬다. 여기서 apply 하면
-          #            image 가 :latest 로 되돌아갔다가 set image 로 다시 :sha 가 되어 롤아웃이 두 번 돈다.
+          #   빼는 것: *-service.yaml 은 아래에서 이미지 태그를 끼워 넣어 따로 apply 한다.
           #            kind-cluster.yaml 은 로컬 kind 설정이라 apply 대상이 아니고,
           #            infisical.yaml 은 CRD 가 있을 때만 적용한다(바로 아래).
           # 서버 브랜치를 건드리지 않으려고 FETCH_HEAD 에서 파일만 꺼내 적용한다.
@@ -148,24 +194,31 @@ jobs:
           echo "~/Backend 클론이 없어 인프라 매니페스트 apply 를 건너뛴다" >&2
           fi
 
-          # Deployment 가 없으면(빈 클러스터, 새로 추가된 서비스) 매니페스트를 먼저 apply 한다. 있으면 apply 하지 않는다: image 가 :latest 로 되돌아갔다가 아래 set image 로 다시 :sha 가 되면서 롤아웃이 두 번 돌기 때문이다.
+          # 서비스도 매니페스트를 apply 한다. set image 만 하면 env·envFrom·probe·리소스 변경이 서버에
+          # 영영 안 간다. 머지도 CD 도 초록불인데 서버만 옛 설정으로 남고, 짝이 되는 다른 변경이 반영될 때
+          # 터진다(archiver-service 의 envFrom 이 이렇게 누락돼 CrashLoopBackOff 가 났다).
+          #
+          # 이미지 태그는 매니페스트의 placeholder 를 쓰지 않고 여기서 끼워 넣는다.
+          #   이번에 구운 모듈  -> :$SHA
+          #   안 구운 모듈      -> 지금 떠 있는 태그 그대로 (그 :$SHA 이미지는 아예 없다)
           DEPLOYED=""
-          for m in $MODULES; do
-          if ! sudo kubectl -n "$NS" get deploy "$m" >/dev/null 2>&1; then
           if [ -d ~/Backend/.git ]; then
-          echo "deployment/$m 없음 → k8s/$m.yaml 을 apply 한다" >&2
-          git -C ~/Backend show "FETCH_HEAD:k8s/$m.yaml" | sudo kubectl apply -f -
-          else
-          echo "deployment/$m 없음. ~/Backend 클론이 없어 apply 도 못 한다" >&2
-          continue
-          fi
-          fi
+          for m in $MODULES; do
+          CUR=$(sudo kubectl -n "$NS" get deploy "$m" -o jsonpath='{.spec.template.spec.containers[0].image}' 2>/dev/null || true)
+          case " $BUILT " in
+          *" $m "*) TAG="$SHA" ;;
+          *) TAG="${CUR##*:}"; [ -n "$CUR" ] || TAG="$SHA" ;;
+          esac
+          echo "apply k8s/$m.yaml (:${TAG})" >&2
+          git -C ~/Backend show "FETCH_HEAD:k8s/$m.yaml" \
+          | sed "s#^\( *\)image: ghcr.io/.*#\1image: ghcr.io/$REPO/$m:$TAG#" \
+          | sudo kubectl apply -f -
           DEPLOYED="$DEPLOYED $m"
           done
+          else
+          echo "~/Backend 클론이 없어 서비스 매니페스트 apply 를 건너뛴다" >&2
+          fi
 
-          for m in $DEPLOYED; do
-          sudo kubectl -n "$NS" set image "deployment/$m" "$m=ghcr.io/$REPO/$m:$SHA"
-          done
           for m in $DEPLOYED; do
           sudo kubectl -n "$NS" rollout status "deployment/$m" --timeout=120s
           done

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -45,9 +45,12 @@ jobs:
       - id: list
         run: echo "modules=$(jq -cn --argjson c '${{ steps.filter.outputs.changes }}' '$c - ["shared"]')" >> "$GITHUB_OUTPUT"
 
-  # 빌드 + 최소 테스트 후 boot jar 를 다음 잡으로 넘긴다 (전 모듈)
-  # 굽는 건 바뀐 모듈만이어도, 테스트는 전 모듈을 돌린다. 모듈 간 깨짐을 잡을 그물이 여기뿐이다.
+  # 빌드 + 테스트 후 boot jar 를 다음 잡으로 넘긴다 (바뀐 모듈만)
+  # settings.gradle 의 모듈끼리 의존이 하나도 없어서(project(...) 참조 0건) 모듈별로 잘라 돌려도
+  # 놓치는 깨짐이 없다. 공통 파일(build.gradle, gradle/**)이 바뀌면 shared 필터가 전 모듈을 태운다.
   build:
+    needs: changes
+    if: needs.changes.outputs.modules != '[]'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -67,13 +70,17 @@ jobs:
         # GeoLite2 mmdb 는 빌드 시점에 받아 jar 에 번들된다. 이 키가 없으면 다운로드를 건너뛰고 빌드는 그대로 성공하지만, 런타임에 GET /api/events/geo 가 항상 빈 배열을 준다(위협 지도가 빈다).
         env:
           MAXMIND_LICENSE_KEY: ${{ secrets.MAXMIND_LICENSE_KEY }}
-        run: ./gradlew build
+          MODULES_JSON: ${{ needs.changes.outputs.modules }}
+        # 모듈을 따로 돌리지 않고 태스크만 나열해 한 번에 넘긴다. gradle 기동 비용을 한 번만 낸다.
+        run: ./gradlew $(jq -r 'map(":\(.):build") | join(" ")' <<<"$MODULES_JSON")
       - name: Strip plain jars
         run: find . -name '*-plain.jar' -delete
       - name: Upload boot jars
         uses: actions/upload-artifact@v4
         with:
           name: boot-jars
+          # 안 바꾼 모듈은 굽지도 않으니 jar 가 없다. 없는 경로는 넘어간다.
+          if-no-files-found: ignore
           path: |
             detector-service/build/libs/*.jar
             responder-service/build/libs/*.jar
@@ -127,11 +134,11 @@ jobs:
   # 필요한 secret: EC2_HOST(도메인/공인IP), EC2_SSH_KEY(개인키). 선택: EC2_USER(기본 ubuntu).
   # 서비스 환경변수(OTEL_EXPORTER_OTLP_ENDPOINT 등)는 Infisical 로 주입한다.
   #
-  # 바뀐 모듈이 없으면 image 잡이 skip 되는데, needs 만 두면 deploy 까지 딸려 skip 된다.
-  # 매니페스트만 고친 배포도 서버에 가야 하므로 image 가 "실패" 했을 때만 멈춘다.
+  # 바뀐 모듈이 없으면 build·image 가 둘 다 skip 되는데, needs 만 두면 deploy 까지 딸려 skip 된다.
+  # 매니페스트만 고친 배포도 서버에 가야 하므로 "실패" 했을 때만 멈춘다(skip 은 통과시킨다).
   deploy:
     needs: [changes, build, image]
-    if: ${{ !cancelled() && needs.build.result == 'success' && needs.image.result != 'failure' }}
+    if: ${{ !cancelled() && needs.build.result != 'failure' && needs.image.result != 'failure' }}
     runs-on: ubuntu-latest
     steps:
       - name: Deploy over SSH

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -170,8 +170,15 @@ jobs:
           #            kind-cluster.yaml 은 로컬 kind 설정이라 apply 대상이 아니고,
           #            infisical.yaml 은 CRD 가 있을 때만 적용한다(바로 아래).
           # 서버 브랜치를 건드리지 않으려고 FETCH_HEAD 에서 파일만 꺼내 적용한다.
+          # 매니페스트는 전부 이 클론에서 꺼낸다. 없으면 apply 를 통째로 건너뛰게 되는데, 그걸 경고로만
+          # 넘기면 서버가 옛 설정인 채로 배포가 초록불로 끝난다. 오늘 우리를 세 번 문 유형이라 여기서 죽인다.
+          if [ ! -d ~/Backend/.git ]; then
+          echo "서버에 ~/Backend 클론이 없어 매니페스트를 꺼낼 수 없다. 배포를 중단한다." >&2
+          echo "  git clone https://github.com/EDRdog/Backend.git ~/Backend" >&2
+          exit 1
+          fi
+
           INFRA_FAILED=""
-          if [ -d ~/Backend/.git ]; then
           git -C ~/Backend fetch --quiet origin main
           INFRA_DEPLOYS=""
           for f in $(git -C ~/Backend ls-tree --name-only FETCH_HEAD k8s/ | grep '\.yaml$'); do
@@ -197,9 +204,6 @@ jobs:
           # 60s 인 이유: 못 뜰 인프라를 5분씩 기다려봐야 결론이 같고, 그만큼 서비스 배포만 늦어진다.
           sudo kubectl -n "$NS" rollout status "$d" --timeout=60s || INFRA_FAILED="$INFRA_FAILED $d"
           done
-          else
-          echo "~/Backend 클론이 없어 인프라 매니페스트 apply 를 건너뛴다" >&2
-          fi
 
           # 서비스도 매니페스트를 apply 한다. set image 만 하면 env·envFrom·probe·리소스 변경이 서버에
           # 영영 안 간다. 머지도 CD 도 초록불인데 서버만 옛 설정으로 남고, 짝이 되는 다른 변경이 반영될 때
@@ -209,7 +213,6 @@ jobs:
           #   이번에 구운 모듈  -> :$SHA
           #   안 구운 모듈      -> 지금 떠 있는 태그 그대로 (그 :$SHA 이미지는 아예 없다)
           DEPLOYED=""
-          if [ -d ~/Backend/.git ]; then
           for m in $MODULES; do
           CUR=$(sudo kubectl -n "$NS" get deploy "$m" -o jsonpath='{.spec.template.spec.containers[0].image}' 2>/dev/null || true)
           case " $BUILT " in
@@ -222,9 +225,6 @@ jobs:
           | sudo kubectl apply -f -
           DEPLOYED="$DEPLOYED $m"
           done
-          else
-          echo "~/Backend 클론이 없어 서비스 매니페스트 apply 를 건너뛴다" >&2
-          fi
 
           for m in $DEPLOYED; do
           sudo kubectl -n "$NS" rollout status "deployment/$m" --timeout=120s

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -100,37 +100,60 @@ curl -sk https://localhost:8443/api/agent/enroll -H 'Content-Type: application/j
 
 | 파일 | 왜 빼는가 |
 |---|---|
-| `*-service.yaml` | 아래처럼 이미지 태그까지 맞춰 따로 다룬다 |
+| `*-service.yaml` | 이미지 태그를 끼워 넣어야 해서 바로 다음 단계에서 따로 apply 한다 |
 | `kind-cluster.yaml` | 로컬 kind 설정이라 apply 대상이 아니다 |
 | `infisical.yaml` | CRD 가 있을 때만 적용한다 |
 
 인프라가 안 떠도 앱 배포는 막지 않고, 대신 CD 가 맨 끝에서 실패한다. `kafka-ui`·`portainer` 는
 시크릿이 없으면 일부러 안 뜨는데 그것 때문에 앱 배포가 멈추면 곤란해서다.
 
-서비스 매니페스트만 손으로 적용한다. CD 가 apply 하면 image 가 `:latest` 로 되돌아갔다가
-`set image` 로 다시 `:sha` 가 되면서 롤아웃이 두 번 돈다.
+**서비스 매니페스트도 CD 가 apply 한다.** 그래서 `env`·`envFrom`·probe·리소스를 고치면 머지만으로
+서버에 반영된다. 예전에는 `set image` 만 해서 그런 변경이 영영 안 갔고, 머지도 CD 도 초록불인데
+서버만 옛 설정으로 남았다(`archiver-service` 의 `envFrom` 이 이렇게 누락돼 CrashLoopBackOff 가 났다).
 
-⚠️ **그래서 `k8s/<서비스>.yaml` 의 `env`·`envFrom` 을 고쳐도 배포로는 서버에 안 간다.** CD 는
-Deployment 가 이미 있으면 `set image` 만 하고 매니페스트를 apply 하지 않는다. 머지도 CD 도 초록불인데
-서버만 옛 설정인 채로 남고, 짝이 되는 다른 변경(예: ClickHouse 비번)만 반영되면 그때 터진다.
-실제로 `archiver-service` 의 `envFrom` 이 이렇게 누락돼 CrashLoopBackOff 가 났다.
-아래 절차를 밟거나, env 만 바꾸는 거면 patch 가 더 안전하다:
+이미지 태그는 매니페스트의 `:latest` 를 쓰지 않고 CD 가 apply 직전에 갈아 끼운다.
 
-```bash
-sudo kubectl -n edrdog patch deployment alert-service --type=strategic \
-  -p '{"spec":{"template":{"spec":{"containers":[{"name":"alert-service","envFrom":[{"secretRef":{"name":"edrdog-secrets"}}]}]}}}}'
-```
+| | 태그 |
+|---|---|
+| 이번 커밋에서 코드가 바뀐 모듈 | `:<sha>` (새로 구운 것) |
+| 안 바뀐 모듈 | 지금 떠 있는 태그 그대로 |
 
-`k8s/api-service.yaml` 처럼 매니페스트 전체를 적용해야 하면 지금 떠 있는 이미지 태그를 지키면서 적용한다:
+두 번째가 필요한 이유는, 안 바꾼 모듈은 이미지를 굽지 않아서 그 커밋의 `:<sha>` 이미지가 GHCR 에
+아예 없기 때문이다. 매니페스트만 고친 배포도 이 규칙 덕분에 롤아웃 없이 통과한다.
+
+⚠️ **`:latest` 는 GHCR 에 올리지 않는다.** 매니페스트의 `:latest` 는 자리표시용이라 그대로 apply 하면
+이미지를 못 받는다. 손으로 적용해야 하면 지금 떠 있는 태그를 끼워서 넣는다:
 
 ```bash
 IMG=$(sudo kubectl -n edrdog get deploy/api-service -o jsonpath='{.spec.template.spec.containers[0].image}')
-sudo kubectl -n edrdog apply -f k8s/api-service.yaml
-sudo kubectl -n edrdog set image deployment/api-service api-service="$IMG"
+sed "s#^\( *\)image: ghcr.io/.*#\1image: $IMG#" k8s/api-service.yaml | sudo kubectl -n edrdog apply -f -
 sudo kubectl -n edrdog rollout status deployment/api-service
 ```
 
 Service 는 매니페스트가 서버 실제 상태(NodePort 30084)와 같아 apply 해도 그대로다.
+
+### 롤백
+
+이미지 태그가 커밋 `:<sha>` 라 되돌릴 지점이 명확하다. 직전 버전으로만 돌리면 되면:
+
+```bash
+sudo kubectl -n edrdog rollout undo deployment/api-service
+sudo kubectl -n edrdog rollout status deployment/api-service
+```
+
+특정 커밋으로 찍어서 돌리려면(어느 리비전이 어느 이미지였는지 먼저 본다):
+
+```bash
+sudo kubectl -n edrdog rollout history deployment/api-service
+sudo kubectl -n edrdog set image deployment/api-service api-service=ghcr.io/2026-siheung-bootcamp-team-i/backend/api-service:<되돌릴-sha>
+```
+
+⚠️ `set image` 로 돌린 것은 **다음 배포 때 매니페스트 apply 로 덮인다.** 임시 조치라는 뜻이고,
+문제가 코드에 있으면 `main` 에서 revert 해서 정상 경로로 다시 배포해야 한다.
+
+DB 스키마가 바뀐 릴리스는 이미지만 되돌려도 원상복구가 안 된다. ClickHouse 는 `CREATE TABLE IF NOT
+EXISTS` + `ALTER` 로만 진화시키므로 컬럼이 늘어나는 방향은 안전하지만, 줄이는 변경은 롤백 계획을
+따로 세운다.
 
 - kind 로컬에서는 `kind-cluster.yaml` 의 `30443 -> hostPort 8443` 매핑을 쓴다.
   **`extraPortMappings` 는 클러스터 생성 시에만 반영**되므로 기존 클러스터라면 다시 만들거나
@@ -162,8 +185,7 @@ ls -l /opt/edrdog/geoip/GeoLite2-Country.mmdb
 
 # 3) 매니페스트를 적용한다 (위 "매니페스트 변경을 배포서버에 반영하기" 와 같은 순서)
 IMG=$(sudo kubectl -n edrdog get deploy/api-service -o jsonpath='{.spec.template.spec.containers[0].image}')
-sudo kubectl -n edrdog apply -f k8s/api-service.yaml
-sudo kubectl -n edrdog set image deployment/api-service api-service="$IMG"
+sed "s#^\( *\)image: ghcr.io/.*#\1image: $IMG#" k8s/api-service.yaml | sudo kubectl -n edrdog apply -f -
 sudo kubectl -n edrdog rollout status deployment/api-service
 
 # 4) 파일에서 읽었는지 로그로 확인한다

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -145,7 +145,7 @@ sudo kubectl -n edrdog rollout status deployment/api-service
 
 ```bash
 sudo kubectl -n edrdog rollout history deployment/api-service
-sudo kubectl -n edrdog set image deployment/api-service api-service=ghcr.io/2026-siheung-bootcamp-team-i/backend/api-service:<되돌릴-sha>
+sudo kubectl -n edrdog set image deployment/api-service api-service=ghcr.io/edrdog/backend/api-service:<되돌릴-sha>
 ```
 
 ⚠️ `set image` 로 돌린 것은 **다음 배포 때 매니페스트 apply 로 덮인다.** 임시 조치라는 뜻이고,

--- a/k8s/alert-service.yaml
+++ b/k8s/alert-service.yaml
@@ -18,7 +18,7 @@ spec:
       containers:
         - name: alert-service
           # 태그는 CD 가 apply 직전에 :<sha> 로 갈아 끼운다. :latest 는 GHCR 에 안 올라가므로 이 값 그대로는 못 뜬다.
-          image: ghcr.io/2026-siheung-bootcamp-team-i/backend/alert-service:latest
+          image: ghcr.io/edrdog/backend/alert-service:latest
           ports:
             - containerPort: 8083
           # INTERNAL_API_KEY 를 여기서 안 받으면 코드 기본값(dev-internal-key)으로 붙어, api-service 가 401 을 낸다.

--- a/k8s/alert-service.yaml
+++ b/k8s/alert-service.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
         - name: alert-service
-          # 배포 시 CI 가 kubectl set image 로 실제 태그(:<sha>) 주입
+          # 태그는 CD 가 apply 직전에 :<sha> 로 갈아 끼운다. :latest 는 GHCR 에 안 올라가므로 이 값 그대로는 못 뜬다.
           image: ghcr.io/2026-siheung-bootcamp-team-i/backend/alert-service:latest
           ports:
             - containerPort: 8083

--- a/k8s/api-service.yaml
+++ b/k8s/api-service.yaml
@@ -18,7 +18,7 @@ spec:
       containers:
         - name: api-service
           # 태그는 CD 가 apply 직전에 :<sha> 로 갈아 끼운다. :latest 는 GHCR 에 안 올라가므로 이 값 그대로는 못 뜬다.
-          image: ghcr.io/2026-siheung-bootcamp-team-i/backend/api-service:latest
+          image: ghcr.io/edrdog/backend/api-service:latest
           ports:
             - containerPort: 8084
             - containerPort: 8443   # 에이전트 전용 HTTPS 커넥터 (agent-tls Secret 이 있을 때만 열린다)

--- a/k8s/api-service.yaml
+++ b/k8s/api-service.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
         - name: api-service
-          # 배포 시 CI 가 kubectl set image 로 실제 태그(:<sha>) 주입
+          # 태그는 CD 가 apply 직전에 :<sha> 로 갈아 끼운다. :latest 는 GHCR 에 안 올라가므로 이 값 그대로는 못 뜬다.
           image: ghcr.io/2026-siheung-bootcamp-team-i/backend/api-service:latest
           ports:
             - containerPort: 8084

--- a/k8s/archiver-service.yaml
+++ b/k8s/archiver-service.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
         - name: archiver-service
-          # 배포 시 CI 가 kubectl set image 로 실제 태그(:<sha>) 주입
+          # 태그는 CD 가 apply 직전에 :<sha> 로 갈아 끼운다. :latest 는 GHCR 에 안 올라가므로 이 값 그대로는 못 뜬다.
           image: ghcr.io/2026-siheung-bootcamp-team-i/backend/archiver-service:latest
           ports:
             - containerPort: 8083

--- a/k8s/archiver-service.yaml
+++ b/k8s/archiver-service.yaml
@@ -18,7 +18,7 @@ spec:
       containers:
         - name: archiver-service
           # 태그는 CD 가 apply 직전에 :<sha> 로 갈아 끼운다. :latest 는 GHCR 에 안 올라가므로 이 값 그대로는 못 뜬다.
-          image: ghcr.io/2026-siheung-bootcamp-team-i/backend/archiver-service:latest
+          image: ghcr.io/edrdog/backend/archiver-service:latest
           ports:
             - containerPort: 8083
           # CLICKHOUSE_PASSWORD 를 여기서 안 받으면 코드 기본값으로 붙는다. 지금은 그 값이 우연히 맞아서 돌아갈 뿐이다.

--- a/k8s/collector-service.yaml
+++ b/k8s/collector-service.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
         - name: collector-service
-          # 배포 시 CI 가 kubectl set image 로 실제 태그(:<sha>) 주입
+          # 태그는 CD 가 apply 직전에 :<sha> 로 갈아 끼운다. :latest 는 GHCR 에 안 올라가므로 이 값 그대로는 못 뜬다.
           image: ghcr.io/2026-siheung-bootcamp-team-i/backend/collector-service:latest
           ports:
             - containerPort: 8082

--- a/k8s/collector-service.yaml
+++ b/k8s/collector-service.yaml
@@ -20,7 +20,7 @@ spec:
       containers:
         - name: collector-service
           # 태그는 CD 가 apply 직전에 :<sha> 로 갈아 끼운다. :latest 는 GHCR 에 안 올라가므로 이 값 그대로는 못 뜬다.
-          image: ghcr.io/2026-siheung-bootcamp-team-i/backend/collector-service:latest
+          image: ghcr.io/edrdog/backend/collector-service:latest
           ports:
             - containerPort: 8082
           # 다른 서비스와 같은 패턴 (Infisical 동기화 Secret)

--- a/k8s/detector-service.yaml
+++ b/k8s/detector-service.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
         - name: detector-service
-          # 배포 시 CI 가 kubectl set image 로 실제 태그(:<sha>) 주입
+          # 태그는 CD 가 apply 직전에 :<sha> 로 갈아 끼운다. :latest 는 GHCR 에 안 올라가므로 이 값 그대로는 못 뜬다.
           image: ghcr.io/2026-siheung-bootcamp-team-i/backend/detector-service:latest
           ports:
             - containerPort: 8081

--- a/k8s/detector-service.yaml
+++ b/k8s/detector-service.yaml
@@ -18,7 +18,7 @@ spec:
       containers:
         - name: detector-service
           # 태그는 CD 가 apply 직전에 :<sha> 로 갈아 끼운다. :latest 는 GHCR 에 안 올라가므로 이 값 그대로는 못 뜬다.
-          image: ghcr.io/2026-siheung-bootcamp-team-i/backend/detector-service:latest
+          image: ghcr.io/edrdog/backend/detector-service:latest
           ports:
             - containerPort: 8081
           env:

--- a/k8s/responder-service.yaml
+++ b/k8s/responder-service.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
         - name: responder-service
-          # 배포 시 CI 가 kubectl set image 로 실제 태그(:<sha>) 주입
+          # 태그는 CD 가 apply 직전에 :<sha> 로 갈아 끼운다. :latest 는 GHCR 에 안 올라가므로 이 값 그대로는 못 뜬다.
           image: ghcr.io/2026-siheung-bootcamp-team-i/backend/responder-service:latest
           ports:
             - containerPort: 8082

--- a/k8s/responder-service.yaml
+++ b/k8s/responder-service.yaml
@@ -18,7 +18,7 @@ spec:
       containers:
         - name: responder-service
           # 태그는 CD 가 apply 직전에 :<sha> 로 갈아 끼운다. :latest 는 GHCR 에 안 올라가므로 이 값 그대로는 못 뜬다.
-          image: ghcr.io/2026-siheung-bootcamp-team-i/backend/responder-service:latest
+          image: ghcr.io/edrdog/backend/responder-service:latest
           ports:
             - containerPort: 8082
           # Infisical 이 동기화한 edrdog-secrets. api/alert/detector 등 다른 서비스와 같은 패턴이고, 아래 env 에 같은 이름이 있으면 그쪽이 이긴다.


### PR DESCRIPTION
## 왜

CD 가 서비스 매니페스트를 **apply 하지 않고 `set image` 만** 한다. 그래서 `env`·`envFrom`·probe·리소스 변경은 서버에 영영 가지 않는다.

머지도 CD 도 초록불인데 서버만 옛 설정으로 남는 게 이 구조의 진짜 위험이다. 짝이 되는 다른 변경이 반영되는 순간 터진다. 실제로 `archiver-service` 의 `envFrom` 이 누락된 채 ClickHouse 비번만 바뀌어 CrashLoopBackOff 가 났다.

곁가지로 두 가지가 더 있었다. 6개 모듈을 매번 다 굽고(README 한 줄 고친 배포에도), `:latest` 를 같이 밀어 드리프트 함정을 만들어두고 있었다.

## 고친 것

### 1. 서비스 매니페스트도 apply 한다

`set image` 를 없앴다. 이미지 태그는 매니페스트의 `:latest` 를 쓰지 않고 apply 직전에 끼워 넣는다.

| | 태그 |
|---|---|
| 이번 커밋에서 바뀐 모듈 | `:<sha>` |
| 안 바뀐 모듈 | 지금 떠 있는 태그 그대로 |

두 번째가 필요한 이유는, 안 바꾼 모듈은 굽지 않아서 그 커밋의 `:<sha>` 이미지가 GHCR 에 아예 없기 때문이다. 매니페스트만 고친 배포도 이 규칙으로 롤아웃 없이 통과한다.

기존 주석은 apply 를 안 하는 이유로 "롤아웃이 두 번 돈다"를 들었는데, 태그를 미리 끼워 넣으면 그 문제 자체가 없다.

⚠️ 지금 서버에 `kubectl patch` 로 넣은 설정(`alert-service` 의 `envFrom` 등)은 **apply 로 지워지지 않는다.** client-side 3-way merge 가 `last-applied-configuration` 에 없던 필드는 안 건드리기 때문이다. kind 에서 직접 재현해 확인했고, 배포서버 6개 모듈 `kubectl diff` 도 전부 깨끗하다.

### 2. 바뀐 모듈만 굽는다

`dorny/paths-filter` 로 모듈별 변경을 잡는다. 공통 파일(`build.gradle`, `settings.gradle`, `gradle/**`, `gradlew`, `cd.yml`)은 앵커로 묶어 전 모듈에 걸었다.

**테스트는 전 모듈 그대로 돌린다.** 굽는 것만 줄인다. 모듈 간 깨짐을 잡을 그물이 거기뿐이다.

바뀐 모듈이 없으면 `image` 잡이 skip 되는데, 그러면 `needs` 때문에 `deploy` 도 딸려 skip 된다. 매니페스트만 고친 배포도 반영돼야 하므로 `image` 가 **실패** 했을 때만 멈추도록 `if` 를 바꿨다.

### 3. `:latest` 를 안 민다

배포는 `:sha` 로만 하는데 `:latest` 가 같이 있으면 손배포하는 사람이 그걸 집어 자기도 모르게 다른 버전을 띄운다. 오늘 Infisical Operator 가 정확히 그 드리프트로 9시간 죽어 있었다.

📌 **GHCR 에 이미 올라간 `:latest` 태그는 그대로 남는다.** 앞으로 갱신만 안 될 뿐이라 오히려 낡은 채로 남으니, 함정을 완전히 없애려면 GHCR 패키지에서 손으로 지우는 게 좋다.

### 4. 롤백 절차 (README)

`rollout undo`, 특정 `:<sha>` 로 되돌리기, 그리고 `set image` 로 되돌린 건 다음 배포 때 apply 로 덮인다는 점(임시 조치라는 뜻)을 적었다. DB 스키마가 바뀐 릴리스는 이미지만 되돌려도 복구가 안 된다는 것도 같이.

## 검증

실행해서 확인한 것들이다.

- `cd.yml` YAML 파싱
- `deploy` 잡의 `run` 블록과 그 안의 `REMOTE` heredoc **각각** `bash -n` (heredoc 은 바깥 셸에 문자열이라 따로 떼어 검사해야 잡힌다)
- paths-filter 앵커가 펼쳐진 결과를 눈으로 확인 (모듈 6개 각각에 공통 5개가 들어갔는지)
- `shared` 제거 jq 를 4가지 입력으로 실행 (`["shared"]` -> `[]` 이라 image 잡이 정상 skip)
- 태그 선택 분기 3가지 실행: 구운 모듈 -> `:sha`, 안 구운 기존 모듈 -> 현재 태그 유지, 신규 모듈 -> `:sha`
- 6개 매니페스트를 태그 치환 후 `kubectl apply --dry-run=server` (들여쓰기 보존 포함)

## 실제 확인

이건 머지해서 CD 를 돌려봐야 최종 확인이 된다. 첫 배포는 `cd.yml` 이 공통 파일이라 6개 모듈이 다 구워지고, 그다음 배포부터 변경분만 도는 게 보일 것이다.