### PR TITLE
fix: 포테이너·그라파나가 안 열리던 문제 (Caddy 설정을 레포가 소유)

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -130,7 +130,7 @@ jobs:
           # 그걸 집어 자기도 모르게 다른 버전을 띄운다(Infisical Operator 가 :latest 드리프트로 죽어 있었다).
           tags: ${{ steps.vars.outputs.image_base }}:${{ github.sha }}
 
-  # EC2(k3s) 에 SSH 로 접속해 k8s/ 매니페스트를 통째로 apply 한다. k3s API 를 외부에 노출하지 않는다.
+  # 배포서버(k3s) 에 SSH 로 접속해 k8s/ 매니페스트와 호스트 Caddy 설정을 통째로 넣는다. k3s API 를 외부에 노출하지 않는다.
   # 필요한 secret: EC2_HOST(도메인/공인IP), EC2_SSH_KEY(개인키). 선택: EC2_USER(기본 ubuntu).
   # 서비스 환경변수(OTEL_EXPORTER_OTLP_ENDPOINT 등)는 Infisical 로 주입한다.
   #
@@ -188,6 +188,28 @@ jobs:
           echo "$APPLIED" >&2
           INFRA_DEPLOYS="$INFRA_DEPLOYS $(echo "$APPLIED" | grep '^deployment' || true)"
           done
+
+          # 호스트의 Caddy 설정. k8s 밖이라 kubectl 로는 안 닿아서, 여기서 안 하면 아무도 조정하지 않는 유일한 조각으로 남는다.
+          # 실제로 레포에 portainer 블록을 넣고도 서버는 계속 모른 채였고, 서브도메인이 인증서가 없어 TLS 핸드셰이크부터 깨졌다.
+          CADDYFILE=$(mktemp)
+          if ! git -C ~/Backend show "FETCH_HEAD:scripts/Caddyfile" > "$CADDYFILE" 2>/dev/null || [ ! -s "$CADDYFILE" ]; then
+          # 빈 파일도 validate 는 통과한다. 그대로 넣고 reload 하면 사이트가 통째로 사라지므로 여기서 막는다.
+          echo "scripts/Caddyfile 을 못 꺼냈다" >&2
+          INFRA_FAILED="$INFRA_FAILED caddy"
+          elif ! caddy validate --config "$CADDYFILE" --adapter caddyfile >/dev/null 2>&1; then
+          # 틀린 설정을 넣고 reload 하면 사이트가 통째로 죽는다. 넣지 않고 옛 설정으로 두는 편이 낫다.
+          echo "Caddyfile 이 잘못돼 적용하지 않는다" >&2
+          INFRA_FAILED="$INFRA_FAILED caddy"
+          elif sudo cmp -s "$CADDYFILE" /etc/caddy/Caddyfile; then
+          echo "Caddyfile 그대로" >&2
+          else
+          sudo install -m 644 "$CADDYFILE" /etc/caddy/Caddyfile
+          # reload 는 설정만 다시 읽어서 연결이 안 끊긴다. 새 도메인이면 여기서 인증서를 받느라 첫 접속이 잠깐 늦다.
+          sudo systemctl reload caddy || INFRA_FAILED="$INFRA_FAILED caddy"
+          echo "Caddyfile 갱신 후 reload" >&2
+          fi
+          rm -f "$CADDYFILE"
+
           # Infisical 연동은 Operator 가 깔려 있을 때만 한다. 없으면 CRD 가 없어 apply 가 실패하고 set -e 때문에 서비스 롤링까지 같이 죽는다.
           # 슬러그가 플레이스홀더면 apply 하지 않는다. 그대로 밀면 서버에 제대로 들어가 있던 설정을 덮어써서
           # Operator 가 인증을 못 하게 되고, 시크릿이 조용히 낡아간다(실제로 하루 동안 그랬다).
@@ -251,7 +273,8 @@ jobs:
           fi
           if [ -n "$INFRA_FAILED" ] || [ -n "$SMOKE_FAILED" ]; then
           [ -z "$INFRA_FAILED" ] || echo "인프라 롤아웃 실패:$INFRA_FAILED" >&2
