### PR TITLE
fix: 맥 설치가 인증서를 받고도 실패하던 문제

### DIFF
--- a/agent/packaging/install-macos.sh
+++ b/agent/packaging/install-macos.sh
@@ -57,10 +57,12 @@ install -m 755 "$BINARY" "$BIN_PATH"
 echo "[2/4] 서버 인증서 수신 ($SERVER)"
 mkdir -p "$CONF_DIR"
 chmod 755 "$CONF_DIR"
-# 에이전트가 이 인증서로 서버를 고정한다. 여기서 받아 두면 배포 때 파일을 따로 옮기지 않아도 된다.
+# 에이전트가 이 인증서로 서버를 고정한다. 여기서는 받아오기만 한다.
+# 서버 인증서가 self-signed 라 openssl 은 받아 놓고도 검증 실패로 종료코드 1 을 낸다.
+# pipefail 이 켜져 있어 그 코드를 그대로 믿으면 정상 수신도 실패로 끝난다. 파일로 판단한다.
 openssl s_client -connect "$SERVER" -servername "${SERVER%%:*}" </dev/null 2>/dev/null \
-  | sed -n '/BEGIN CERTIFICATE/,/END CERTIFICATE/p' > "$CERT_PATH" || fail "서버 인증서를 받지 못했다"
-[[ -s "$CERT_PATH" ]] || fail "받아온 인증서가 비어 있다. $SERVER 가 열려 있는지 확인해라"
+  | sed -n '/BEGIN CERTIFICATE/,/END CERTIFICATE/p' > "$CERT_PATH" || true
+[[ -s "$CERT_PATH" ]] || fail "서버 인증서를 받지 못했다. $SERVER 가 열려 있는지 확인해라"
 chmod 644 "$CERT_PATH"
 
 echo "[3/4] 설정 파일 작성"

--- a/api-service/src/main/resources/install/macos.sh
+++ b/api-service/src/main/resources/install/macos.sh
@@ -82,10 +82,12 @@ install -m 755 "$TMP/agent" "$BIN_PATH"
 step "2/4 설정을 쓴다 ($SERVER)"
 mkdir -p "$CONF_DIR"
 chmod 755 "$CONF_DIR"
-# 에이전트가 이 인증서로 서버를 고정한다.
+# 에이전트가 이 인증서로 서버를 고정한다. 여기서는 받아오기만 한다.
+# 서버 인증서가 self-signed 라 openssl 은 받아 놓고도 검증 실패로 종료코드 1 을 낸다.
+# pipefail 이 켜져 있어 그 코드를 그대로 믿으면 정상 수신도 실패로 끝난다. 파일로 판단한다.
 openssl s_client -connect "$SERVER" -servername "${SERVER%%:*}" </dev/null 2>/dev/null \
-  | sed -n '/BEGIN CERTIFICATE/,/END CERTIFICATE/p' > "$CERT_PATH" || fail "서버 인증서를 받지 못했다"
-[[ -s "$CERT_PATH" ]] || fail "받아온 인증서가 비어 있다. $SERVER 가 열려 있는지 확인해라"
+  | sed -n '/BEGIN CERTIFICATE/,/END CERTIFICATE/p' > "$CERT_PATH" || true
+[[ -s "$CERT_PATH" ]] || fail "서버 인증서를 받지 못했다. $SERVER 가 열려 있는지 확인해라"
 chmod 644 "$CERT_PATH"
 
 # enroll secret 이 들어가므로 다른 사용자가 읽으면 안 된다.


### PR DESCRIPTION
## 문제

설치 링크로 맥에 에이전트를 깔면 2/4 단계에서 멈춘다.

```
== 2/4 설정을 쓴다 (edrdog-api.duckdns.org:30443)
오류: 서버 인증서를 받지 못했다
```

## 원인

서버 인증서가 self-signed 라 `openssl s_client` 는 인증서를 **정상적으로 내려받고도** 검증 실패(`verify error:num=18`)로 종료코드 1 을 낸다. 스크립트에 `set -o pipefail` 이 켜져 있어 그 코드가 그대로 파이프라인 실패가 되고, 바로 다음 줄의 빈 파일 검사까지 가지도 못한 채 실패로 끝났다.

self-signed 인증서를 고정(pinning)하려고 받아오는 자리인데, self-signed 라서 못 받는다고 판단하던 셈이다.

재현하면 인증서는 멀쩡히 저장돼 있다.

```
PIPELINE FAILED
pipeline ok, size=1123
```

## 고친 방법

`openssl` 의 종료코드를 버리고, 이미 아래 줄에 있던 빈 파일 검사에 판단을 맡긴다. 두 검사가 하던 말이 겹쳐서 실패 메시지도 하나로 합쳤다.

대상은 맥 스크립트 2개 (`agent/packaging/install-macos.sh`, `api-service/src/main/resources/install/macos.sh`).

## 윈도우는 해당 없음

`windows.ps1` 은 `SslStream` 에 검증 통과 콜백을 이미 넣어 두어 이 실패 모드가 구조적으로 없다. 다만 윈도우 설치 전체를 실기로 돌려본 것은 아니다.

## 검증

- `bash -n` 두 파일 통과 (플레이스홀더 치환 후)
- 실제 서버 정상 경로: `OK: edrdog-api.duckdns.org:30443 -> 1123 bytes`
- 닫힌 포트 실패 경로: 기존대로 `오류: ...` exit 1 — 진짜 실패는 여전히 잡힌다

배포돼야 설치 링크가 고쳐진 스크립트를 내려준다.