### PR TITLE
release: 호스트 상태 정합성과 탐지 룰 경로 판정 수정

### DIFF
--- a/api-service/src/main/java/com/edrdog/apiservice/host/HostAggregator.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/host/HostAggregator.java
@@ -27,6 +27,8 @@ public final class HostAggregator {
 
     /**
      * events 행(host, last_seen)에 host 별 alert 집계, severity 분포(위험 점수), 등록 노드 정보를 붙여 목록을 만든다.
+     * status 와 riskScore 는 한 값(severity 분포로 낸 점수)에서 같이 나온다. 따로 계산하면 한 행 안에서
+     * "위험도 100 인데 정상" 처럼 서로 반대되는 말을 할 수 있다.
      * events 쿼리가 last_seen DESC 로 정렬돼 오므로 그 순서를 그대로 유지하고,
      * events 는 없고 등록만 된 host 는 agentSeen DESC 로 정렬해 뒤에 붙인다.
      * host 이름은 엔드포인트가 OS 원본 그대로 보내 대소문자가 어긋나는 사례가 있어
@@ -47,24 +49,23 @@ public final class HostAggregator {
             String host = String.valueOf(row.get("host"));
             long lastSeen = Long.parseLong(String.valueOf(row.get("last_seen")));
             HostAlertCount c = byHost.get(host);
-            long critical = c == null ? 0 : c.openCritical();
-            long high = c == null ? 0 : c.openHigh();
             long threats = c == null ? 0 : c.openTotal();
             HostRisk risk = riskByHost.get(host);
+            int score = risk == null ? 0 : risk.score();
 
             EnrolledHost node = enrolledByHost.get(host.toLowerCase());
             boolean isEnrolled = node != null;
             long agentSeen = node == null ? 0 : node.agentSeen();
             matched.add(host.toLowerCase());
 
-            out.add(new HostResponse(host, lastSeen, HostStatus.classify(critical, high), threats,
-                    risk == null ? 0 : risk.score(), isEnrolled, agentSeen, platformOf(node)));
+            out.add(new HostResponse(host, lastSeen, HostStatus.classify(score), threats,
+                    score, isEnrolled, agentSeen, platformOf(node)));
         }
 
         enrolledByHost.values().stream()
                 .filter(node -> !matched.contains(node.host().toLowerCase()))
                 .sorted(Comparator.comparingLong(EnrolledHost::agentSeen).reversed())
-                .forEach(node -> out.add(new HostResponse(node.host(), 0L, HostStatus.HEALTHY, 0L,
+                .forEach(node -> out.add(new HostResponse(node.host(), 0L, HostStatus.classify(0), 0L,
                         0, true, node.agentSeen(), platformOf(node))));
 
         return out;

--- a/api-service/src/main/java/com/edrdog/apiservice/host/HostStatus.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/host/HostStatus.java
@@ -1,8 +1,14 @@
 package com.edrdog.apiservice.host;
 
 /**
- * 호스트 상태 분류(순수). 열린 alert 의 severity 로만 판정한다.
- * 열린 CRITICAL 이 하나라도 있으면 critical(위험), 없고 HIGH 가 있으면 warning(주의), 둘 다 없으면 healthy(정상).
+ * 호스트 상태 분류(순수). 위험 점수(RiskScore)의 함수라 목록에서 두 값이 서로 어긋날 수 없다.
+ * 예전에는 열린 CRITICAL/HIGH 의 유무로만 갈라서, MEDIUM 이 54건 쌓여 점수가 100 인 기기가
+ * "정상"(초록)으로 뜨는 일이 있었다. 같은 데이터로 두 지표가 정반대를 말하면 어느 쪽도 못 믿는다.
+ *
+ * <p>임계값을 RiskScore 의 가중치로 두는 이유:
+ * 열린 CRITICAL 한 건(25)이면 위험, HIGH 한 건(10)이면 주의라는 기존 의미를 그대로 유지하면서,
+ * 가중치가 나중에 바뀌어도 임계값이 같이 따라가 위 모순이 되돌아오지 않게 하려는 것이다.
+ * 25/10 을 여기 리터럴로 적으면 한쪽만 고쳐질 수 있다.
  */
 public final class HostStatus {
 
@@ -10,14 +16,17 @@ public final class HostStatus {
     public static final String WARNING = "warning";
     public static final String CRITICAL = "critical";
 
+    private static final int CRITICAL_AT = RiskScore.W_CRITICAL;
+    private static final int WARNING_AT = RiskScore.W_HIGH;
+
     private HostStatus() {
     }
 
-    public static String classify(long openCritical, long openHigh) {
-        if (openCritical > 0) {
+    public static String classify(int riskScore) {
+        if (riskScore >= CRITICAL_AT) {
             return CRITICAL;
         }
-        if (openHigh > 0) {
+        if (riskScore >= WARNING_AT) {
             return WARNING;
         }
         return HEALTHY;

--- a/api-service/src/main/java/com/edrdog/apiservice/host/RiskScore.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/host/RiskScore.java
@@ -10,13 +10,16 @@ package com.edrdog.apiservice.host;
  * <p>가중치를 25/10/3/1 로 둔 이유:
  * CRITICAL 한 건이면 25점이라 그 호스트 하나만으로 화면 상단에 올라와야 하고, 네 건이면 상한 100 에 닿는다.
  * HIGH 두 건(20)보다 CRITICAL 한 건(25)이 무거워야 HostStatus 의 분류(CRITICAL 하나면 위험,
- * HIGH 하나면 주의)와 순서가 어긋나지 않는다. MEDIUM/LOW 는 쌓였을 때만 의미가 있어 낮게 둔다.
+ * HIGH 하나면 주의)와 순서가 어긋나지 않는다. MEDIUM/LOW 는 쌓였을 때만 의미가 있어 낮게 둔다
+ * (낮게 두는 것과 무시하는 것은 다르다. 쌓여서 임계를 넘으면 HostStatus 도 같이 올라간다).
  * 상한을 두는 이유는 알림이 폭주한 호스트 하나가 점수 축을 독차지하면 나머지가 전부 0 으로 보이기 때문이다.
  */
 public final class RiskScore {
 
-    private static final int W_CRITICAL = 25;
-    private static final int W_HIGH = 10;
+    /** HostStatus 의 위험/주의 임계값이 이 둘을 그대로 쓴다. 임계값이 가중치를 따라가야 상태와 점수가 갈리지 않는다. */
+    public static final int W_CRITICAL = 25;
+    public static final int W_HIGH = 10;
+
     private static final int W_MEDIUM = 3;
     private static final int W_LOW = 1;
     private static final int MAX = 100;

--- a/api-service/src/main/java/com/edrdog/apiservice/host/web/HostResponse.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/host/web/HostResponse.java
@@ -1,7 +1,7 @@
 package com.edrdog.apiservice.host.web;
 
 /**
- * 엔드포인트(호스트) 목록 한 행. status 는 영문 enum(healthy|warning|critical),
+ * 엔드포인트(호스트) 목록 한 행. status 는 영문 enum(healthy|warning|critical)이고 riskScore 에서 유도한다(HostStatus).
  * threats 는 열린 alert 총수, lastSeen 은 events 최신 ts(epoch millis).
  * riskScore 는 열린 alert 를 severity 로 가중합한 0..100 값(RiskScore)으로, 토폴로지 엔드포인트 노드와 같은 값이다.
  * 열린 알림이 없으면 0 이다(이건 관측 결과라서 null 이 아니다). 목록에 위험도를 보이려고

--- a/api-service/src/test/java/com/edrdog/apiservice/host/HostAggregatorTest.java
+++ b/api-service/src/test/java/com/edrdog/apiservice/host/HostAggregatorTest.java
@@ -15,7 +15,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 /**
  * events 행, alert 집계, 등록 노드(agent_nodes)를 host 기준으로 병합하는 순수 로직 검증.
  * 호스트 집합은 events ∪ 등록 노드다(이벤트가 없어도 등록만 됐으면 목록에 나와야 한다).
- * status/위협수는 alert 집계에서 붙는다.
+ * 위협수는 alert 집계에서, status 와 위험 점수는 severity 분포 하나에서 같이 나온다.
  */
 class HostAggregatorTest {
 
@@ -56,7 +56,7 @@ class HostAggregatorTest {
     void 열린_CRITICAL_있는_host_는_위험_위협수는_열린총수() {
         List<HostResponse> hosts = HostAggregator.hosts(
                 List.of(row("h1", "1000")),
-                List.of(count("h1", 3, 1, 2)), List.of(), List.of());
+                List.of(count("h1", 3, 1, 2)), List.of(risk("h1", 1, 2, 0, 0)), List.of());
 
         HostResponse h = hosts.get(0);
         assertEquals(HostStatus.CRITICAL, h.status());
@@ -67,10 +67,22 @@ class HostAggregatorTest {
     void HIGH만_있는_host_는_주의() {
         List<HostResponse> hosts = HostAggregator.hosts(
                 List.of(row("h1", "1000")),
-                List.of(count("h1", 2, 0, 2)), List.of(), List.of());
+                List.of(count("h1", 2, 0, 2)), List.of(risk("h1", 0, 2, 0, 0)), List.of());
 
         assertEquals(HostStatus.WARNING, hosts.get(0).status());
         assertEquals(2L, hosts.get(0).threats());
+    }
+
+    @Test
+    void MEDIUM_만_쌓인_host_는_점수를_따라_위험이다() {
+        // 열린 MEDIUM 54건이면 점수가 상한 100 인데, 예전 분류는 MEDIUM 을 보지 않아 "정상"으로 떴다.
+        List<HostResponse> hosts = HostAggregator.hosts(
+                List.of(row("h1", "1000")),
+                List.of(count("h1", 54, 0, 0)), List.of(risk("h1", 0, 0, 54, 0)), List.of());
+
+        HostResponse h = hosts.get(0);
+        assertEquals(100, h.riskScore());
+        assertEquals(HostStatus.CRITICAL, h.status());
     }
 
     // --- 위험 점수 ---

--- a/api-service/src/test/java/com/edrdog/apiservice/host/HostStatusRiskConsistencyTest.java
+++ b/api-service/src/test/java/com/edrdog/apiservice/host/HostStatusRiskConsistencyTest.java
@@ -1,0 +1,114 @@
+package com.edrdog.apiservice.host;
+
+import com.edrdog.apiservice.host.web.HostResponse;
+import com.edrdog.apiservice.host.web.HostSummary;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * 목록 한 행의 status 와 riskScore 가 어긋날 수 없다는 것을 severity 조합 전수로 고정한다.
+ * 사례 몇 개를 나열하지 않는 이유: 나중에 가중치나 임계값을 한쪽만 고치면 "열린 알림 54건이라 점수가 100 인데 정상"
+ * 같은 모순이 되돌아오는데, 그때 여기서 깨져야 한다.
+ */
+class HostStatusRiskConsistencyTest {
+
+    /** 전수로 훑는 severity 조합. medium 은 그것만으로 상한(100)을 넘길 만큼 넉넉히 본다. */
+    private static final int MAX_CRITICAL = 3;
+    private static final int MAX_HIGH = 4;
+    private static final int MAX_MEDIUM = 40;
+    private static final int MAX_LOW = 12;
+
+    private static final List<HostResponse> ALL = allCombinations();
+
+    /** 위험한 순서. 점수가 오를 때 이 값이 내려가면 안 된다. */
+    private static int rank(String status) {
+        return switch (status) {
+            case HostStatus.CRITICAL -> 2;
+            case HostStatus.WARNING -> 1;
+            default -> 0;
+        };
+    }
+
+    /** 모든 severity 조합을 각각 한 호스트로 만들어 실제 목록 조립 경로(HostAggregator)를 통과시킨다. */
+    private static List<HostResponse> allCombinations() {
+        List<Map<String, Object>> rows = new ArrayList<>();
+        List<HostRisk> risks = new ArrayList<>();
+        int i = 0;
+        for (int c = 0; c <= MAX_CRITICAL; c++) {
+            for (int h = 0; h <= MAX_HIGH; h++) {
+                for (int m = 0; m <= MAX_MEDIUM; m++) {
+                    for (int l = 0; l <= MAX_LOW; l++) {
+                        String host = "h" + i++;
+                        rows.add(Map.of("host", host, "last_seen", "1000"));
+                        risks.add(new HostRisk(host, c, h, m, l));
+                    }
+                }
+            }
+        }
+        return HostAggregator.hosts(rows, List.of(), risks, List.of());
+    }
+
+    @Test
+    void 어떤_severity_조합에서도_status_는_riskScore_가_정하는_값과_같다() {
+        for (HostResponse h : ALL) {
+            assertEquals(HostStatus.classify(h.riskScore()), h.status(),
+                    "riskScore=" + h.riskScore() + " 인데 status=" + h.status());
+        }
+    }
+
+    @Test
+    void 정상으로_보이는_호스트는_점수가_주의_임계_미만일_때뿐이다() {
+        for (HostResponse h : ALL) {
+            if (HostStatus.HEALTHY.equals(h.status())) {
+                assertTrue(h.riskScore() < RiskScore.W_HIGH,
+                        "점수 " + h.riskScore() + " 인데 정상으로 보인다");
+            }
+        }
+    }
+
+    @Test
+    void 위험과_주의는_각_임계_구간에서만_나온다() {
+        for (HostResponse h : ALL) {
+            int score = h.riskScore();
+            String expected = score >= RiskScore.W_CRITICAL ? HostStatus.CRITICAL
+                    : score >= RiskScore.W_HIGH ? HostStatus.WARNING
+                    : HostStatus.HEALTHY;
+            assertEquals(expected, h.status(), "riskScore=" + score);
+        }
+    }
+
+    @Test
+    void 점수가_더_높은_호스트가_더_가벼운_status_로_나오지_않는다() {
+        List<HostResponse> byScore = new ArrayList<>(ALL);
+        byScore.sort(Comparator.comparingInt(HostResponse::riskScore));
+        for (int i = 1; i < byScore.size(); i++) {
+            HostResponse lower = byScore.get(i - 1);
+            HostResponse higher = byScore.get(i);
+            assertTrue(rank(higher.status()) >= rank(lower.status()),
+                    "점수 " + higher.riskScore() + " 가 " + lower.riskScore() + " 보다 가볍게 분류됐다");
+        }
+    }
+
+    @Test
+    void 요약의_정상_주의_위험_수는_점수가_정한_분류를_그대로_따른다() {
+        Map<String, Long> expected = new HashMap<>();
+        for (HostResponse h : ALL) {
+            expected.merge(HostStatus.classify(h.riskScore()), 1L, Long::sum);
+        }
+
+        HostSummary s = HostAggregator.summary(ALL);
+        assertEquals(expected.getOrDefault(HostStatus.HEALTHY, 0L), s.healthy());
+        assertEquals(expected.getOrDefault(HostStatus.WARNING, 0L), s.warning());
+        assertEquals(expected.getOrDefault(HostStatus.CRITICAL, 0L), s.critical());
+        assertEquals(ALL.size(), s.total());
+        assertEquals(0L, s.noEvents());
+    }
+}

--- a/api-service/src/test/java/com/edrdog/apiservice/host/HostStatusTest.java
+++ b/api-service/src/test/java/com/edrdog/apiservice/host/HostStatusTest.java
@@ -5,29 +5,37 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
- * 호스트 상태 분류 순수 로직. 열린 CRITICAL 우선, 없으면 HIGH, 둘 다 없으면 정상.
+ * 호스트 상태 분류 순수 로직. status 는 위험 점수의 함수다.
  */
 class HostStatusTest {
 
     @Test
-    void 열린_CRITICAL_이_있으면_위험() {
-        assertEquals(HostStatus.CRITICAL, HostStatus.classify(1, 0));
-        assertEquals(HostStatus.CRITICAL, HostStatus.classify(2, 3));
+    void 열린_CRITICAL_한_건이면_위험() {
+        assertEquals(HostStatus.CRITICAL, HostStatus.classify(RiskScore.of(1, 0, 0, 0)));
     }
 
     @Test
-    void CRITICAL_없고_HIGH_있으면_주의() {
-        assertEquals(HostStatus.WARNING, HostStatus.classify(0, 1));
-        assertEquals(HostStatus.WARNING, HostStatus.classify(0, 5));
+    void CRITICAL_없고_HIGH_한_건이면_주의() {
+        assertEquals(HostStatus.WARNING, HostStatus.classify(RiskScore.of(0, 1, 0, 0)));
     }
 
     @Test
     void 열린것이_없으면_정상() {
-        assertEquals(HostStatus.HEALTHY, HostStatus.classify(0, 0));
+        assertEquals(HostStatus.HEALTHY, HostStatus.classify(RiskScore.of(0, 0, 0, 0)));
     }
 
     @Test
-    void CRITICAL_이_HIGH_보다_우선() {
-        assertEquals(HostStatus.CRITICAL, HostStatus.classify(1, 10));
+    void MEDIUM_만_쌓여도_점수를_따라_주의와_위험으로_올라간다() {
+        assertEquals(HostStatus.HEALTHY, HostStatus.classify(RiskScore.of(0, 0, 3, 0)));
+        assertEquals(HostStatus.WARNING, HostStatus.classify(RiskScore.of(0, 0, 4, 0)));
+        assertEquals(HostStatus.CRITICAL, HostStatus.classify(RiskScore.of(0, 0, 54, 0)));
+    }
+
+    @Test
+    void 임계값은_RiskScore_의_가중치에_묶여있다() {
+        assertEquals(HostStatus.CRITICAL, HostStatus.classify(RiskScore.W_CRITICAL));
+        assertEquals(HostStatus.WARNING, HostStatus.classify(RiskScore.W_CRITICAL - 1));
+        assertEquals(HostStatus.WARNING, HostStatus.classify(RiskScore.W_HIGH));
+        assertEquals(HostStatus.HEALTHY, HostStatus.classify(RiskScore.W_HIGH - 1));
     }
 }

--- a/api-service/src/test/java/com/edrdog/apiservice/host/web/HostApiIntegrationTest.java
+++ b/api-service/src/test/java/com/edrdog/apiservice/host/web/HostApiIntegrationTest.java
@@ -131,9 +131,25 @@ class HostApiIntegrationTest {
     }
 
     @Test
+    void 열린_MEDIUM_만_많은_기기는_정상이_아니라_위험으로_나온다() throws Exception {
+        // 배포 서버에서 열린 MEDIUM 54건짜리 기기가 riskScore 100 인 채로 "정상"으로 떴던 사례다.
+        String[] a = signup("a-medium@edrdog.com");
+        countRows = List.of(count("h1", 54, 0, 0));
+        severityRows = List.of(severity("h1", 0, 0, 54, 0));
+
+        mvc.perform(get("/api/hosts").header("Authorization", "Bearer " + a[0]))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].host").value("h1"))
+                .andExpect(jsonPath("$[0].riskScore").value(100))
+                .andExpect(jsonPath("$[0].status").value("critical"))
+                .andExpect(jsonPath("$[0].threats").value(54));
+    }
+
+    @Test
     void 요약은_status별_수와_총수를_준다() throws Exception {
         String[] a = signup("a-summary@edrdog.com");
         countRows = List.of(count("h1", 1, 0, 1));   // h1 주의(HIGH), h2 정상
+        severityRows = List.of(severity("h1", 0, 1, 0, 0));
 
         mvc.perform(get("/api/hosts/summary").header("Authorization", "Bearer " + a[0]))
                 .andExpect(status().isOk())

--- a/detector-service/src/main/java/com/edrdog/detectorservice/rule/Rules.java
+++ b/detector-service/src/main/java/com/edrdog/detectorservice/rule/Rules.java
@@ -32,13 +32,9 @@ public final class Rules {
     private static final Set<String> BASELINE_SAFE = Set.of(
             "onedrive.exe", "teams.exe", "gupdate.exe", "msedgeupdate.exe", "update.exe");
 
-    /** 임시/다운로드 경로 표식 — 여기서 스크립트가 실행되면 저심각 의심(R3). 소문자 기준. */
-    private static final Set<String> SCRIPT_TEMP_MARKERS = Set.of(
-            "\\temp\\", "/tmp/", "\\downloads\\", "/downloads/", "appdata\\local\\temp");
-
-    /** 자동실행/시작 경로 표식 — 여기에 파일이 생기면 지속성 확보 의심(R4). 소문자 기준. */
+    /** 자동실행/시작 경로 표식 (Windows) — 여기에 파일이 생기면 지속성 확보 의심(R4). 소문자 기준. */
     private static final Set<String> FILE_AUTORUN_MARKERS = Set.of(
-            "\\startup\\", "/launchagents/", "\\currentversion\\run");
+            "\\startup\\", "\\currentversion\\run");
 
     /**
      * 현재 이벤트가 선행 버퍼와 상관되어 룰을 완성하면 Alert 반환. 여러 룰 매칭 시 가장 심각한 것 채택.
@@ -85,7 +81,7 @@ public final class Rules {
         }
         if (isProcess(e)) {
             return in(OFFICE_APPS, lower(e.process()))
-                    || executableHasMarker(e.cmdline(), SCRIPT_TEMP_MARKERS);
+                    || executableFromTempPath(e.cmdline());
         }
         return false;
     }
@@ -127,7 +123,7 @@ public final class Rules {
             return prior.stream()
                     .filter(Rules::isProcess)
                     .filter(e -> !isBaseline(lower(e.process())))
-                    .filter(e -> executableHasMarker(e.cmdline(), SCRIPT_TEMP_MARKERS))
+                    .filter(e -> executableFromTempPath(e.cmdline()))
                     .filter(e -> e.ts() >= current.ts())   // 시각상 다운로드가 먼저여야 한다
                     .findFirst()
                     .map(exec -> alertOf("DOWNLOAD_AND_EXECUTE", "T1105+T1204", Alert.SEV_CRITICAL,
@@ -140,7 +136,7 @@ public final class Rules {
         // 모든 프로세스 실행이 CRITICAL 이 된다. 인자까지 보면 정상 프로세스가 임시 경로를
         // 인자로 받는 경우(find /private/tmp/..., mount_apfs ... /private/tmp/PKInstallSandbox/...)
         // 까지 걸리므로, 실행된 파일 자체(argv[0])만 본다.
-        if (!executableHasMarker(current.cmdline(), SCRIPT_TEMP_MARKERS)) {
+        if (!executableFromTempPath(current.cmdline())) {
             return Optional.empty();
         }
         Optional<Event> download = prior.stream()
@@ -157,7 +153,7 @@ public final class Rules {
 
     /** R3 T1059: 임시/다운로드 경로에서 실행된 스크립트 (저심각 point 룰). */
     private static Optional<Alert> scriptFromTempPath(Event current) {
-        if (!isScript(current) || !pathArgumentHasMarker(current.cmdline(), SCRIPT_TEMP_MARKERS)) {
+        if (!isScript(current) || !pathArgumentFromTempPath(current.cmdline())) {
             return Optional.empty();
         }
         return Optional.of(alertOf("SCRIPT_FROM_TEMP_PATH", "T1059", Alert.SEV_MEDIUM,
@@ -166,7 +162,7 @@ public final class Rules {
 
     /** R4 T1547: 자동실행/시작 경로에 생성된 파일 (지속성 확보, 저심각 point 룰). */
     private static Optional<Alert> fileInAutorunPath(Event current) {
-        if (!isFile(current) || !pathHasMarker(current.cmdline(), FILE_AUTORUN_MARKERS)) {
+        if (!isFile(current) || !isAutorunPath(current.cmdline())) {
             return Optional.empty();
         }
         return Optional.of(alertOf("FILE_IN_AUTORUN_PATH", "T1547", Alert.SEV_MEDIUM,
@@ -232,46 +228,132 @@ public final class Rules {
         return Event.TYPE_FILE.equals(e.type());
     }
 
-    private static boolean pathHasMarker(String path, Set<String> markers) {
-        String p = lower(path);
-        return p != null && markers.stream().anyMatch(p::contains);
-    }
-
     /** 셸 연산자 — 여기부터는 실행 대상이 아니라 출력/후속 명령이라 판정에서 제외한다. */
     private static final Set<String> SHELL_OPERATORS = Set.of(">", ">>", ">|", "<", "|", "||", "&&", ";", "&");
 
     /** 실행된 파일 자체(argv[0])만 본다. 인자까지 보면 정상 프로세스의 오탐이 난다(find/mount_apfs 사례, downloadAndExecute 참고). */
-    private static boolean executableHasMarker(String cmdline, Set<String> markers) {
-        String c = lower(cmdline);
-        if (c == null || c.isBlank()) {
-            return false;
-        }
-        String argv0 = c.trim().split("\\s+")[0];
-        return markers.stream().anyMatch(argv0::contains);
-    }
-
-    /**
-     * cmdline 에서 "실행 대상으로 보이는 경로 인자"에만 표식이 있는지 본다.
-     *
-     * <p>cmdline 전체를 문자열로 훑으면 실행과 무관한 위치의 경로까지 걸린다. 실제로
-     * {@code ... && pwd -P >| /tmp/x} 처럼 리다이렉션 대상이 임시 경로라는 이유로 알림이 나갔다.
-     * 그래서 셸 연산자가 나오면 거기서 끊고, 앞쪽 인자 중 경로처럼 생긴 토큰만 검사한다.
-     */
-    private static boolean pathArgumentHasMarker(String cmdline, Set<String> markers) {
+    private static boolean executableFromTempPath(String cmdline) {
         String c = lower(cmdline);
         if (c == null) {
             return false;
         }
-        for (String token : c.split("\\s+")) {
+        List<String> tokens = tokenize(c);
+        return !tokens.isEmpty() && isTempOrDownloadPath(tokens.get(0));
+    }
+
+    /**
+     * cmdline 에서 "실행 대상으로 보이는 경로 인자"가 임시·다운로드 경로인지 본다.
+     *
+     * <p>cmdline 전체를 문자열로 훑으면 실행과 무관한 위치의 경로까지 걸린다. 실제로
+     * {@code ... && pwd -P >| /tmp/x} 처럼 리다이렉션 대상이 임시 경로라는 이유로 알림이 나갔다.
+     * 그래서 셸 연산자가 나오면 거기서 끊는다.
+     */
+    private static boolean pathArgumentFromTempPath(String cmdline) {
+        String c = lower(cmdline);
+        if (c == null) {
+            return false;
+        }
+        for (String token : tokenize(c)) {
             if (SHELL_OPERATORS.contains(token)) {
                 return false;   // 연산자 뒤는 실행 대상이 아니다
             }
-            boolean looksLikePath = token.contains("/") || token.contains("\\");
-            if (looksLikePath && markers.stream().anyMatch(token::contains)) {
+            if (isTempOrDownloadPath(token)) {
                 return true;
             }
         }
         return false;
+    }
+
+    /**
+     * 공백으로 자르되 인용부호로 묶인 구간은 한 토큰으로 유지하고 인용부호는 벗긴다.
+     *
+     * <p>경로가 인용부호로 감싸여 온다(실측: {@code launchctl unload "/Applications/.../tmp/x.plist"}).
+     * 단순히 공백으로만 자르면 사용자명에 공백이 있는 경로({@code "C:\Users\John Doe\Downloads\x.ps1"})가
+     * 조각나서, 시작 위치로 판정하는 방식이 그런 경로를 아예 못 본다.
+     */
+    private static List<String> tokenize(String cmdline) {
+        List<String> tokens = new ArrayList<>();
+        StringBuilder token = new StringBuilder();
+        char quote = 0;
+        for (char ch : cmdline.toCharArray()) {
+            if (quote != 0) {
+                if (ch == quote) {
+                    quote = 0;
+                } else {
+                    token.append(ch);
+                }
+            } else if (ch == '"' || ch == '\'') {
+                quote = ch;
+            } else if (Character.isWhitespace(ch)) {
+                if (token.length() > 0) {
+                    tokens.add(token.toString());
+                    token.setLength(0);
+                }
+            } else {
+                token.append(ch);
+            }
+        }
+        if (token.length() > 0) {
+            tokens.add(token.toString());
+        }
+        return tokens;
+    }
+
+    /**
+     * 시스템 임시·다운로드 경로인지 경로 구조로 판정한다 (소문자 기준).
+     *
+     * <p>{@code /tmp/} 같은 조각을 경로 어디서든 찾으면 앱 내부 폴더가 시스템 임시 경로로 오인된다.
+     * 실기기에서 R3 알림 42건이 전부 이것이었다: AhnLab 보안제품이 자기 업데이트 plist 를 다루는
+     * {@code "/Applications/AhnLab/ASTx/tmp/..."} 가 걸렸다. 조각을 더 빼는 대신 시작 위치를 고정한다.
+     */
+    private static boolean isTempOrDownloadPath(String p) {
+        if (p.startsWith("/")) {
+            return p.startsWith("/tmp/")
+                    || p.startsWith("/private/tmp/")
+                    || p.startsWith("/var/folders/")
+                    || underUserHome(p, "/users/", "downloads/")
+                    || underUserHome(p, "/home/", "downloads/");
+        }
+        String w = stripDriveLetter(p);
+        return w != null
+                && (w.startsWith("\\temp\\")
+                || w.startsWith("\\windows\\temp\\")
+                || underUserHome(w, "\\users\\", "appdata\\local\\temp\\")
+                || underUserHome(w, "\\users\\", "downloads\\"));
+    }
+
+    /** 자동실행/지속성 경로인지 (소문자 기준). LaunchAgents 는 아래 세 곳에 놓일 때만 실제로 등록된다. */
+    private static boolean isAutorunPath(String path) {
+        String p = lower(path);
+        if (p == null) {
+            return false;
+        }
+        p = p.trim().replace("\"", "");   // 경로가 인용부호로 감싸여 오는 경우가 있다
+        return FILE_AUTORUN_MARKERS.stream().anyMatch(p::contains)
+                || p.startsWith("/library/launchagents/")
+                || p.startsWith("/system/library/launchagents/")
+                || underUserHome(p, "/users/", "library/launchagents/");
+    }
+
+    /**
+     * 홈 바로 아래가 tail 인지 (예: {@code /users/me/downloads/...}).
+     *
+     * <p>사용자명 한 칸을 강제해서, 홈 밑이 아닌 곳에 같은 이름 폴더가 있는 경우를 거른다.
+     */
+    private static boolean underUserHome(String path, String homeRoot, String tail) {
+        if (!path.startsWith(homeRoot)) {
+            return false;
+        }
+        int userEnd = path.indexOf(homeRoot.charAt(0), homeRoot.length());
+        return userEnd > homeRoot.length() && path.startsWith(tail, userEnd + 1);
+    }
+
+    /** Windows 경로면 드라이브 문자를 뗀 나머지, 아니면 null. 드라이브 없는 {@code \\users\\...} 도 그대로 받는다. */
+    private static String stripDriveLetter(String path) {
+        if (path.length() >= 3 && Character.isLetter(path.charAt(0)) && path.charAt(1) == ':' && path.charAt(2) == '\\') {
+            return path.substring(2);
+        }
+        return path.startsWith("\\") ? path : null;
     }
 
     /** null 안전한 집합 포함 검사 (immutable Set 은 contains(null) 시 NPE). */

--- a/detector-service/src/test/java/com/edrdog/detectorservice/rule/RulesTest.java
+++ b/detector-service/src/test/java/com/edrdog/detectorservice/rule/RulesTest.java
@@ -197,6 +197,68 @@ class RulesTest {
     }
 
     @Test
+    @DisplayName("R3 음성: 앱 내부 tmp 폴더는 시스템 임시 경로가 아니다 (실제 오탐 사례)")
+    void r3_appInternalTempFolder_noAlert() {
+        // 배포 서버에서 R3 알림 42건이 전부 이것이었다. AhnLab 보안제품이 자기 업데이트 plist 를
+        // 다루는 정상 동작인데, /Applications/AhnLab/ASTx/tmp/ 안의 '/tmp/' 조각에 걸렸다.
+        List<String> observed = List.of(
+                "/bin/sh -c /bin/launchctl unload \"/Applications/AhnLab/ASTx/tmp/com.ahnlab.astx.astxUpdate.plist\"",
+                "/bin/sh -c /bin/launchctl load \"/Applications/AhnLab/ASTx/tmp/com.ahnlab.astx.astxUpdate.plist\"",
+                "/bin/sh -c /usr/sbin/chown -R root:wheel \"/Applications/AhnLab/ASTx/tmp/com.ahnlab.astx.astxUpdate.plist\"",
+                "/bin/bash -c /bin/launchctl unload \"/Applications/AhnLab/ASTx/tmp/com.ahnlab.astx.astxUpdate.plist\"",
+                "/bin/bash -c /bin/launchctl load \"/Applications/AhnLab/ASTx/tmp/com.ahnlab.astx.astxUpdate.plist\"",
+                "/bin/bash -c /usr/sbin/chown -R root:wheel \"/Applications/AhnLab/ASTx/tmp/com.ahnlab.astx.astxUpdate.plist\"");
+
+        for (String cmdline : observed) {
+            assertThat(Rules.evaluate(List.of(), script("sh", cmdline, 3000)))
+                    .as(cmdline)
+                    .isEmpty();
+        }
+    }
+
+    @Test
+    @DisplayName("R3 양성: /private/tmp/ 는 macOS 의 진짜 시스템 임시 경로라 계속 잡는다 (실제 관측 사례)")
+    void r3_realSystemTempPath_stillAlerts() {
+        // 배포 서버에서 관측된 개발 도구 노이즈지만 룰이 의도대로 동작한 것이다.
+        // 여기를 빼면 공격자가 쓰는 바로 그 경로를 허용하게 된다.
+        List<String> observed = List.of(
+                "/bin/bash -c tsc --noEmit -p /private/tmp/claude-501/proj/scratchpad/tsconfig.check.json",
+                "/usr/bin/python3 - /private/tmp/claude-501/proj/scratchpad/typecheck/src/api/demo.ts");
+
+        for (String cmdline : observed) {
+            assertThat(Rules.evaluate(List.of(), script("sh", cmdline, 3000)))
+                    .as(cmdline)
+                    .isPresent()
+                    .get()
+                    .extracting(Alert::ruleId)
+                    .isEqualTo("SCRIPT_FROM_TEMP_PATH");
+        }
+    }
+
+    @Test
+    @DisplayName("R3 양성: 경로에 인용부호가 붙어 있어도 잡는다")
+    void r3_quotedTempPath_alerts() {
+        Event current = script("powershell.exe",
+                "powershell -File \"C:\\Users\\victim\\Downloads\\setup.ps1\"", 3000);
+
+        assertThat(Rules.evaluate(List.of(), current))
+                .isPresent()
+                .get()
+                .extracting(Alert::ruleId)
+                .isEqualTo("SCRIPT_FROM_TEMP_PATH");
+    }
+
+    @Test
+    @DisplayName("R2 음성: 앱 내부 tmp 폴더에서 실행된 것은 다운로드-실행이 아니다")
+    void r2_executeFromAppInternalTempFolder_noAlert() {
+        // R3 오탐과 같은 결함이다. R2 도 같은 경로 판정을 쓴다.
+        List<Event> buffer = List.of(network("203.0.113.9", 443, 1000));
+        Event current = processFrom("astxUpdate", "/Applications/AhnLab/ASTx/tmp/astxUpdate", 2000);
+
+        assertThat(Rules.evaluate(buffer, current)).isEmpty();
+    }
+
+    @Test
     @DisplayName("R4: 자동실행(시작프로그램) 경로에 파일 생성 → FILE_IN_AUTORUN_PATH(T1547, MEDIUM, notify)")
     void r4_fileInAutorunPath_alerts() {
         Event current = file("evil.lnk",
@@ -219,6 +281,35 @@ class RulesTest {
     @DisplayName("R4 음성: 파일이지만 일반 경로면 미판정")
     void r4_fileInNormalPath_noAlert() {
         Event current = file("report.docx", "C:\\Users\\victim\\Documents\\report.docx", 4000);
+
+        assertThat(Rules.evaluate(List.of(), current)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("R4 양성: macOS 실제 자동실행 경로(LaunchAgents)의 plist 는 잡는다")
+    void r4_realLaunchAgentPaths_alert() {
+        List<String> autorunPaths = List.of(
+                "/Library/LaunchAgents/com.evil.agent.plist",
+                "/System/Library/LaunchAgents/com.evil.agent.plist",
+                "/Users/victim/Library/LaunchAgents/com.evil.agent.plist");
+
+        for (String path : autorunPaths) {
+            assertThat(Rules.evaluate(List.of(), file("com.evil.agent.plist", path, 4000)))
+                    .as(path)
+                    .isPresent()
+                    .get()
+                    .extracting(Alert::ruleId)
+                    .isEqualTo("FILE_IN_AUTORUN_PATH");
+        }
+    }
+
+    @Test
+    @DisplayName("R4 음성: 앱 번들 안의 LaunchAgents 는 자동실행 경로가 아니다")
+    void r4_launchAgentsInsideAppBundle_noAlert() {
+        // 앱 번들은 자기 Contents/Library/LaunchAgents 에 plist 원본을 넣어 배포한다.
+        // 거기 파일이 생기는 것은 설치일 뿐이고, 실제 등록은 위 세 곳에 놓일 때 일어난다.
+        Event current = file("com.vendor.agent.plist",
+                "/Applications/Vendor.app/Contents/Library/LaunchAgents/com.vendor.agent.plist", 4000);
 
         assertThat(Rules.evaluate(List.of(), current)).isEmpty();
     }


### PR DESCRIPTION
프로덕션에서 발견된 두 건을 고친다. 둘 다 화면이 사실과 다른 것을 보여 주던 문제다.

## #173 열린 알림이 쌓인 기기가 "정상" 으로 뜨던 문제

열린 알림 54건짜리 맥북이 초록색 "정상" 인데 옆 칸 위험도는 100 이었다. 같은 데이터로 두 서버 값이 정반대를 말하면 어느 쪽도 믿을 수 없다.

상태 분류가 열린 CRITICAL/HIGH 의 유무만 보고 MEDIUM 을 인자로 받지도 않았다. 상태를 위험 점수의 함수로 만들어 두 값이 구조적으로 어긋날 수 없게 했다. 임계값은 점수 가중치 상수를 그대로 참조한다.

기존 의미는 유지된다. 열린 CRITICAL 1건이면 위험, HIGH 1건이면 주의. 달라지는 것은 누적된 경우뿐이다.

**프론트 영향**: `/api/hosts` 의 `status` 와 summary 건수가 바뀐다. MEDIUM 이 쌓인 기기가 초록에서 노랑·빨강으로 옮겨간다. 프론트는 이 변경 전후 양쪽에서 참인 문구로 이미 배포를 마쳤다.

## #174 앱 내부 tmp 폴더를 시스템 임시 경로로 오인하던 문제

R3 알림 42건이 전부 하나의 오탐이었다. AhnLab 보안제품이 자기 업데이트 plist 를 다루는 정상 동작이 `/Applications/AhnLab/ASTx/tmp/` 안의 `/tmp/` 조각에 걸렸다.

경로 표식을 부분 문자열로 찾은 것이 원인이다. 조각을 예외로 빼는 대신 경로 구조로 판정하도록 고쳤다. 같은 결함이 R2 와 R4 에도 있었다.

데모 정탐(`C:\Users\victim\Downloads\setup.ps1`)과 진짜 시스템 임시 경로 실행은 그대로 잡는다.

## 배포 후 확인

알림 재집계로 노이즈가 실제로 줄었는지 본다. 이 두 변경이 겹쳐서, 오탐이 빠지면 그 맥북의 위험도도 같이 내려간다.

```
SELECT rule_id, count() FROM edrdog.alerts FINAL GROUP BY rule_id ORDER BY 2 DESC
```

기존 알림은 재판정되지 않으므로 배포 직후에는 그대로 남는다. 새로 들어오는 것부터 달라진다.

## 검증

`./gradlew build --rerun-tasks` 통과. 두 PR 모두 실기기에서 관측한 값을 테스트 픽스처로 썼다.