-          [ -z "$INFRA_FAILED" ] || echo "kafka-ui·portainer 라면 edrdog-secrets 에 계정 키가 없는 것이다(k8s/README.md)." >&2
+          [ -z "$INFRA_FAILED" ] || echo "kafka-ui·portainer·otel-lgtm 이라면 edrdog-secrets 에 계정 키가 없는 것이다(k8s/README.md)." >&2
+          [ -z "$INFRA_FAILED" ] || echo "caddy 라면 scripts/Caddyfile 이 잘못됐거나 reload 가 실패한 것이다. 서버 설정은 옛 상태 그대로다." >&2
           exit 1
           fi
           REMOTE

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -209,6 +209,11 @@ sudo kubectl -n edrdog logs deploy/api-service | grep 'GeoIP DB 로드'
 basic auth 를 걸면 비번이 Infisical 과 호스트 파일 두 군데로 갈라지고, Infisical 에서 바꿔도 호스트의
 Caddyfile 은 그대로라 반영되지 않는다.
 
+**경로를 추가하거나 도메인을 바꿀 때는 `scripts/Caddyfile` 을 고친다.** 이 파일이 원본이고 CD 가
+배포서버의 `/etc/caddy/Caddyfile` 로 넣는다(달라졌을 때만 `install` + `systemctl reload`). 서버에서 직접
+고치면 다음 CD 가 덮어쓴다. 전에는 bootstrap 이 최초 1회 쓰고 아무도 다시 보지 않아서, 레포에 portainer
+블록을 넣고도 서버는 모른 채였고 서브도메인이 인증서가 없어 TLS 핸드셰이크부터 깨졌다.
+
 - **Kafka UI 와 Portainer 는 키가 없으면 파드가 뜨지 않는다** (`optional` 을 안 줬다). 인증이 꺼진 채로
   멀쩡히 떠 있는 것보다 멈추는 편이 낫다. 키를 넣은 뒤
   `kubectl -n edrdog rollout restart deploy/kafka-ui deploy/portainer`.

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -8,7 +8,10 @@
 ```bash
 kind create cluster --config k8s/kind-cluster.yaml   # 클러스터 생성 (name: edrdog)
 # kind-cluster.yaml 은 kind 전용이라 apply 대상에서 제외 (아래는 실제 매니페스트만)
-kubectl apply -f k8s/00-namespace.yaml -f k8s/kafka.yaml -f k8s/clickhouse.yaml \
+kubectl apply -f k8s/00-namespace.yaml
+# Grafana 로그인 비번. 없으면 otel-lgtm 파드가 안 뜬다 (로컬은 아무 값이나)
+kubectl -n edrdog create secret generic edrdog-secrets --from-literal=GRAFANA_ADMIN_PASSWORD=admin
+kubectl apply -f k8s/kafka.yaml -f k8s/clickhouse.yaml \
               -f k8s/otel-lgtm.yaml -f k8s/alloy.yaml
 kubectl -n edrdog get pods                            # Running 확인
 ```
@@ -20,7 +23,7 @@ kubectl -n edrdog get pods                            # Running 확인
 | Kafka | `localhost:9092` | detector 등 (EXTERNAL 리스너) |
 | ClickHouse HTTP | `http://localhost:8123` | user/pw/db = `edrdog` |
 | ClickHouse native | `localhost:9000` | JDBC/드라이버용 |
-| Grafana | `http://localhost:3000` | admin / admin. 첫 화면이 EDRdog Overview |
+| Grafana | `http://localhost:3000` | `admin` / `GRAFANA_ADMIN_PASSWORD`. 첫 화면이 EDRdog Overview |
 | OTLP HTTP | `http://localhost:4318` | 서비스가 메트릭·트레이스를 보내는 곳 |
 | OTLP gRPC | `localhost:4317` | 〃 |
 | 에이전트 수집 HTTPS | `localhost:8443` (NodePort 30443) | 엔드포인트 에이전트가 붙는 곳. 아래 시크릿을 만들어야 열린다 |
@@ -195,17 +198,18 @@ sudo kubectl -n edrdog logs deploy/api-service | grep 'GeoIP DB 로드'
 4번이 `GeoIP DB 로드(파일)` 이면 성공이다. `(클래스패스)` 면 볼륨의 파일을 못 읽어 jar 번들로
 넘어간 것이고, 그 상태로 mmdb 없는 이미지가 배포되면 지도가 빈다.
 
-## 운영 UI (Portainer / Kafka UI / Swagger)
+## 운영 UI (Portainer / Kafka UI / Grafana / Swagger)
 
