### PR TITLE
fix: 열린 알림이 쌓인 기기가 "정상" 으로 뜨던 문제

### DIFF
--- a/api-service/src/main/java/com/edrdog/apiservice/host/HostAggregator.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/host/HostAggregator.java
@@ -27,6 +27,8 @@ public final class HostAggregator {
 
     /**
      * events 행(host, last_seen)에 host 별 alert 집계, severity 분포(위험 점수), 등록 노드 정보를 붙여 목록을 만든다.
+     * status 와 riskScore 는 한 값(severity 분포로 낸 점수)에서 같이 나온다. 따로 계산하면 한 행 안에서
+     * "위험도 100 인데 정상" 처럼 서로 반대되는 말을 할 수 있다.
      * events 쿼리가 last_seen DESC 로 정렬돼 오므로 그 순서를 그대로 유지하고,
      * events 는 없고 등록만 된 host 는 agentSeen DESC 로 정렬해 뒤에 붙인다.
      * host 이름은 엔드포인트가 OS 원본 그대로 보내 대소문자가 어긋나는 사례가 있어
@@ -47,24 +49,23 @@ public final class HostAggregator {
             String host = String.valueOf(row.get("host"));
             long lastSeen = Long.parseLong(String.valueOf(row.get("last_seen")));
             HostAlertCount c = byHost.get(host);
-            long critical = c == null ? 0 : c.openCritical();
-            long high = c == null ? 0 : c.openHigh();
             long threats = c == null ? 0 : c.openTotal();
             HostRisk risk = riskByHost.get(host);
+            int score = risk == null ? 0 : risk.score();
 
             EnrolledHost node = enrolledByHost.get(host.toLowerCase());
             boolean isEnrolled = node != null;
             long agentSeen = node == null ? 0 : node.agentSeen();
             matched.add(host.toLowerCase());
 
-            out.add(new HostResponse(host, lastSeen, HostStatus.classify(critical, high), threats,
-                    risk == null ? 0 : risk.score(), isEnrolled, agentSeen, platformOf(node)));
+            out.add(new HostResponse(host, lastSeen, HostStatus.classify(score), threats,
+                    score, isEnrolled, agentSeen, platformOf(node)));
         }
 
         enrolledByHost.values().stream()
                 .filter(node -> !matched.contains(node.host().toLowerCase()))
                 .sorted(Comparator.comparingLong(EnrolledHost::agentSeen).reversed())
-                .forEach(node -> out.add(new HostResponse(node.host(), 0L, HostStatus.HEALTHY, 0L,
+                .forEach(node -> out.add(new HostResponse(node.host(), 0L, HostStatus.classify(0), 0L,
                         0, true, node.agentSeen(), platformOf(node))));
 
         return out;

--- a/api-service/src/main/java/com/edrdog/apiservice/host/HostStatus.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/host/HostStatus.java
@@ -1,8 +1,14 @@
 package com.edrdog.apiservice.host;
 
 /**
- * 호스트 상태 분류(순수). 열린 alert 의 severity 로만 판정한다.
- * 열린 CRITICAL 이 하나라도 있으면 critical(위험), 없고 HIGH 가 있으면 warning(주의), 둘 다 없으면 healthy(정상).
+ * 호스트 상태 분류(순수). 위험 점수(RiskScore)의 함수라 목록에서 두 값이 서로 어긋날 수 없다.
+ * 예전에는 열린 CRITICAL/HIGH 의 유무로만 갈라서, MEDIUM 이 54건 쌓여 점수가 100 인 기기가
+ * "정상"(초록)으로 뜨는 일이 있었다. 같은 데이터로 두 지표가 정반대를 말하면 어느 쪽도 못 믿는다.
+ *
+ * <p>임계값을 RiskScore 의 가중치로 두는 이유:
+ * 열린 CRITICAL 한 건(25)이면 위험, HIGH 한 건(10)이면 주의라는 기존 의미를 그대로 유지하면서,
+ * 가중치가 나중에 바뀌어도 임계값이 같이 따라가 위 모순이 되돌아오지 않게 하려는 것이다.
+ * 25/10 을 여기 리터럴로 적으면 한쪽만 고쳐질 수 있다.
  */
 public final class HostStatus {
 
@@ -10,14 +16,17 @@ public final class HostStatus {
     public static final String WARNING = "warning";
     public static final String CRITICAL = "critical";
 
+    private static final int CRITICAL_AT = RiskScore.W_CRITICAL;
+    private static final int WARNING_AT = RiskScore.W_HIGH;
+
     private HostStatus() {
     }
 
-    public static String classify(long openCritical, long openHigh) {
-        if (openCritical > 0) {
+    public static String classify(int riskScore) {
+        if (riskScore >= CRITICAL_AT) {
             return CRITICAL;
         }
-        if (openHigh > 0) {
+        if (riskScore >= WARNING_AT) {
             return WARNING;
         }
         return HEALTHY;

--- a/api-service/src/main/java/com/edrdog/apiservice/host/RiskScore.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/host/RiskScore.java
@@ -10,13 +10,16 @@ package com.edrdog.apiservice.host;
  * <p>가중치를 25/10/3/1 로 둔 이유:
  * CRITICAL 한 건이면 25점이라 그 호스트 하나만으로 화면 상단에 올라와야 하고, 네 건이면 상한 100 에 닿는다.
  * HIGH 두 건(20)보다 CRITICAL 한 건(25)이 무거워야 HostStatus 의 분류(CRITICAL 하나면 위험,
- * HIGH 하나면 주의)와 순서가 어긋나지 않는다. MEDIUM/LOW 는 쌓였을 때만 의미가 있어 낮게 둔다.
+ * HIGH 하나면 주의)와 순서가 어긋나지 않는다. MEDIUM/LOW 는 쌓였을 때만 의미가 있어 낮게 둔다
+ * (낮게 두는 것과 무시하는 것은 다르다. 쌓여서 임계를 넘으면 HostStatus 도 같이 올라간다).
  * 상한을 두는 이유는 알림이 폭주한 호스트 하나가 점수 축을 독차지하면 나머지가 전부 0 으로 보이기 때문이다.
  */
 public final class RiskScore {
 
-    private static final int W_CRITICAL = 25;
-    private static final int W_HIGH = 10;
+    /** HostStatus 의 위험/주의 임계값이 이 둘을 그대로 쓴다. 임계값이 가중치를 따라가야 상태와 점수가 갈리지 않는다. */
+    public static final int W_CRITICAL = 25;
+    public static final int W_HIGH = 10;
+
     private static final int W_MEDIUM = 3;
     private static final int W_LOW = 1;
     private static final int MAX = 100;

--- a/api-service/src/main/java/com/edrdog/apiservice/host/web/HostResponse.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/host/web/HostResponse.java
@@ -1,7 +1,7 @@
 package com.edrdog.apiservice.host.web;
 
 /**
- * 엔드포인트(호스트) 목록 한 행. status 는 영문 enum(healthy|warning|critical),
+ * 엔드포인트(호스트) 목록 한 행. status 는 영문 enum(healthy|warning|critical)이고 riskScore 에서 유도한다(HostStatus).
  * threats 는 열린 alert 총수, lastSeen 은 events 최신 ts(epoch millis).
  * riskScore 는 열린 alert 를 severity 로 가중합한 0..100 값(RiskScore)으로, 토폴로지 엔드포인트 노드와 같은 값이다.
  * 열린 알림이 없으면 0 이다(이건 관측 결과라서 null 이 아니다). 목록에 위험도를 보이려고

--- a/api-service/src/test/java/com/edrdog/apiservice/host/HostAggregatorTest.java
+++ b/api-service/src/test/java/com/edrdog/apiservice/host/HostAggregatorTest.java
@@ -15,7 +15,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 /**
  * events 행, alert 집계, 등록 노드(agent_nodes)를 host 기준으로 병합하는 순수 로직 검증.
  * 호스트 집합은 events ∪ 등록 노드다(이벤트가 없어도 등록만 됐으면 목록에 나와야 한다).
- * status/위협수는 alert 집계에서 붙는다.
+ * 위협수는 alert 집계에서, status 와 위험 점수는 severity 분포 하나에서 같이 나온다.
  */
 class HostAggregatorTest {
 
@@ -56,7 +56,7 @@ class HostAggregatorTest {
     void 열린_CRITICAL_있는_host_는_위험_위협수는_열린총수() {
         List<HostResponse> hosts = HostAggregator.hosts(
                 List.of(row("h1", "1000")),
-                List.of(count("h1", 3, 1, 2)), List.of(), List.of());
+                List.of(count("h1", 3, 1, 2)), List.of(risk("h1", 1, 2, 0, 0)), List.of());
 
         HostResponse h = hosts.get(0);
         assertEquals(HostStatus.CRITICAL, h.status());
@@ -67,10 +67,22 @@ class HostAggregatorTest {
     void HIGH만_있는_host_는_주의() {
         List<HostResponse> hosts = HostAggregator.hosts(
                 List.of(row("h1", "1000")),
-                List.of(count("h1", 2, 0, 2)), List.of(), List.of());
+                List.of(count("h1", 2, 0, 2)), List.of(risk("h1", 0, 2, 0, 0)), List.of());
 
         assertEquals(HostStatus.WARNING, hosts.get(0).status());
         assertEquals(2L, hosts.get(0).threats());
+    }
+
+    @Test
+    void MEDIUM_만_쌓인_host_는_점수를_따라_위험이다() {
+        // 열린 MEDIUM 54건이면 점수가 상한 100 인데, 예전 분류는 MEDIUM 을 보지 않아 "정상"으로 떴다.
+        List<HostResponse> hosts = HostAggregator.hosts(
+                List.of(row("h1", "1000")),
+                List.of(count("h1", 54, 0, 0)), List.of(risk("h1", 0, 0, 54, 0)), List.of());
+
+        HostResponse h = hosts.get(0);
+        assertEquals(100, h.riskScore());
+        assertEquals(HostStatus.CRITICAL, h.status());
     }
 
     // --- 위험 점수 ---

--- a/api-service/src/test/java/com/edrdog/apiservice/host/HostStatusRiskConsistencyTest.java
+++ b/api-service/src/test/java/com/edrdog/apiservice/host/HostStatusRiskConsistencyTest.java
@@ -1,0 +1,114 @@
+package com.edrdog.apiservice.host;
+
+import com.edrdog.apiservice.host.web.HostResponse;
+import com.edrdog.apiservice.host.web.HostSummary;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * 목록 한 행의 status 와 riskScore 가 어긋날 수 없다는 것을 severity 조합 전수로 고정한다.
+ * 사례 몇 개를 나열하지 않는 이유: 나중에 가중치나 임계값을 한쪽만 고치면 "열린 알림 54건이라 점수가 100 인데 정상"
+ * 같은 모순이 되돌아오는데, 그때 여기서 깨져야 한다.
+ */
+class HostStatusRiskConsistencyTest {
+
+    /** 전수로 훑는 severity 조합. medium 은 그것만으로 상한(100)을 넘길 만큼 넉넉히 본다. */
+    private static final int MAX_CRITICAL = 3;
+    private static final int MAX_HIGH = 4;
+    private static final int MAX_MEDIUM = 40;
+    private static final int MAX_LOW = 12;
+
+    private static final List<HostResponse> ALL = allCombinations();
+
+    /** 위험한 순서. 점수가 오를 때 이 값이 내려가면 안 된다. */
+    private static int rank(String status) {
+        return switch (status) {
+            case HostStatus.CRITICAL -> 2;
+            case HostStatus.WARNING -> 1;
+            default -> 0;
+        };
+    }
+
+    /** 모든 severity 조합을 각각 한 호스트로 만들어 실제 목록 조립 경로(HostAggregator)를 통과시킨다. */
+    private static List<HostResponse> allCombinations() {
+        List<Map<String, Object>> rows = new ArrayList<>();
+        List<HostRisk> risks = new ArrayList<>();
+        int i = 0;
+        for (int c = 0; c <= MAX_CRITICAL; c++) {
+            for (int h = 0; h <= MAX_HIGH; h++) {
+                for (int m = 0; m <= MAX_MEDIUM; m++) {
+                    for (int l = 0; l <= MAX_LOW; l++) {
+                        String host = "h" + i++;
+                        rows.add(Map.of("host", host, "last_seen", "1000"));
+                        risks.add(new HostRisk(host, c, h, m, l));
+                    }
+                }
+            }
+        }
+        return HostAggregator.hosts(rows, List.of(), risks, List.of());
+    }
+
+    @Test
+    void 어떤_severity_조합에서도_status_는_riskScore_가_정하는_값과_같다() {
+        for (HostResponse h : ALL) {
+            assertEquals(HostStatus.classify(h.riskScore()), h.status(),
+                    "riskScore=" + h.riskScore() + " 인데 status=" + h.status());
+        }
+    }
+
+    @Test
+    void 정상으로_보이는_호스트는_점수가_주의_임계_미만일_때뿐이다() {
+        for (HostResponse h : ALL) {
+            if (HostStatus.HEALTHY.equals(h.status())) {
+                assertTrue(h.riskScore() < RiskScore.W_HIGH,
+                        "점수 " + h.riskScore() + " 인데 정상으로 보인다");
+            }
+        }
+    }
+
+    @Test
+    void 위험과_주의는_각_임계_구간에서만_나온다() {
+        for (HostResponse h : ALL) {
+            int score = h.riskScore();
+            String expected = score >= RiskScore.W_CRITICAL ? HostStatus.CRITICAL
+                    : score >= RiskScore.W_HIGH ? HostStatus.WARNING
+                    : HostStatus.HEALTHY;
+            assertEquals(expected, h.status(), "riskScore=" + score);
+        }
+    }
+
+    @Test
+    void 점수가_더_높은_호스트가_더_가벼운_status_로_나오지_않는다() {
+        List<HostResponse> byScore = new ArrayList<>(ALL);
+        byScore.sort(Comparator.comparingInt(HostResponse::riskScore));
+        for (int i = 1; i < byScore.size(); i++) {
+            HostResponse lower = byScore.get(i - 1);
+            HostResponse higher = byScore.get(i);
+            assertTrue(rank(higher.status()) >= rank(lower.status()),
+                    "점수 " + higher.riskScore() + " 가 " + lower.riskScore() + " 보다 가볍게 분류됐다");
+        }
+    }
+
+    @Test
+    void 요약의_정상_주의_위험_수는_점수가_정한_분류를_그대로_따른다() {
+        Map<String, Long> expected = new HashMap<>();
+        for (HostResponse h : ALL) {
+            expected.merge(HostStatus.classify(h.riskScore()), 1L, Long::sum);
+        }
+
+        HostSummary s = HostAggregator.summary(ALL);
+        assertEquals(expected.getOrDefault(HostStatus.HEALTHY, 0L), s.healthy());
+        assertEquals(expected.getOrDefault(HostStatus.WARNING, 0L), s.warning());
+        assertEquals(expected.getOrDefault(HostStatus.CRITICAL, 0L), s.critical());
+        assertEquals(ALL.size(), s.total());
+        assertEquals(0L, s.noEvents());
+    }
+}

--- a/api-service/src/test/java/com/edrdog/apiservice/host/HostStatusTest.java
+++ b/api-service/src/test/java/com/edrdog/apiservice/host/HostStatusTest.java
@@ -5,29 +5,37 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
- * 호스트 상태 분류 순수 로직. 열린 CRITICAL 우선, 없으면 HIGH, 둘 다 없으면 정상.
+ * 호스트 상태 분류 순수 로직. status 는 위험 점수의 함수다.
  */
 class HostStatusTest {
 
     @Test
-    void 열린_CRITICAL_이_있으면_위험() {
-        assertEquals(HostStatus.CRITICAL, HostStatus.classify(1, 0));
-        assertEquals(HostStatus.CRITICAL, HostStatus.classify(2, 3));
+    void 열린_CRITICAL_한_건이면_위험() {
+        assertEquals(HostStatus.CRITICAL, HostStatus.classify(RiskScore.of(1, 0, 0, 0)));
     }
 
     @Test
-    void CRITICAL_없고_HIGH_있으면_주의() {
-        assertEquals(HostStatus.WARNING, HostStatus.classify(0, 1));
-        assertEquals(HostStatus.WARNING, HostStatus.classify(0, 5));
+    void CRITICAL_없고_HIGH_한_건이면_주의() {
+        assertEquals(HostStatus.WARNING, HostStatus.classify(RiskScore.of(0, 1, 0, 0)));
     }
 
     @Test
     void 열린것이_없으면_정상() {
-        assertEquals(HostStatus.HEALTHY, HostStatus.classify(0, 0));
+        assertEquals(HostStatus.HEALTHY, HostStatus.classify(RiskScore.of(0, 0, 0, 0)));
     }
 
     @Test
-    void CRITICAL_이_HIGH_보다_우선() {
-        assertEquals(HostStatus.CRITICAL, HostStatus.classify(1, 10));
+    void MEDIUM_만_쌓여도_점수를_따라_주의와_위험으로_올라간다() {
+        assertEquals(HostStatus.HEALTHY, HostStatus.classify(RiskScore.of(0, 0, 3, 0)));
+        assertEquals(HostStatus.WARNING, HostStatus.classify(RiskScore.of(0, 0, 4, 0)));
+        assertEquals(HostStatus.CRITICAL, HostStatus.classify(RiskScore.of(0, 0, 54, 0)));
+    }
+
+    @Test
+    void 임계값은_RiskScore_의_가중치에_묶여있다() {
+        assertEquals(HostStatus.CRITICAL, HostStatus.classify(RiskScore.W_CRITICAL));
+        assertEquals(HostStatus.WARNING, HostStatus.classify(RiskScore.W_CRITICAL - 1));
+        assertEquals(HostStatus.WARNING, HostStatus.classify(RiskScore.W_HIGH));
+        assertEquals(HostStatus.HEALTHY, HostStatus.classify(RiskScore.W_HIGH - 1));
     }
 }

--- a/api-service/src/test/java/com/edrdog/apiservice/host/web/HostApiIntegrationTest.java
+++ b/api-service/src/test/java/com/edrdog/apiservice/host/web/HostApiIntegrationTest.java
@@ -131,9 +131,25 @@ class HostApiIntegrationTest {
     }
 
     @Test
+    void 열린_MEDIUM_만_많은_기기는_정상이_아니라_위험으로_나온다() throws Exception {
+        // 배포 서버에서 열린 MEDIUM 54건짜리 기기가 riskScore 100 인 채로 "정상"으로 떴던 사례다.
+        String[] a = signup("a-medium@edrdog.com");
+        countRows = List.of(count("h1", 54, 0, 0));
+        severityRows = List.of(severity("h1", 0, 0, 54, 0));
+
+        mvc.perform(get("/api/hosts").header("Authorization", "Bearer " + a[0]))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].host").value("h1"))
+                .andExpect(jsonPath("$[0].riskScore").value(100))
+                .andExpect(jsonPath("$[0].status").value("critical"))
+                .andExpect(jsonPath("$[0].threats").value(54));
+    }
+
+    @Test
     void 요약은_status별_수와_총수를_준다() throws Exception {
         String[] a = signup("a-summary@edrdog.com");
         countRows = List.of(count("h1", 1, 0, 1));   // h1 주의(HIGH), h2 정상
+        severityRows = List.of(severity("h1", 0, 1, 0, 0));
 
         mvc.perform(get("/api/hosts/summary").header("Authorization", "Bearer " + a[0]))
                 .andExpect(status().isOk())


### PR DESCRIPTION
배포 서버에서 발견됐다. 프론트가 보고했다.

```
host: gimdonghyeon-ui-MacBookPro.local
status: "healthy"    화면에 "정상"(초록)
riskScore: 100       최대치
threats: 54          전부 MEDIUM, 전부 open
```

열린 알림 54건짜리 기기가 초록색으로 뜨는데 옆 칸 위험도는 100 이다. 같은 데이터로 두 서버 값이 정반대를 말하면 어느 쪽도 믿을 수 없다.

## 원인

- `HostStatus.classify(openCritical, openHigh)` — MEDIUM 을 인자로 받지도 않았다
- `RiskScore.of(critical, high, medium, low)` — MEDIUM 가중치 3, 54건이면 162 → 상한 100

각자는 규칙대로 동작했다. 나란히 놓였을 때만 어긋난다.

## 고친 방향

상태를 점수의 함수로 만든다. 임계값을 하나 더 얹는 방식은 지금 어긋난 자리만 덮고, 다음에 가중치나 분류가 바뀔 때 같은 모순이 되돌아온다.

임계값은 점수 가중치 상수를 그대로 참조한다(`RiskScore.W_CRITICAL`, `W_HIGH`).

| 상황 | 기존 | 변경 후 |
| --- | --- | --- |
| 열린 CRITICAL 1건 | critical | critical (동일) |
| 열린 HIGH 1건 | warning | warning (동일) |
| 열린 MEDIUM 54건 | **healthy** | **critical** |
| 열린 MEDIUM 4건 | healthy | warning |
| 열린 MEDIUM 3건 | healthy | healthy |

기존 의미는 그대로고 누적된 경우만 달라진다.

## 검증

`HostStatusRiskConsistencyTest` 가 severity 조합을 전수로 훑어 두 값이 어긋날 수 없음을 고정한다. 분류를 따로 부르지 않고 목록 조립 경로(`HostAggregator.hosts`) 전체를 통과시켜, 조립 중에 값이 갈리는 경우도 잡는다. 점수가 오를 때 상태가 내려가지 않는 단조성도 함께 본다.

`./gradlew :api-service:build --rerun-tasks` 통과.

## 프론트 영향

`/api/hosts` 의 `status` 와 `/api/hosts/summary` 의 healthy/warning/critical 건수가 바뀐다. 응답 형태는 그대로고 값만 달라진다. MEDIUM 이 쌓인 기기가 초록에서 노랑·빨강으로 옮겨간다.

## 함께 보면 좋을 것 (이 PR 범위 밖)

배포 서버 집계에서 `SCRIPT_FROM_TEMP_PATH` 가 48건으로 압도적이다. 그 룰은 임시·다운로드 경로를 인자로 받은 스크립트 실행에 발화하는데, 개발용 맥에서는 일상적인 동작이라 오탐일 공산이 크다. 이 변경으로 그 기기가 빨간색이 되면 오탐이 더 눈에 띈다. 룰 제외 경로 조정은 별건이다.