### PR TITLE
fix: 변경 감지가 항상 비어 아무것도 안 구워지던 문제

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -12,38 +12,35 @@ jobs:
     outputs:
       modules: ${{ steps.list.outputs.modules }}
     steps:
+      # git diff 로 직접 비교하므로 전체 히스토리가 필요하다.
       - uses: actions/checkout@v4
-      - uses: dorny/paths-filter@v3
-        id: filter
         with:
-          filters: |
-            shared: &shared
-              - 'build.gradle'
-              - 'settings.gradle'
-              - 'gradle/**'
-              - 'gradlew'
-              - '.github/workflows/cd.yml'
-            detector-service:
-              - *shared
-              - 'detector-service/**'
-            responder-service:
-              - *shared
-              - 'responder-service/**'
-            archiver-service:
-              - *shared
-              - 'archiver-service/**'
-            api-service:
-              - *shared
-              - 'api-service/**'
-            alert-service:
-              - *shared
-              - 'alert-service/**'
-            collector-service:
-              - *shared
-              - 'collector-service/**'
-      # shared 는 "전 모듈 공통" 을 앵커로 재사용하려고 만든 항목이라 모듈이 아니다. matrix 에서 뺀다.
+          fetch-depth: 0
+      # dorny/paths-filter 를 썼다가 뺐다. 그 액션의 기본 base 는 레포 기본 브랜치(dev)인데,
+      # main push 는 항상 dev 를 머지해서 생기니 dev...main 차이가 언제나 0 이다. 결과가 늘 비어
+      # 아무것도 안 구워지고 옛 이미지로 배포되는데, CD 는 초록불이라 아무도 모른다.
       - id: list
-        run: echo "modules=$(jq -cn --argjson c '${{ steps.filter.outputs.changes }}' '$c - ["shared"]')" >> "$GITHUB_OUTPUT"
+        env:
+          BEFORE: ${{ github.event.before }}
+        run: |
+          ALL='["detector-service","responder-service","archiver-service","api-service","alert-service","collector-service"]'
+          # 판단이 안 서면 전부 굽는다. 느린 배포가 낡은 이미지 배포보다 낫다.
+          if [ -z "$BEFORE" ] || ! git cat-file -e "$BEFORE^{commit}" 2>/dev/null; then
+            echo "직전 커밋($BEFORE)을 못 찾아 전 모듈을 다시 굽는다" >&2
+            echo "modules=$ALL" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          FILES=$(git diff --name-only "$BEFORE" "$GITHUB_SHA")
+          echo "바뀐 파일:" >&2; echo "$FILES" | sed 's/^/  /' >&2
+          # 공통 파일은 어느 모듈이 영향받을지 알 수 없으므로 전부 굽는다.
+          if echo "$FILES" | grep -qE '^(build\.gradle|settings\.gradle|gradlew|gradle/|\.github/workflows/cd\.yml)'; then
+            echo "공통 파일이 바뀌어 전 모듈을 다시 굽는다" >&2
+            echo "modules=$ALL" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          MODS=$(echo "$FILES" | awk -F/ '{print $1}' | sort -u \
+            | grep -E '^(detector|responder|archiver|api|alert|collector)-service$' || true)
+          MODULES=$(jq -Rc -s 'split("\n") | map(select(length > 0))' <<<"$MODS")
+          echo "다시 구울 모듈: $MODULES" >&2
+          echo "modules=$MODULES" >> "$GITHUB_OUTPUT"
 
   # 빌드 + 테스트 후 boot jar 를 다음 잡으로 넘긴다 (바뀐 모듈만)
   # settings.gradle 의 모듈끼리 의존이 하나도 없어서(project(...) 참조 0건) 모듈별로 잘라 돌려도


### PR DESCRIPTION
## 증상

#162 에서 넣은 변경 감지가 **동작하지 않는다.** 배포 로그를 보고 잡았다.

```
Changes will be detected between dev and main
git diff refs/remotes/origin/dev...refs/remotes/origin/main
Detected 0 changed files
```

`build`·`image` 가 둘 다 skip 되고, 서비스는 이전 `:sha` 태그 그대로 apply 됐다.

## 원인

`dorny/paths-filter` 의 기본 `base` 는 **레포 기본 브랜치(`dev`)** 다. 그런데 `main` push 는 항상 `dev` 를 머지해서 생기므로 `dev...main` 차이가 **언제나 0** 이다.

결과가 늘 비어서 **어떤 코드를 고쳐도 영원히 아무것도 안 구워진다.** 서비스는 옛 이미지로 계속 돌고, CD 는 초록불이라 아무도 모른다. 오늘 계속 잡아온 "조용한 누락" 을 새로 하나 만든 셈이다.

## 고친 것

액션을 빼고 `git diff` 로 직접 비교한다. base 는 `github.event.before`(직전 `main` 커밋)를 명시한다.

**판단이 안 서면 전 모듈을 굽는다.** `before` 가 비었거나 그 커밋을 못 찾으면 6개를 다 굽는다. 느린 배포가 낡은 이미지 배포보다 낫다. 이번 버그가 정확히 반대 방향(판단 실패 -> 아무것도 안 함)으로 조용히 실패했기 때문에 방향을 뒤집었다.

`checkout` 에 `fetch-depth: 0` 을 준다. `git diff` 에 히스토리가 필요하다.

## 검증

레포의 실제 커밋 구간을 그대로 재생했다.

| 구간 | 결과 |
|---|---|
| TTL 커밋 (archiver·api·k8s) | `["api-service","archiver-service"]` |
| 주석 정리 (`cd.yml` 포함) | 전 모듈 6개 |
| `infisical.yaml` 만 | `[]` (굽지 않고 apply 만) |
| `before` 를 못 찾음 | 전 모듈 6개 |

`bash -n`, YAML 파싱도 통과.

## 다음 배포에서 볼 것

이번 머지도 `cd.yml` 을 바꾸므로 **또 6개가 다 구워진다.** 좁혀지는 건 그다음 배포부터 보인다. `changes` 잡 로그에 `바뀐 파일:` 목록과 `다시 구울 모듈:` 이 찍히므로 그걸로 확인한다.