-배포서버 전용이다. 셋 다 Caddy 뒤에 있고 NodePort 를 방화벽에 열지 않으므로 Caddy 를 통해서만 들어간다.
+배포서버 전용이다. 넷 다 Caddy 뒤에 있고 NodePort 를 방화벽에 열지 않으므로 Caddy 를 통해서만 들어간다.
 
 | 대상 | 주소 | 인증 | Infisical 키 | NodePort |
 |---|---|---|---|---|
 | Portainer | `https://portainer.<도메인>` | 자체 로그인 (`admin`) | `PORTAINER_ADMIN_PASSWORD` | 30777 |
 | Kafka UI | `https://<도메인>/kafka-ui` | 자체 로그인 폼 | `KAFKA_UI_USER` / `KAFKA_UI_PASSWORD` | 30901 |
+| Grafana | `https://grafana.<도메인>` | 자체 로그인 (`admin`) | `GRAFANA_ADMIN_PASSWORD` | 30300 |
 | Swagger | `https://<도메인>/swagger-ui.html` | Basic (`SwaggerAuthFilter`) | `EDRDOG_SWAGGER_USER` / `EDRDOG_SWAGGER_PASSWORD` | (api 30084) |
 
-**Caddy 는 인증을 하지 않는다.** 셋 다 자기 안에서 막고 계정은 `edrdog-secrets` 에서 받는다. Caddy 에
+**Caddy 는 인증을 하지 않는다.** 넷 다 자기 안에서 막고 계정은 `edrdog-secrets` 에서 받는다. Caddy 에
 basic auth 를 걸면 비번이 Infisical 과 호스트 파일 두 군데로 갈라지고, Infisical 에서 바꿔도 호스트의
 Caddyfile 은 그대로라 반영되지 않는다.
 
@@ -214,10 +218,10 @@ Caddyfile 은 그대로라 반영되지 않는다.
 고치면 다음 CD 가 덮어쓴다. 전에는 bootstrap 이 최초 1회 쓰고 아무도 다시 보지 않아서, 레포에 portainer
 블록을 넣고도 서버는 모른 채였고 서브도메인이 인증서가 없어 TLS 핸드셰이크부터 깨졌다.
 
-- **Kafka UI 와 Portainer 는 키가 없으면 파드가 뜨지 않는다** (`optional` 을 안 줬다). 인증이 꺼진 채로
+- **Kafka UI·Portainer·Grafana 는 키가 없으면 파드가 뜨지 않는다** (`optional` 을 안 줬다). 인증이 꺼진 채로
   멀쩡히 떠 있는 것보다 멈추는 편이 낫다. 키를 넣은 뒤
-  `kubectl -n edrdog rollout restart deploy/kafka-ui deploy/portainer`.
-  `/kafka-ui/actuator/health` 는 로그인 없이 200 이라 readinessProbe 는 그대로 통과한다.
+  `kubectl -n edrdog rollout restart deploy/kafka-ui deploy/portainer deploy/otel-lgtm`.
+  `/kafka-ui/actuator/health` 와 Grafana `/api/health` 는 로그인 없이 200 이라 readinessProbe 는 그대로 통과한다.
 - **Swagger 는 비번이 없으면 열리는 게 아니라 닫힌다.** `application.yml` 에 기본값을 두지 않았다.
   레포에 박아 두면 그게 곧 공개 비번이라서다. 로컬에서 보려면 `EDRDOG_SWAGGER_PASSWORD` 를 넣고 띄운다.
 - Swagger 가 `ApiKeyPolicy` 의 인증 예외로 남아 있는 건 그대로다. 브라우저로 여는 화면이라 `X-API-Key`
@@ -239,6 +243,39 @@ Caddyfile 은 그대로라 반영되지 않는다.
 - `--trusted-origins` 가 없으면 Caddy 뒤에서 로그인할 때 `Origin invalid` 로 막힌다. 도메인을 바꾸면
   매니페스트의 이 값도 같이 바꿔야 한다.
 - 계정과 설정은 PVC 에 있다(k3s `local-path`). 지우면 다음 기동에서 Infisical 값으로 다시 만들어진다.
