### PR TITLE
fix: 앱 내부 tmp 폴더를 시스템 임시 경로로 오인해 오탐이 나던 문제

### DIFF
--- a/detector-service/src/main/java/com/edrdog/detectorservice/rule/Rules.java
+++ b/detector-service/src/main/java/com/edrdog/detectorservice/rule/Rules.java
@@ -32,13 +32,9 @@ public final class Rules {
     private static final Set<String> BASELINE_SAFE = Set.of(
             "onedrive.exe", "teams.exe", "gupdate.exe", "msedgeupdate.exe", "update.exe");
 
-    /** 임시/다운로드 경로 표식 — 여기서 스크립트가 실행되면 저심각 의심(R3). 소문자 기준. */
-    private static final Set<String> SCRIPT_TEMP_MARKERS = Set.of(
-            "\\temp\\", "/tmp/", "\\downloads\\", "/downloads/", "appdata\\local\\temp");
-
-    /** 자동실행/시작 경로 표식 — 여기에 파일이 생기면 지속성 확보 의심(R4). 소문자 기준. */
+    /** 자동실행/시작 경로 표식 (Windows) — 여기에 파일이 생기면 지속성 확보 의심(R4). 소문자 기준. */
     private static final Set<String> FILE_AUTORUN_MARKERS = Set.of(
-            "\\startup\\", "/launchagents/", "\\currentversion\\run");
+            "\\startup\\", "\\currentversion\\run");
 
     /**
      * 현재 이벤트가 선행 버퍼와 상관되어 룰을 완성하면 Alert 반환. 여러 룰 매칭 시 가장 심각한 것 채택.
@@ -85,7 +81,7 @@ public final class Rules {
         }
         if (isProcess(e)) {
             return in(OFFICE_APPS, lower(e.process()))
-                    || executableHasMarker(e.cmdline(), SCRIPT_TEMP_MARKERS);
+                    || executableFromTempPath(e.cmdline());
         }
         return false;
     }
@@ -127,7 +123,7 @@ public final class Rules {
             return prior.stream()
                     .filter(Rules::isProcess)
                     .filter(e -> !isBaseline(lower(e.process())))
-                    .filter(e -> executableHasMarker(e.cmdline(), SCRIPT_TEMP_MARKERS))
+                    .filter(e -> executableFromTempPath(e.cmdline()))
                     .filter(e -> e.ts() >= current.ts())   // 시각상 다운로드가 먼저여야 한다
                     .findFirst()
                     .map(exec -> alertOf("DOWNLOAD_AND_EXECUTE", "T1105+T1204", Alert.SEV_CRITICAL,
@@ -140,7 +136,7 @@ public final class Rules {
         // 모든 프로세스 실행이 CRITICAL 이 된다. 인자까지 보면 정상 프로세스가 임시 경로를
         // 인자로 받는 경우(find /private/tmp/..., mount_apfs ... /private/tmp/PKInstallSandbox/...)
         // 까지 걸리므로, 실행된 파일 자체(argv[0])만 본다.
-        if (!executableHasMarker(current.cmdline(), SCRIPT_TEMP_MARKERS)) {
+        if (!executableFromTempPath(current.cmdline())) {
             return Optional.empty();
         }
         Optional<Event> download = prior.stream()
@@ -157,7 +153,7 @@ public final class Rules {
 
     /** R3 T1059: 임시/다운로드 경로에서 실행된 스크립트 (저심각 point 룰). */
     private static Optional<Alert> scriptFromTempPath(Event current) {
-        if (!isScript(current) || !pathArgumentHasMarker(current.cmdline(), SCRIPT_TEMP_MARKERS)) {
+        if (!isScript(current) || !pathArgumentFromTempPath(current.cmdline())) {
             return Optional.empty();
         }
         return Optional.of(alertOf("SCRIPT_FROM_TEMP_PATH", "T1059", Alert.SEV_MEDIUM,
@@ -166,7 +162,7 @@ public final class Rules {
 
     /** R4 T1547: 자동실행/시작 경로에 생성된 파일 (지속성 확보, 저심각 point 룰). */
     private static Optional<Alert> fileInAutorunPath(Event current) {
-        if (!isFile(current) || !pathHasMarker(current.cmdline(), FILE_AUTORUN_MARKERS)) {
+        if (!isFile(current) || !isAutorunPath(current.cmdline())) {
             return Optional.empty();
         }
         return Optional.of(alertOf("FILE_IN_AUTORUN_PATH", "T1547", Alert.SEV_MEDIUM,
@@ -232,46 +228,132 @@ public final class Rules {
         return Event.TYPE_FILE.equals(e.type());
     }
 
-    private static boolean pathHasMarker(String path, Set<String> markers) {
-        String p = lower(path);
-        return p != null && markers.stream().anyMatch(p::contains);
-    }
-
     /** 셸 연산자 — 여기부터는 실행 대상이 아니라 출력/후속 명령이라 판정에서 제외한다. */
     private static final Set<String> SHELL_OPERATORS = Set.of(">", ">>", ">|", "<", "|", "||", "&&", ";", "&");
 
     /** 실행된 파일 자체(argv[0])만 본다. 인자까지 보면 정상 프로세스의 오탐이 난다(find/mount_apfs 사례, downloadAndExecute 참고). */
-    private static boolean executableHasMarker(String cmdline, Set<String> markers) {
-        String c = lower(cmdline);
-        if (c == null || c.isBlank()) {
-            return false;
-        }
-        String argv0 = c.trim().split("\\s+")[0];
-        return markers.stream().anyMatch(argv0::contains);
-    }
-
-    /**
-     * cmdline 에서 "실행 대상으로 보이는 경로 인자"에만 표식이 있는지 본다.
-     *
-     * <p>cmdline 전체를 문자열로 훑으면 실행과 무관한 위치의 경로까지 걸린다. 실제로
-     * {@code ... && pwd -P >| /tmp/x} 처럼 리다이렉션 대상이 임시 경로라는 이유로 알림이 나갔다.
-     * 그래서 셸 연산자가 나오면 거기서 끊고, 앞쪽 인자 중 경로처럼 생긴 토큰만 검사한다.
-     */
-    private static boolean pathArgumentHasMarker(String cmdline, Set<String> markers) {
+    private static boolean executableFromTempPath(String cmdline) {
         String c = lower(cmdline);
         if (c == null) {
             return false;
         }
-        for (String token : c.split("\\s+")) {
+        List<String> tokens = tokenize(c);
+        return !tokens.isEmpty() && isTempOrDownloadPath(tokens.get(0));
+    }
+
+    /**
+     * cmdline 에서 "실행 대상으로 보이는 경로 인자"가 임시·다운로드 경로인지 본다.
+     *
+     * <p>cmdline 전체를 문자열로 훑으면 실행과 무관한 위치의 경로까지 걸린다. 실제로
+     * {@code ... && pwd -P >| /tmp/x} 처럼 리다이렉션 대상이 임시 경로라는 이유로 알림이 나갔다.
+     * 그래서 셸 연산자가 나오면 거기서 끊는다.
+     */
+    private static boolean pathArgumentFromTempPath(String cmdline) {
+        String c = lower(cmdline);
+        if (c == null) {
+            return false;
+        }
+        for (String token : tokenize(c)) {
             if (SHELL_OPERATORS.contains(token)) {
                 return false;   // 연산자 뒤는 실행 대상이 아니다
             }
-            boolean looksLikePath = token.contains("/") || token.contains("\\");
-            if (looksLikePath && markers.stream().anyMatch(token::contains)) {
+            if (isTempOrDownloadPath(token)) {
                 return true;
             }
         }
         return false;
+    }
+
+    /**
+     * 공백으로 자르되 인용부호로 묶인 구간은 한 토큰으로 유지하고 인용부호는 벗긴다.
+     *
+     * <p>경로가 인용부호로 감싸여 온다(실측: {@code launchctl unload "/Applications/.../tmp/x.plist"}).
+     * 단순히 공백으로만 자르면 사용자명에 공백이 있는 경로({@code "C:\Users\John Doe\Downloads\x.ps1"})가
+     * 조각나서, 시작 위치로 판정하는 방식이 그런 경로를 아예 못 본다.
+     */
+    private static List<String> tokenize(String cmdline) {
+        List<String> tokens = new ArrayList<>();
+        StringBuilder token = new StringBuilder();
+        char quote = 0;
+        for (char ch : cmdline.toCharArray()) {
+            if (quote != 0) {
+                if (ch == quote) {
+                    quote = 0;
+                } else {
+                    token.append(ch);
+                }
+            } else if (ch == '"' || ch == '\'') {
+                quote = ch;
+            } else if (Character.isWhitespace(ch)) {
+                if (token.length() > 0) {
+                    tokens.add(token.toString());
+                    token.setLength(0);
+                }
+            } else {
+                token.append(ch);
+            }
+        }
+        if (token.length() > 0) {
+            tokens.add(token.toString());
+        }
+        return tokens;
+    }
+
+    /**
+     * 시스템 임시·다운로드 경로인지 경로 구조로 판정한다 (소문자 기준).
+     *
+     * <p>{@code /tmp/} 같은 조각을 경로 어디서든 찾으면 앱 내부 폴더가 시스템 임시 경로로 오인된다.
+     * 실기기에서 R3 알림 42건이 전부 이것이었다: AhnLab 보안제품이 자기 업데이트 plist 를 다루는
+     * {@code "/Applications/AhnLab/ASTx/tmp/..."} 가 걸렸다. 조각을 더 빼는 대신 시작 위치를 고정한다.
+     */
+    private static boolean isTempOrDownloadPath(String p) {
+        if (p.startsWith("/")) {
+            return p.startsWith("/tmp/")
+                    || p.startsWith("/private/tmp/")
+                    || p.startsWith("/var/folders/")
+                    || underUserHome(p, "/users/", "downloads/")
+                    || underUserHome(p, "/home/", "downloads/");
+        }
+        String w = stripDriveLetter(p);
+        return w != null
+                && (w.startsWith("\\temp\\")
+                || w.startsWith("\\windows\\temp\\")
+                || underUserHome(w, "\\users\\", "appdata\\local\\temp\\")
+                || underUserHome(w, "\\users\\", "downloads\\"));
+    }
+
+    /** 자동실행/지속성 경로인지 (소문자 기준). LaunchAgents 는 아래 세 곳에 놓일 때만 실제로 등록된다. */
+    private static boolean isAutorunPath(String path) {
+        String p = lower(path);
+        if (p == null) {
+            return false;
+        }
+        p = p.trim().replace("\"", "");   // 경로가 인용부호로 감싸여 오는 경우가 있다
+        return FILE_AUTORUN_MARKERS.stream().anyMatch(p::contains)
+                || p.startsWith("/library/launchagents/")
+                || p.startsWith("/system/library/launchagents/")
+                || underUserHome(p, "/users/", "library/launchagents/");
+    }
+
+    /**
+     * 홈 바로 아래가 tail 인지 (예: {@code /users/me/downloads/...}).
+     *
+     * <p>사용자명 한 칸을 강제해서, 홈 밑이 아닌 곳에 같은 이름 폴더가 있는 경우를 거른다.
+     */
+    private static boolean underUserHome(String path, String homeRoot, String tail) {
+        if (!path.startsWith(homeRoot)) {
+            return false;
+        }
+        int userEnd = path.indexOf(homeRoot.charAt(0), homeRoot.length());
+        return userEnd > homeRoot.length() && path.startsWith(tail, userEnd + 1);
+    }
+
+    /** Windows 경로면 드라이브 문자를 뗀 나머지, 아니면 null. 드라이브 없는 {@code \\users\\...} 도 그대로 받는다. */
+    private static String stripDriveLetter(String path) {
+        if (path.length() >= 3 && Character.isLetter(path.charAt(0)) && path.charAt(1) == ':' && path.charAt(2) == '\\') {
+            return path.substring(2);
+        }
+        return path.startsWith("\\") ? path : null;
     }
 
     /** null 안전한 집합 포함 검사 (immutable Set 은 contains(null) 시 NPE). */

--- a/detector-service/src/test/java/com/edrdog/detectorservice/rule/RulesTest.java
+++ b/detector-service/src/test/java/com/edrdog/detectorservice/rule/RulesTest.java
@@ -197,6 +197,68 @@ class RulesTest {
     }
 
     @Test
+    @DisplayName("R3 음성: 앱 내부 tmp 폴더는 시스템 임시 경로가 아니다 (실제 오탐 사례)")
+    void r3_appInternalTempFolder_noAlert() {
+        // 배포 서버에서 R3 알림 42건이 전부 이것이었다. AhnLab 보안제품이 자기 업데이트 plist 를
+        // 다루는 정상 동작인데, /Applications/AhnLab/ASTx/tmp/ 안의 '/tmp/' 조각에 걸렸다.
+        List<String> observed = List.of(
+                "/bin/sh -c /bin/launchctl unload \"/Applications/AhnLab/ASTx/tmp/com.ahnlab.astx.astxUpdate.plist\"",
+                "/bin/sh -c /bin/launchctl load \"/Applications/AhnLab/ASTx/tmp/com.ahnlab.astx.astxUpdate.plist\"",
+                "/bin/sh -c /usr/sbin/chown -R root:wheel \"/Applications/AhnLab/ASTx/tmp/com.ahnlab.astx.astxUpdate.plist\"",
+                "/bin/bash -c /bin/launchctl unload \"/Applications/AhnLab/ASTx/tmp/com.ahnlab.astx.astxUpdate.plist\"",
+                "/bin/bash -c /bin/launchctl load \"/Applications/AhnLab/ASTx/tmp/com.ahnlab.astx.astxUpdate.plist\"",
+                "/bin/bash -c /usr/sbin/chown -R root:wheel \"/Applications/AhnLab/ASTx/tmp/com.ahnlab.astx.astxUpdate.plist\"");
+
+        for (String cmdline : observed) {
+            assertThat(Rules.evaluate(List.of(), script("sh", cmdline, 3000)))
+                    .as(cmdline)
+                    .isEmpty();
+        }
+    }
+
+    @Test
+    @DisplayName("R3 양성: /private/tmp/ 는 macOS 의 진짜 시스템 임시 경로라 계속 잡는다 (실제 관측 사례)")
+    void r3_realSystemTempPath_stillAlerts() {
+        // 배포 서버에서 관측된 개발 도구 노이즈지만 룰이 의도대로 동작한 것이다.
+        // 여기를 빼면 공격자가 쓰는 바로 그 경로를 허용하게 된다.
+        List<String> observed = List.of(
+                "/bin/bash -c tsc --noEmit -p /private/tmp/claude-501/proj/scratchpad/tsconfig.check.json",
+                "/usr/bin/python3 - /private/tmp/claude-501/proj/scratchpad/typecheck/src/api/demo.ts");
+
+        for (String cmdline : observed) {
+            assertThat(Rules.evaluate(List.of(), script("sh", cmdline, 3000)))
+                    .as(cmdline)
+                    .isPresent()
+                    .get()
+                    .extracting(Alert::ruleId)
+                    .isEqualTo("SCRIPT_FROM_TEMP_PATH");
+        }
+    }
+
+    @Test
+    @DisplayName("R3 양성: 경로에 인용부호가 붙어 있어도 잡는다")
+    void r3_quotedTempPath_alerts() {
+        Event current = script("powershell.exe",
+                "powershell -File \"C:\\Users\\victim\\Downloads\\setup.ps1\"", 3000);
+
+        assertThat(Rules.evaluate(List.of(), current))
+                .isPresent()
+                .get()
+                .extracting(Alert::ruleId)
+                .isEqualTo("SCRIPT_FROM_TEMP_PATH");
+    }
+
+    @Test
+    @DisplayName("R2 음성: 앱 내부 tmp 폴더에서 실행된 것은 다운로드-실행이 아니다")
+    void r2_executeFromAppInternalTempFolder_noAlert() {
+        // R3 오탐과 같은 결함이다. R2 도 같은 경로 판정을 쓴다.
+        List<Event> buffer = List.of(network("203.0.113.9", 443, 1000));
+        Event current = processFrom("astxUpdate", "/Applications/AhnLab/ASTx/tmp/astxUpdate", 2000);
+
+        assertThat(Rules.evaluate(buffer, current)).isEmpty();
+    }
+
+    @Test
     @DisplayName("R4: 자동실행(시작프로그램) 경로에 파일 생성 → FILE_IN_AUTORUN_PATH(T1547, MEDIUM, notify)")
     void r4_fileInAutorunPath_alerts() {
         Event current = file("evil.lnk",
@@ -219,6 +281,35 @@ class RulesTest {
     @DisplayName("R4 음성: 파일이지만 일반 경로면 미판정")
     void r4_fileInNormalPath_noAlert() {
         Event current = file("report.docx", "C:\\Users\\victim\\Documents\\report.docx", 4000);
+
+        assertThat(Rules.evaluate(List.of(), current)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("R4 양성: macOS 실제 자동실행 경로(LaunchAgents)의 plist 는 잡는다")
+    void r4_realLaunchAgentPaths_alert() {
+        List<String> autorunPaths = List.of(
+                "/Library/LaunchAgents/com.evil.agent.plist",
+                "/System/Library/LaunchAgents/com.evil.agent.plist",
+                "/Users/victim/Library/LaunchAgents/com.evil.agent.plist");
+
+        for (String path : autorunPaths) {
+            assertThat(Rules.evaluate(List.of(), file("com.evil.agent.plist", path, 4000)))
+                    .as(path)
+                    .isPresent()
+                    .get()
+                    .extracting(Alert::ruleId)
+                    .isEqualTo("FILE_IN_AUTORUN_PATH");
+        }
+    }
+
+    @Test
+    @DisplayName("R4 음성: 앱 번들 안의 LaunchAgents 는 자동실행 경로가 아니다")
+    void r4_launchAgentsInsideAppBundle_noAlert() {
+        // 앱 번들은 자기 Contents/Library/LaunchAgents 에 plist 원본을 넣어 배포한다.
+        // 거기 파일이 생기는 것은 설치일 뿐이고, 실제 등록은 위 세 곳에 놓일 때 일어난다.
+        Event current = file("com.vendor.agent.plist",
+                "/Applications/Vendor.app/Contents/Library/LaunchAgents/com.vendor.agent.plist", 4000);
 
         assertThat(Rules.evaluate(List.of(), current)).isEmpty();
     }


### PR DESCRIPTION
배포 서버 데이터로 찾았다.

## 무엇이 잘못됐나

R3(`SCRIPT_FROM_TEMP_PATH`) 알림 42건이 전부 하나의 오탐이었다.

```
/bin/sh -c /bin/launchctl unload "/Applications/AhnLab/ASTx/tmp/com.ahnlab.astx.astxUpdate.plist"
```

AhnLab 보안제품이 자기 업데이트 plist 를 다루는 정상 동작인데, 경로 안의 `/tmp/` 조각에 걸렸다.

원인은 경로 표식을 부분 문자열로 찾은 것이다. `/tmp/` 가 경로 **어디에 있든** 매칭되므로 앱이 자기 설치 폴더 안에 둔 tmp 하위 폴더가 시스템 임시 디렉터리로 읽혔다. 룰의 의도는 시스템 임시 경로에 떨어진 것을 실행했다는 신호를 잡는 것이지, tmp 라는 이름의 폴더를 찾는 것이 아니다.

## 고친 방향

조각을 예외로 빼지 않고 경로 구조로 판정한다. 조각을 하나씩 빼면 다음에 같은 종류의 경로에서 같은 오탐이 다시 난다.

- 임시 경로는 시작 위치 고정: `/tmp/`, `/private/tmp/`, `/var/folders/`, Windows 사용자·시스템 temp
- 다운로드는 사용자 홈 바로 아래일 때만. 사용자명 한 칸을 강제해 홈 밑이 아닌 곳의 같은 이름 폴더를 거른다
- 인용부호와 드라이브 문자를 벗겨 낸 뒤 판정

**같은 결함이 R2 와 R4 에도 있었다.** R4 의 `/launchagents/` 는 앱 번들이 자기 `Contents/Library/LaunchAgents` 에 plist 원본을 넣어 배포하므로 설치할 때마다 지속성 확보로 읽혔다. 실제 등록은 `/Library`, `/System/Library`, 사용자 홈의 `Library` 세 곳이라 그 셋만 인정한다.

## 발화 여부

| 명령줄 | 기존 | 변경 후 |
| --- | --- | --- |
| AhnLab `/Applications/AhnLab/ASTx/tmp/...` (6종, 42건) | 발화 | **미발화** |
| `powershell -File C:\Users\victim\Downloads\setup.ps1` (데모, 12건) | 발화 | 발화 (유지) |
| `/private/tmp/claude-501/...` (12건) | 발화 | 발화 (유지) |
| 앱 번들 안 `Contents/Library/LaunchAgents/` | 발화 | **미발화** |

**시스템 임시 경로 실행은 그대로 잡는다.** `/private/tmp/` 아래 개발 도구가 도는 것도 걸리는데 그건 룰이 의도대로 동작하는 것이다. 여기를 빼면 공격자가 쓰는 바로 그 경로를 허용하게 된다. 그건 탐지력을 깎는 것이라 하지 않았다.

## 이미 같은 교훈이 파일에 있었다

R2 가 같은 이유로 오탐이 났던 기록이 주석에 있다(정상 프로세스가 임시 경로를 **인자로** 받는 경우). 그때는 argv[0] 만 보는 것으로 좁혔는데, 경로 판정 자체를 고치지 않아 인자를 보는 R3 로 문제가 옮겨왔다. 이번에는 세 룰이 같은 판정을 공유한다.

## 검증

테스트에 실기기에서 관측한 명령줄을 그대로 넣었다. 지어낸 경로로만 덮으면 같은 종류가 다시 샌다.

`./gradlew build --rerun-tasks` 통과, 실패 없음. 기존 룰 테스트도 그대로 통과한다.