+
+### Grafana
+
+`k8s/otel-lgtm.yaml`. `admin` / `GRAFANA_ADMIN_PASSWORD` 로 로그인한다. 이미지 기본값이 **익명 Admin** 이라
+(`run-grafana.sh` 가 `GF_AUTH_ANONYMOUS_ENABLED` 를 `true` 로 둔다) 그대로 밖에 열면 로그인 없이 아무나
+로그·트레이스·메트릭을 다 보고 대시보드도 고친다. 그래서 `GF_AUTH_ANONYMOUS_ENABLED=false` 로 끄고
+비번을 받는다.
+
+- **이미 쓰던 PVC 에서는 `GRAFANA_ADMIN_PASSWORD` 가 안 먹는다.** `grafana.db` 가 `/data`(PVC) 에 있고
+  Grafana 는 이 값을 **DB 가 없을 때만** 쓴다. 지금 서버의 DB 에는 기본 `admin` / `admin` 이 들어 있어서,
+  익명만 끄고 끝내면 비번이 `admin` 인 채로 밖에 열리게 된다. 순서를 지켜야 한다.
+
+  ```bash
+  # 1) Infisical(prod)에 GRAFANA_ADMIN_PASSWORD 를 넣고 edrdog-secrets 를 갱신한다
+  # 2) 지금 도는 파드에서 같은 값으로 비번을 바꾼다 (익명이 아직 켜져 있을 때 해 둔다)
+  #    --homepath 는 conf/defaults.ini 가 있는 곳이고, DB 는 PVC 쪽이라 paths.data 를 따로 얹는다.
+  #    /data/grafana 에는 data/ 만 있고 conf/ 가 없어서, 거기를 homepath 로 주면 기동부터 실패한다.
+  sudo kubectl -n edrdog exec deploy/otel-lgtm -- \
+    /otel-lgtm/grafana/bin/grafana cli \
+      --homepath /otel-lgtm/grafana \
+      --configOverrides cfg:default.paths.data=/data/grafana/data \
+      admin reset-admin-password '<넣은-비번>'
+  # 3) 그 다음 이 매니페스트를 배포한다 (CD 든 손이든)
+  ```
+
+  재시작은 필요 없다. 비번은 DB 에 바로 반영된다.
+
+  순서를 뒤집으면 Grafana 가 뜰 때 자기 API 로 서비스 계정을 만드는 단계에서 비번이 안 맞아 401 이 난다
+  (`run-all.sh` 가 `GF_SECURITY_ADMIN_USER`/`PASSWORD` 로 자기 API 를 호출한다).
+- 대시보드는 ConfigMap 으로 프로비저닝되므로 PVC 를 지워도 다시 생긴다. 대신 지표·로그·트레이스 기록이
+  통째로 날아가니 비번 때문에 PVC 를 지우지는 않는다.
+- `GF_SERVER_ROOT_URL` 이 없으면 Grafana 가 만드는 절대 URL 이 `localhost:3000` 이 된다. 도메인을 바꾸면
+  이 값과 `scripts/Caddyfile` 을 같이 바꾼다.
 
 ## 시크릿 (Infisical)
 
@@ -300,6 +337,12 @@ Machine Identity 자격증명 Secret 생성 1회, `kubectl apply -f k8s/infisica
 - 지표는 **PVC(`otel-lgtm-data`, 5Gi)** 에 남는다. 여기만 emptyDir 이 아니다. 파드가 재시작돼도 그동안의
   지표·로그·트레이스가 살아 있어야 발표 중에 그래프가 비지 않기 때문이다. 기본 StorageClass 를 쓴다.
   RWO 볼륨이라 Deployment 전략은 `Recreate`(롤링이면 새 파드가 볼륨을 못 잡고 서로 기다린다).
-- **Grafana 는 비번 없이 들어가진다.** otel-lgtm 이미지가 익명 접속을 Admin 권한으로 열어두기 때문이다
-  (`GF_AUTH_ANONYMOUS_ENABLED=true`, `GF_AUTH_ANONYMOUS_ORG_ROLE=Admin`). 데모용으로 편한 대신,
-  포트에 닿는 사람은 누구나 설정을 바꿀 수 있다. 오래 띄워둘 거면 이 두 env 를 Deployment 에서 꺼야 한다.
+- **Grafana 는 로그인을 받는다** (`admin` / `GRAFANA_ADMIN_PASSWORD`). 이미지 기본값은 익명 Admin 이라
+  포트에 닿는 사람 누구나 설정을 바꿀 수 있는데, 배포서버는 `https://grafana.<도메인>` 으로 밖에 열려
+  있어서 껐다. 자세한 건 위 "운영 UI" 의 Grafana 절.
+- **kind 로컬에서도 이 키가 필요하다.** 없으면 파드가 `CreateContainerConfigError` 로 멈춘다.
+  로컬은 아무 값이나 넣으면 된다.
+
+  ```bash
+  kubectl -n edrdog create secret generic edrdog-secrets --from-literal=GRAFANA_ADMIN_PASSWORD=admin
+  ```

--- a/k8s/otel-lgtm.yaml
+++ b/k8s/otel-lgtm.yaml
@@ -2,7 +2,7 @@
 # 서비스들이 OTLP 로 메트릭/트레이스를 밀어넣고(로그·인프라 메트릭은 k8s/alloy.yaml 이 수집), Grafana 에서 본다.
 #
 #   기동:  kubectl apply -f k8s/otel-lgtm.yaml -f k8s/alloy.yaml
-#   접속:  http://localhost:3000  (익명 Admin 으로 열려 있음)
+#   접속:  http://localhost:3000  (admin / GRAFANA_ADMIN_PASSWORD, 배포서버는 https://grafana.<도메인>)
 #   OTLP:  호스트 실행 서비스 -> http://localhost:4318, 클러스터 내부 -> http://otel-lgtm:4318
 ---
 # 지표 보관용 볼륨. emptyDir 로 두면 파드 재시작 때 지표·로그·트레이스가 통째로 사라져 발표 중 그래프가 빈다. 기본 StorageClass 를 쓴다(kind: standard, k3s: local-path).
@@ -2007,6 +2007,19 @@ spec:
             # 첫 화면을 EDRdog 대시보드로 (기본 Grafana 홈 대신)
             - name: GF_DASHBOARDS_DEFAULT_HOME_DASHBOARD_PATH
               value: /otel-lgtm/edrdog-dashboards/edrdog-overview.json
+            # 이미지 기본값이 익명 Admin 이다(run-grafana.sh). 배포서버는 Caddy 로 밖에 열려 있어서, 끄지 않으면 로그인 없이 아무나 로그·트레이스를 다 보고 대시보드도 고친다.
+            - name: GF_AUTH_ANONYMOUS_ENABLED
+              value: "false"
+            # optional 을 주지 않는다. 키가 없으면 익명으로 열린 채 뜨는 대신 파드가 멈춘다(kafka-ui·portainer 와 같은 이유).
+            # 아이디는 admin 고정. 이 값은 grafana.db 가 없을 때만 먹으므로, 이미 쓰던 PVC 에서는 한 번 재설정해야 한다(k8s/README.md).
+            - name: GF_SECURITY_ADMIN_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: edrdog-secrets
+                  key: GRAFANA_ADMIN_PASSWORD
+            # 리버스 프록시 뒤라 이게 없으면 Grafana 가 만드는 절대 URL 이 localhost:3000 이 된다.
+            - name: GF_SERVER_ROOT_URL
+              value: https://grafana.edrdog-api.duckdns.org
             # 기본값이 무제한이라 안 자르면 계속 쌓인다. 실측 ~63MiB/일 이라 30일이면 ~1.9GiB, size 는 안전망.
             - name: PROMETHEUS_EXTRA_ARGS
               value: --storage.tsdb.retention.time=30d --storage.tsdb.retention.size=2GB

--- a/scripts/Caddyfile
+++ b/scripts/Caddyfile
@@ -31,3 +31,8 @@ edrdog-api.duckdns.org {
 portainer.edrdog-api.duckdns.org {
 	reverse_proxy localhost:30777
 }
+
+# Grafana(otel-lgtm). 이미지 기본이 익명 Admin 이라 k8s/otel-lgtm.yaml 에서 끄고 로그인을 켠 뒤에 연다.
+grafana.edrdog-api.duckdns.org {
+	reverse_proxy localhost:30300
+}

--- a/scripts/Caddyfile
+++ b/scripts/Caddyfile
@@ -1,0 +1,33 @@
+# 배포서버 호스트의 Caddy 설정. 이 파일이 원본이고, CD 가 배포서버의 /etc/caddy/Caddyfile 로 넣는다
+# (.github/workflows/cd.yml). 서버에서 직접 고치면 다음 CD 에서 덮어쓴다.
+#
+# 레포에 두는 이유: Caddy 는 k8s 밖이라 kubectl 로 닿지 않아, 예전에는 bootstrap 이 최초 1회 쓰고 아무도
+# 다시 보지 않았다. 그래서 레포에 portainer 블록을 넣고도 서버는 계속 모른 채였고, 서브도메인이 인증서가
+# 없어 TLS 핸드셰이크부터 깨졌다.
+#
+# Caddy 는 인증을 하지 않는다. 운영 UI 셋이 각자 로그인을 갖고 그 계정은 Infisical 이 넣는다(Kafka UI 는
+# AUTH_TYPE=LOGIN_FORM, Swagger 는 api-service 의 SwaggerAuthFilter, Portainer 는 자체 로그인). 여기서 또
+# 막으면 비번이 두 군데로 갈라지고, Infisical 에서 바꿔도 이 파일은 그대로라 반영이 안 된다.
+#
+# 에이전트 수집(30443)은 여기 없다. 에이전트가 서버 인증서를 고정해서 붙어, 중간에서 TLS 를 다시 종단하면
+# 등록 단계에서 실패한다.
+#
+# 도메인을 바꾸면 k8s/portainer.yaml 의 --trusted-origins 도 같이 바꿔야 한다. 안 바꾸면 화면은 뜨는데
+# 로그인이 Origin invalid 로 막힌다.
+
+# 도메인 블록 안에서 벗은 reverse_proxy 와 handle 은 섞을 수 없다. 처음부터 전부 감싼다.
+edrdog-api.duckdns.org {
+	handle /kafka-ui* {
+		reverse_proxy localhost:30901
+	}
+	handle {
+		reverse_proxy localhost:30084
+	}
+}
+
+# 서브패스가 아니라 서브도메인인 이유는 k8s/portainer.yaml 에 적어 뒀다.
+# DuckDNS 는 하위 도메인이 전부 같은 IP 로 오므로 레코드를 따로 만들 필요가 없고, Caddy 가 이 이름으로
+# 인증서를 알아서 받는다(80 이 열려 있어야 받는다).
+portainer.edrdog-api.duckdns.org {
+	reverse_proxy localhost:30777
+}

--- a/scripts/bootstrap-oracle.sh
+++ b/scripts/bootstrap-oracle.sh
@@ -33,9 +33,7 @@ GHCR_IMAGE_BASE="${GHCR_IMAGE_BASE:-ghcr.io/edrdog/backend}"
 
 # 에이전트가 붙는 포트. Caddy 를 거치지 않는다: 에이전트가 서버 인증서를 고정해서 붙어 중간에서 TLS 를 다시 종단하면 등록 단계에서 실패한다.
 AGENT_PORT=30443
-API_NODEPORT=30084
-KAFKA_UI_NODEPORT=30901
-PORTAINER_NODEPORT=30777
+# 나머지 NodePort(api·kafka-ui·portainer)는 scripts/Caddyfile 에만 적는다. 여기에도 적으면 두 군데가 어긋난다.
 
 fail() { echo "오류: $*" >&2; exit 1; }
 step() { echo; echo "== $*"; }
@@ -147,32 +145,18 @@ if ! command -v caddy >/dev/null 2>&1; then
   fi
 fi
 
-# 도메인 블록 안에서 벗은 reverse_proxy 와 handle 은 섞을 수 없다. 처음부터 전부 감싼다.
-#
-# Caddy 는 인증을 하지 않는다. 운영 UI 세 개가 각자 로그인을 갖고 그 계정은 Infisical 이 넣는다(Kafka UI 는 AUTH_TYPE=LOGIN_FORM, Swagger 는 api-service 의 SwaggerAuthFilter, Portainer 는 자체 로그인).
-# 여기서 또 막으면 비번이 두 군데로 갈라지고, Infisical 에서 비번을 바꿔도 호스트의 이 파일은 그대로라 반영이 안 된다.
-cat > /etc/caddy/Caddyfile <<EOF
-$DOMAIN {
-	handle /kafka-ui* {
-		reverse_proxy localhost:$KAFKA_UI_NODEPORT
-	}
-	handle {
-		reverse_proxy localhost:$API_NODEPORT
-	}
-}
-
-# Portainer. DuckDNS 는 하위 도메인이 전부 같은 IP 로 오므로 레코드를 따로 만들 필요 없고, Caddy 가 이 이름으로 인증서를 알아서 받는다(80 이 열려 있어야 받는다).
-portainer.$DOMAIN {
-	reverse_proxy localhost:$PORTAINER_NODEPORT
-}
-EOF
-# 설정이 틀리면 reload 가 조용히 실패하고 사이트가 옛 설정으로 남거나 죽는다. 여기서 잡는다.
-caddy validate --config /etc/caddy/Caddyfile --adapter caddyfile >/dev/null 2>&1 \
-  || fail "Caddyfile 이 잘못됐다: caddy validate --config /etc/caddy/Caddyfile --adapter caddyfile"
+# 설정은 scripts/Caddyfile 하나만 본다. 여기서 다시 쓰면 원본이 둘이 되고, 레포만 고쳤을 때 서버가 그걸 모른 채로 남는다(portainer 블록이 실제로 그랬다). CD 도 같은 파일을 넣는다.
+CADDYFILE_SRC="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/Caddyfile"
+[[ -f "$CADDYFILE_SRC" ]] || fail "$CADDYFILE_SRC 가 없다. 레포 클론 안에서 실행해야 한다"
+# 도메인을 바꿔서 돌리는 경우. 여기서 안 짚으면 Caddy 는 옛 도메인으로 멀쩡히 뜨고, 새 도메인만 인증서가 없어 TLS 에러가 난다.
+grep -q "^$DOMAIN {" "$CADDYFILE_SRC" || fail "DOMAIN=$DOMAIN 인데 $CADDYFILE_SRC 는 다른 도메인을 쓴다. 파일을 먼저 고쳐라"
+# 넣기 전에 본다. 넣고 나서 보면 돌던 서버의 설정을 이미 깨뜨린 뒤라 되돌릴 게 없다.
+caddy validate --config "$CADDYFILE_SRC" --adapter caddyfile >/dev/null 2>&1 \
+  || fail "Caddyfile 이 잘못됐다: caddy validate --config $CADDYFILE_SRC --adapter caddyfile"
+install -m 644 "$CADDYFILE_SRC" /etc/caddy/Caddyfile
 systemctl enable --now caddy >/dev/null 2>&1 || true
 systemctl reload caddy 2>/dev/null || systemctl restart caddy
-echo "  $DOMAIN -> localhost:$API_NODEPORT"
-echo "  portainer.$DOMAIN -> localhost:$PORTAINER_NODEPORT"
+echo "  $CADDYFILE_SRC -> /etc/caddy/Caddyfile"
 
 # --- 5. 에이전트 수집 TLS -----------------------------------------------------
 # 에이전트가 호스트명을 SAN 과 대조한다. 도메인을 바꾸면 여기도 다시 만들어야 한다.

--- a/scripts/bootstrap-oracle.sh
+++ b/scripts/bootstrap-oracle.sh
@@ -271,9 +271,10 @@ cat <<EOF
      KAFKA_UI_USER / KAFKA_UI_PASSWORD              <- Kafka UI 로그인
      EDRDOG_SWAGGER_USER / EDRDOG_SWAGGER_PASSWORD  <- Swagger 로그인
      PORTAINER_ADMIN_PASSWORD                       <- Portainer 관리자 (아이디는 admin 고정)
+     GRAFANA_ADMIN_PASSWORD                         <- Grafana 관리자 (아이디는 admin 고정)
    넣은 뒤 edrdog-secrets 를 다시 만든다(위 7단계의 명령). 그리고:
-     kubectl -n $NS rollout restart deploy/kafka-ui deploy/portainer
-   kafka-ui 와 portainer 는 이 키가 없으면 파드가 뜨지 않는다. 인증이 꺼진 채로 떠 있으면
+     kubectl -n $NS rollout restart deploy/kafka-ui deploy/portainer deploy/otel-lgtm
+   kafka-ui·portainer·otel-lgtm 은 이 키가 없으면 파드가 뜨지 않는다. 인증이 꺼진 채로 떠 있으면
    토픽 메시지가 그대로 공개돼서, 멈추는 편이 낫다고 보고 일부러 그렇게 뒀다.
    Swagger 는 비번이 없으면 열리는 게 아니라 닫힌다.
    PORTAINER_ADMIN_PASSWORD 는 첫 기동에만 먹는다. 계정이 생긴 뒤에 바꾸려면 Portainer UI 에서 바꾼다.
@@ -284,6 +285,7 @@ cat <<EOF
    curl -sS -o /dev/null -w '%{http_code}\n' https://$DOMAIN/kafka-ui/          # -> 302 (로그인으로)
    curl -sS -o /dev/null -w '%{http_code}\n' https://$DOMAIN/swagger-ui.html    # -> 401
    curl -sS -o /dev/null -w '%{http_code}\n' https://portainer.$DOMAIN/api/users/admin/check  # -> 204 (계정 생성됨)
+   curl -sS -o /dev/null -w '%{http_code}\n' https://grafana.$DOMAIN/api/dashboards/home      # -> 401 (익명이 꺼졌다)
    openssl s_client -connect $DOMAIN:$AGENT_PORT </dev/null 2>/dev/null | head -3
 
    Portainer 는 admin / PORTAINER_ADMIN_PASSWORD 로 로그인한다.


### PR DESCRIPTION
## 무엇이 문제였나

`https://portainer.edrdog-api.duckdns.org` 가 TLS 핸드셰이크부터 깨졌다. 레포에는 블록이 있는데 서버의 `/etc/caddy/Caddyfile` 에는 없었다.

Caddy 설정은 bootstrap 이 최초 1회 쓰고 나면 **아무도 다시 보지 않는 파일**이다. k8s 매니페스트는 CD 가 `k8s/` 를 훑어서 apply 하는데, 이 파일만 조정하는 주체가 없어서 나중에 추가한 블록이 서버로 갈 길이 없었다.

그라파나는 애초에 Caddy 에 블록이 없어서 노출된 적이 없다.

## 무엇을 바꿨나

**1. Caddy 설정을 레포가 소유한다** (`scripts/Caddyfile`)

- bootstrap 의 heredoc 을 없애고, bootstrap 과 CD 가 같은 파일을 넣는다
- CD 는 내용이 다를 때만 `install` + `systemctl reload`
- 꺼내기 실패나 빈 파일이면 넣지 않는다. 빈 설정도 `caddy validate` 는 통과해서, 그대로 reload 하면 사이트가 통째로 사라진다
- 설정이 틀려도 넣지 않고 옛 설정으로 둔 뒤 CD 를 실패시킨다. 앱 배포는 막지 않는다

**2. 그라파나를 로그인 뒤로 넣고 연다** (`k8s/otel-lgtm.yaml`)

otel-lgtm 이미지는 익명 접속을 Admin 으로 열어둔다. 그대로 노출하면 로그인 없이 아무나 로그·트레이스를 다 보고 대시보드도 고친다. 익명을 끄고 비번을 `edrdog-secrets` 에서 받는다.

## 머지 전에 해야 할 것

- [x] Infisical(prod) 에 `GRAFANA_ADMIN_PASSWORD` 추가
- [x] 서버에서 `reset-admin-password` 로 같은 값 설정

⚠️ `GRAFANA_ADMIN_PASSWORD` 는 `grafana.db` 가 없을 때만 먹는다. 이미 쓰던 PVC 에는 기본 `admin`/`admin` 이 남아 있어서, 이 단계를 건너뛰면 익명만 꺼진 채 비번이 `admin` 인 그라파나가 밖에 열린다. 순서와 명령은 `k8s/README.md` 의 Grafana 절에 있다.

**kind 로컬은 이제 `edrdog-secrets` 가 필요하다.** 없으면 otel-lgtm 파드가 `CreateContainerConfigError` 로 멈춘다. README 기동 절차에 한 줄 넣어 뒀다.

## 확인한 것

- `caddy validate` 통과 (공식 `caddy:2` 이미지)
- `cd.yml` 원격 스크립트와 `bootstrap-oracle.sh` `bash -n` 통과
- kind: 시크릿 없음 → `CreateContainerConfigError`, 넣으면 기동
- kind: 익명 401 / PVC 에 남아 있던 `admin`/`admin` 200(위 함정) → `reset-admin-password` 뒤 새 비번 200, 옛 비번 401

## 머지 뒤 확인

```bash
curl -sS -o /dev/null -w '%{http_code}\n' https://portainer.edrdog-api.duckdns.org/               # -> 200
curl -sS -o /dev/null -w '%{http_code}\n' https://grafana.edrdog-api.duckdns.org/api/dashboards/home  # -> 401
```

인증서는 reload 직후 Let's Encrypt 에서 받으므로 첫 접속이 10초~1분쯤 늦다.