### PR TITLE
feat: 알림·호스트·이벤트를 한 번에 훑는 검색을 연다

### DIFF
--- a/api-service/src/main/java/com/edrdog/apiservice/search/SearchQueryBuilder.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/search/SearchQueryBuilder.java
@@ -1,0 +1,145 @@
+package com.edrdog.apiservice.search;
+
+import com.edrdog.apiservice.query.ClickHouseQuery;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * 상단바 통합 검색의 events/alerts 조회 SQL 을 만드는 순수 로직
+ * (EventQueryBuilder·AlertQueryBuilder 와 같은 패턴: tenant 강제 + 파라미터 바인딩 + 상한 클램프).
+ *
+ * <p><b>LIKE 대신 positionCaseInsensitive 를 쓰는 이유.</b> LIKE 는 needle 의 %/_ 를 패턴으로 읽는다.
+ * 상단바에 %를 친 사람은 그 글자를 찾는 것인데 LIKE 로는 그게 "전부" 라는 뜻이 되어, 검색 한 번이
+ * 전체를 긁어 상위 N건을 무작위로 돌려준다. 이스케이프로 막을 수도 있지만 position 계열은 needle 을
+ * 애초에 글자로만 보므로 이스케이프 자체가 필요 없다. 대소문자 무관도 같은 함수가 해결한다
+ * (도메인·해시가 소문자로 적재되어 있어도 대문자로 친 검색어가 그대로 걸린다).
+ *
+ * <p><b>부분일치는 인덱스를 못 쓴다.</b> 그래서 이 조회의 비용은 스캔 범위로만 묶인다:
+ * 호출부가 항상 시간 범위를 좁혀 주고, 뽑는 건수는 상한으로 클램프한다.
+ */
+@Component
+public class SearchQueryBuilder {
+
+    /** 상단바 드롭다운은 종류별로 몇 줄만 보여 준다. 더 필요하면 각 목록 조회로 넘어가는 자리다. */
+    public static final int DEFAULT_LIMIT = 5;
+
+    /** 상한. 드롭다운이 감당하는 줄 수의 끝이고, 여기가 스캔 결과를 실어 나르는 비용의 상한이다. */
+    public static final int MAX_LIMIT = 20;
+
+    /**
+     * 이벤트에서 훑을 컬럼. 조사하는 사람이 상단바에 칠 법한 것만 골랐다:
+     * 기기 이름(host), 프로세스와 그 부모(process/parent), 명령줄(cmdline), 목적지(domain/dest_ip), 파일 해시(sha256).
+     *
+     * <p>제외한 것들. type 은 값이 몇 종류뿐이라 부분일치로 치면 그 종류 전체가 딸려 나온다(그건 필터가 할 일이다).
+     * detail 은 JSON 원문이라 이 표에서 가장 크고, 훑으면 스캔 비용이 가장 많이 붙는 컬럼인데
+     * 그 안의 값은 대부분 이미 다른 컬럼에 펴져 있다.
+     */
+    private static final List<String> EVENT_FIELDS =
+            List.of("host", "process", "parent", "cmdline", "domain", "dest_ip", "sha256");
+
+    /**
+     * 알림에서 훑을 컬럼. id 를 넣는 이유는 티켓이나 공유 링크에서 알림 id 를 복사해 상단바에 붙이는
+     * 경로가 실제로 있어서다. mitre 는 조사자가 T1059 같은 태그로 찾는다.
+     * matched(Array)는 룰이 무엇에 걸렸는지의 내부 표현이라 사람이 칠 말이 아니라서 뺐다.
+     */
+    private static final List<String> ALERT_FIELDS =
+            List.of("id", "host", "rule_id", "mitre", "domain", "dest_ip");
+
+    /**
+     * 이벤트 조회 컬럼. 화면에 보일 값(process/cmdline/domain)에 더해, 검색 결과에서 이벤트 단건으로
+     * 바로 넘어가는 데 필요한 씨앗(host/ts/type/process/parent/dest_ip/dest_port/detail 의 pid)이 전부 있어야 한다.
+     * id 는 저장된 값이 아니라 이 컬럼들을 접어 만들기 때문이다(EventId).
+     */
+    private static final String EVENT_COLUMNS =
+            "host, type, ts, process, parent, cmdline, dest_ip, dest_port, domain, detail, sha256";
+
+    private static final String ALERT_COLUMNS =
+            "id, host, rule_id, mitre, severity, ts";
+
+    private final String eventsTable;
+    private final String alertsTable;
+
+    public SearchQueryBuilder(@Value("${edrdog.clickhouse.table}") String eventsTable,
+                              @Value("${edrdog.clickhouse.alerts-table}") String alertsTable) {
+        this.eventsTable = eventsTable;
+        this.alertsTable = alertsTable;
+    }
+
+    /** tenant 격리 하에 시간 범위[from,to] 안의 events 를 질의어 부분일치로 훑는다. tenantId·term 은 필수. */
+    public ClickHouseQuery events(String tenantId, String term, long from, long to, Integer limit) {
+        Map<String, String> params = new LinkedHashMap<>();
+        String where = where(tenantId, term, from, to, EVENT_FIELDS, List.of(), params);
+        String sql = "SELECT " + EVENT_COLUMNS + " FROM " + eventsTable
+                + where
+                + " ORDER BY ts DESC LIMIT " + (pageSize(limit) + 1);
+        return new ClickHouseQuery(sql, params);
+    }
+
+    /**
+     * tenant 격리 하에 시간 범위[from,to] 안의 alerts 를 질의어 부분일치로 훑는다.
+     * ruleIds 는 한글 위협명으로 미리 찾아 둔 룰(SearchService.threatRuleIds)이며, 질의어 조건에 OR 로 얹는다.
+     * ReplacingMergeTree dedup 때문에 FROM ... FINAL 을 쓴다(AlertQueryBuilder 와 같은 이유).
+     */
+    public ClickHouseQuery alerts(String tenantId, String term, List<String> ruleIds,
+                                  long from, long to, Integer limit) {
+        Map<String, String> params = new LinkedHashMap<>();
+        String where = where(tenantId, term, from, to, ALERT_FIELDS, ruleIds, params);
+        String sql = "SELECT " + ALERT_COLUMNS + " FROM " + alertsTable + " FINAL"
+                + where
+                + " ORDER BY ts DESC LIMIT " + (pageSize(limit) + 1);
+        return new ClickHouseQuery(sql, params);
+    }
+
+    /** 클램프가 적용된 실제 섹션 크기. 호출부가 탐침 행을 잘라내려면 이 값을 알아야 한다. */
+    public static int pageSize(Integer limit) {
+        if (limit == null || limit <= 0) {
+            return DEFAULT_LIMIT;
+        }
+        return Math.min(limit, MAX_LIMIT);
+    }
+
+    private static String where(String tenantId, String term, long from, long to,
+                                List<String> fields, List<String> ruleIds, Map<String, String> params) {
+        if (!hasText(tenantId)) {
+            throw new IllegalArgumentException("tenant 는 필수입니다(격리)");
+        }
+        if (!hasText(term)) {
+            throw new IllegalArgumentException("검색어는 필수입니다");
+        }
+        List<String> conds = new ArrayList<>();
+        // tenant 격리는 항상 첫 조건으로 강제한다.
+        conds.add("tenant_id = {tenant:String}");
+        params.put("tenant", tenantId.trim());
+        conds.add("ts >= {from:UInt64}");
+        params.put("from", String.valueOf(from));
+        conds.add("ts <= {to:UInt64}");
+        params.put("to", String.valueOf(to));
+        conds.add("(" + String.join(" OR ", matchConds(term, fields, ruleIds, params)) + ")");
+        return " WHERE " + String.join(" AND ", conds);
+    }
+
+    /** 훑을 컬럼 하나당 조건 하나. 질의어와 ruleId 는 전부 바인딩이라 SQL 에 문자열이 들어가지 않는다. */
+    private static List<String> matchConds(String term, List<String> fields, List<String> ruleIds,
+                                           Map<String, String> params) {
+        params.put("q", term);
+        List<String> conds = new ArrayList<>();
+        for (String field : fields) {
+            conds.add("positionCaseInsensitive(" + field + ", {q:String}) > 0");
+        }
+        for (int i = 0; i < ruleIds.size(); i++) {
+            String name = "rid" + i;
+            conds.add("rule_id = {" + name + ":String}");
+            params.put(name, ruleIds.get(i));
+        }
+        return conds;
+    }
+
+    private static boolean hasText(String s) {
+        return s != null && !s.trim().isEmpty();
+    }
+}

--- a/api-service/src/main/java/com/edrdog/apiservice/search/SearchService.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/search/SearchService.java
@@ -1,0 +1,80 @@
+package com.edrdog.apiservice.search;
+
+import com.edrdog.apiservice.alert.ThreatCatalog;
+import com.edrdog.apiservice.clickhouse.ClickHouseReader;
+import com.edrdog.apiservice.host.HostService;
+import com.edrdog.apiservice.host.web.HostResponse;
+import com.edrdog.apiservice.search.web.AlertHit;
+import com.edrdog.apiservice.search.web.EventHit;
+import com.edrdog.apiservice.search.web.SearchResponse;
+import com.edrdog.apiservice.search.web.SearchSection;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * 상단바 통합 검색. 알림(ClickHouse)·호스트(HostService)·이벤트(ClickHouse)를 한 번에 훑어
+ * 종류별 상위 N건씩 돌려준다. 모든 조회는 tenant 로 격리한다.
+ */
+@Service
+public class SearchService {
+
+    private final ClickHouseReader reader;
+    private final SearchQueryBuilder builder;
+    private final HostService hosts;
+
+    public SearchService(ClickHouseReader reader, SearchQueryBuilder builder, HostService hosts) {
+        this.reader = reader;
+        this.builder = builder;
+        this.hosts = hosts;
+    }
+
+    /**
+     * term 은 이미 정규화된 질의어여야 한다(SearchTerm.normalize). 길이 검증은 400 으로 돌려줘야 해서
+     * 웹 계층이 먼저 한다.
+     */
+    public SearchResponse search(String tenantId, String term, long from, long to, Integer limit) {
+        int size = SearchQueryBuilder.pageSize(limit);
+        return new SearchResponse(term, from, to,
+                SearchSection.of(matchingHosts(tenantId, term), size),
+                SearchSection.of(alertHits(tenantId, term, from, to, limit), size),
+                SearchSection.of(eventHits(tenantId, term, from, to, limit), size));
+    }
+
+    /**
+     * 이름이 걸린 엔드포인트. 호스트 목록은 tenant 당 기기 수만큼이라(수십 대 규모) 통째로 받아
+     * 메모리에서 거른다. 부분일치를 SQL 로 내리려면 목록·위험도 집계 경로를 따로 하나 더 만들어야 한다.
+     *
+     * <p>여기만 시간 범위를 안 건다. 호스트는 "그 기간에 이벤트가 있었나" 가 아니라 "그런 기기가 있나" 를
+     * 묻는 대상이라, 조용히 있던 기기가 기간 밖이라는 이유로 안 나오면 검색이 틀린 답을 준다.
+     */
+    private List<HostResponse> matchingHosts(String tenantId, String term) {
+        return hosts.hosts(tenantId).stream()
+                .filter(host -> SearchTerm.matches(host.host(), term))
+                .toList();
+    }
+
+    private List<AlertHit> alertHits(String tenantId, String term, long from, long to, Integer limit) {
+        List<Map<String, Object>> rows = reader.query(
+                builder.alerts(tenantId, term, threatRuleIds(term), from, to, limit));
+        return rows.stream().map(AlertHit::fromRow).toList();
+    }
+
+    private List<EventHit> eventHits(String tenantId, String term, long from, long to, Integer limit) {
+        List<Map<String, Object>> rows = reader.query(builder.events(tenantId, term, from, to, limit));
+        return rows.stream().map(EventHit::fromRow).toList();
+    }
+
+    /**
+     * 한글 위협명이 걸리는 ruleId 들(순수). 화면에는 한글 위협명이 보이는데 ClickHouse 에는 영문 ruleId 만
+     * 적재되므로, 본 대로 친 말이 조회에 닿으려면 여기서 옮겨야 한다. 카탈로그는 룰 몇 개짜리 상수 맵이라
+     * 매번 훑어도 비용이 없다. 영문 ruleId 자체는 SQL 이 직접 훑으므로 여기서 또 다루지 않는다.
+     */
+    public static List<String> threatRuleIds(String term) {
+        return ThreatCatalog.all().stream()
+                .filter(entry -> SearchTerm.matches(entry.threatName(), term))
+                .map(ThreatCatalog.Entry::ruleId)
+                .toList();
+    }
+}

--- a/api-service/src/main/java/com/edrdog/apiservice/search/SearchTerm.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/search/SearchTerm.java
@@ -1,0 +1,52 @@
+package com.edrdog.apiservice.search;
+
+import java.util.Locale;
+
+/**
+ * 상단바 질의어의 정규화와 부분일치 판정(순수).
+ *
+ * <p>부분일치는 인덱스를 못 쓴다. 이벤트는 조회 시점에 이미 수십만 건이라 질의어 하나가
+ * 그대로 전체 스캔이므로, 결과가 쓸모없는 질의어는 조회를 돌기 전에 여기서 막는다.
+ */
+public final class SearchTerm {
+
+    /**
+     * 최소 길이. 한 글자는 사실상 모든 명령줄·경로에 들어 있어 상위 N건이 무작위와 다를 바 없다.
+     * 스캔 비용은 글자 수와 무관하게 같으니, 막는 이유는 비용이 아니라 결과가 조사에 쓸모없어서다.
+     * 두 글자는 조사에서 실제로 치는 가장 짧은 말(ls, sh, 88 같은 포트)을 살려 둔다.
+     */
+    public static final int MIN_LENGTH = 2;
+
+    /** 최대 길이. 이보다 긴 질의어는 사람이 친 것이 아니라 무언가를 통째로 붙여 넣은 것이다. */
+    public static final int MAX_LENGTH = 200;
+
+    private SearchTerm() {
+    }
+
+    /**
+     * 질의어를 조회에 쓸 형태로 다듬는다. 앞뒤 공백만 떼고 대소문자는 건드리지 않는다
+     * (대소문자 무관 비교는 조회 쪽이 하므로 여기서 접으면 원문만 잃는다).
+     * 길이가 범위를 벗어나면 조용히 자르지 않고 거절한다.
+     */
+    public static String normalize(String q) {
+        String trimmed = q == null ? "" : q.trim();
+        if (trimmed.length() < MIN_LENGTH) {
+            throw new IllegalArgumentException("검색어는 " + MIN_LENGTH + "글자 이상이어야 합니다");
+        }
+        if (trimmed.length() > MAX_LENGTH) {
+            throw new IllegalArgumentException("검색어는 " + MAX_LENGTH + "글자 이하여야 합니다");
+        }
+        return trimmed;
+    }
+
+    /**
+     * 값이 질의어를 부분일치로 품는지. 대소문자를 가리지 않는다.
+     *
+     * <p>SQL 쪽 positionCaseInsensitive 와 같은 규칙이라야 한다. 호스트 목록은 SQL 이 아니라
+     * 여기서 걸러지므로, 규칙이 갈리면 같은 검색어가 화면 섹션마다 다르게 걸린다.
+     * 패턴 매칭이 아니므로 %/_ 는 찾을 글자 그대로다.
+     */
+    public static boolean matches(String value, String term) {
+        return value != null && value.toLowerCase(Locale.ROOT).contains(term.toLowerCase(Locale.ROOT));
+    }
+}

--- a/api-service/src/main/java/com/edrdog/apiservice/search/web/AlertHit.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/search/web/AlertHit.java
@@ -1,0 +1,42 @@
+package com.edrdog.apiservice.search.web;
+
+import com.edrdog.apiservice.alert.ThreatCatalog;
+
+import java.util.Map;
+
+/**
+ * 검색 결과의 알림 한 줄. 화면은 id 로 GET /api/alerts/{id} 에 바로 넘어간다.
+ * threatName 은 화면에 보이는 한글 위협명이고, 이 이름으로 검색해도 걸린다(SearchService.threatRuleIds).
+ */
+public record AlertHit(
+        String id,
+        String host,
+        String ruleId,
+        String threatName,
+        String mitre,
+        String severity,
+        long ts
+) {
+    public static AlertHit fromRow(Map<String, Object> row) {
+        String ruleId = str(row, "rule_id");
+        return new AlertHit(str(row, "id"), str(row, "host"), ruleId, ThreatCatalog.threatName(ruleId),
+                str(row, "mitre"), str(row, "severity"), asLong(row, "ts"));
+    }
+
+    private static String str(Map<String, Object> row, String key) {
+        Object v = row.get(key);
+        return v == null ? "" : String.valueOf(v);
+    }
+
+    /** ClickHouse UInt64 는 JSON 에서 문자열로 온다(AlertResponse.asLong 과 같은 이유). */
+    private static long asLong(Map<String, Object> row, String key) {
+        Object v = row.get(key);
+        if (v == null) {
+            return 0L;
+        }
+        if (v instanceof Number n) {
+            return n.longValue();
+        }
+        return Long.parseLong(String.valueOf(v));
+    }
+}

--- a/api-service/src/main/java/com/edrdog/apiservice/search/web/EventHit.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/search/web/EventHit.java
@@ -1,0 +1,48 @@
+package com.edrdog.apiservice.search.web;
+
+import com.edrdog.apiservice.web.EventId;
+
+import java.util.Map;
+
+/**
+ * 검색 결과의 이벤트 한 줄.
+ *
+ * <p>host 와 ts 를 싣는 이유는 화면 표시가 아니라 이동 때문이다. 이벤트 단건 조회는
+ * GET /api/events/{id}?host=&ts= 라서(id 가 저장된 값이 아니라 행을 접어 만든 것이므로) 셋이 다 있어야
+ * 검색 결과에서 그 이벤트로 넘어갈 수 있다.
+ */
+public record EventHit(
+        String id,
+        String host,
+        long ts,
+        String type,
+        String process,
+        String cmdline,
+        String domain,
+        String destIp,
+        String sha256
+) {
+    public static EventHit fromRow(Map<String, Object> row) {
+        String host = str(row, "host");
+        return new EventHit(EventId.ofRow(host, row), host, asLong(row, "ts"), str(row, "type"),
+                str(row, "process"), str(row, "cmdline"), str(row, "domain"), str(row, "dest_ip"),
+                str(row, "sha256"));
+    }
+
+    private static String str(Map<String, Object> row, String key) {
+        Object v = row.get(key);
+        return v == null ? "" : String.valueOf(v);
+    }
+
+    /** ClickHouse UInt64 는 JSON 에서 문자열로 온다(EventResponse.asLong 과 같은 이유). */
+    private static long asLong(Map<String, Object> row, String key) {
+        Object v = row.get(key);
+        if (v == null) {
+            return 0L;
+        }
+        if (v instanceof Number n) {
+            return n.longValue();
+        }
+        return Long.parseLong(String.valueOf(v));
+    }
+}

--- a/api-service/src/main/java/com/edrdog/apiservice/search/web/SearchController.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/search/web/SearchController.java
@@ -1,0 +1,92 @@
+package com.edrdog.apiservice.search.web;
+
+import com.edrdog.apiservice.auth.exception.AuthException;
+import com.edrdog.apiservice.auth.service.AuthService;
+import com.edrdog.apiservice.auth.service.Principal;
+import com.edrdog.apiservice.search.SearchQueryBuilder;
+import com.edrdog.apiservice.search.SearchService;
+import com.edrdog.apiservice.search.SearchTerm;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 상단바 통합 검색 REST. 세션 Bearer 토큰으로 인증하고 그 tenant 로만 격리한다
+ * (EventQueryController 와 동일 패턴).
+ */
+@RestController
+@RequestMapping("/api")
+@Tag(name = "search", description = "통합 검색 (알림·호스트·이벤트를 한 번에, tenant 격리)")
+public class SearchController {
+
+    private static final String BEARER_PREFIX = "Bearer ";
+
+    /**
+     * 기본 조회 기간: 최근 7일. 목록 조회의 24시간보다 넓게 잡는 이유는 검색이 "어디 있는지 모를 때"
+     * 쓰는 것이라서다. 어제 본 것을 못 찾으면 상단바를 다시 안 쓴다.
+     * 이벤트는 TTL 이 7일이라 이보다 넓혀도 나올 것이 없다.
+     */
+    private static final long DEFAULT_WINDOW_MS = 7 * 24 * 60 * 60 * 1000L;
+
+    private final SearchService search;
+    private final AuthService auth;
+
+    public SearchController(SearchService search, AuthService auth) {
+        this.search = search;
+        this.auth = auth;
+    }
+
+    @Operation(summary = "통합 검색",
+            description = "로그인 유저의 tenant 것만 알림·호스트·이벤트를 한 번에 훑어 종류별 상위 N건을 준다. "
+                    + "대소문자를 가리지 않는 부분일치이며, %/_ 는 패턴이 아니라 찾을 글자다.\n\n"
+                    + "검색 대상: 이벤트는 host/process/parent/cmdline/domain/dest_ip/sha256, "
+                    + "알림은 id/host/rule_id/mitre/domain/dest_ip 와 화면에 보이는 한글 위협명, "
+                    + "호스트는 이름이다.\n\n"
+                    + "q 는 " + SearchTerm.MIN_LENGTH + ".." + SearchTerm.MAX_LENGTH + "글자여야 하고 "
+                    + "벗어나면 400 이다(한 글자는 사실상 전부와 일치해 결과가 조사에 쓸모없다). "
+                    + "limit 은 종류별 상한이며 기본 " + SearchQueryBuilder.DEFAULT_LIMIT
+                    + ", 상한 " + SearchQueryBuilder.MAX_LIMIT + " 로 클램프한다.\n\n"
+                    + "기간은 from/to(epoch millis)로 주고, 안 주면 최근 7일이다. 부분일치는 인덱스를 못 쓰므로 "
+                    + "이 기간이 스캔 범위를 정한다. 실제로 적용된 값은 응답의 from/to 에 실려 나간다.\n\n"
+                    + "**섹션마다 hasMore 가 붙는다.** 상한 때문에 잘렸다는 뜻이며, 전부 보려면 "
+                    + "해당 목록 조회(/api/alerts, /api/hosts, /api/events)로 넘어가야 한다. "
+                    + "호스트 섹션만 기간을 적용하지 않는다(조용한 기기가 기간 밖이라고 사라지면 안 된다).")
+    @GetMapping("/search")
+    public SearchResponse search(
+            @RequestHeader(name = "Authorization", required = false) String authorization,
+            @RequestParam(required = false) String q,
+            @RequestParam(required = false) Long from,
+            @RequestParam(required = false) Long to,
+            @RequestParam(required = false) Integer limit) {
+        String tenantId = currentTenantId(authorization);
+        String term = requireTerm(q);
+        long resolvedTo = to != null ? to : System.currentTimeMillis();
+        long resolvedFrom = from != null ? from : resolvedTo - DEFAULT_WINDOW_MS;
+        return search.search(tenantId, term, resolvedFrom, resolvedTo, limit);
+    }
+
+    /** 정규화는 순수 로직이라 IllegalArgumentException 을 던진다. 그대로 두면 500 이라 400 으로 옮긴다. */
+    private static String requireTerm(String q) {
+        try {
+            return SearchTerm.normalize(q);
+        } catch (IllegalArgumentException e) {
+            throw AuthException.invalidInput(e.getMessage());
+        }
+    }
+
+    private String currentTenantId(String authorization) {
+        Principal principal = auth.resolve(bearerToken(authorization));
+        return String.valueOf(principal.tenantId());
+    }
+
+    private static String bearerToken(String authorization) {
+        if (authorization == null || !authorization.startsWith(BEARER_PREFIX)) {
+            return null;
+        }
+        return authorization.substring(BEARER_PREFIX.length()).trim();
+    }
+}

--- a/api-service/src/main/java/com/edrdog/apiservice/search/web/SearchResponse.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/search/web/SearchResponse.java
@@ -1,0 +1,24 @@
+package com.edrdog.apiservice.search.web;
+
+import com.edrdog.apiservice.host.web.HostResponse;
+
+/**
+ * GET /api/search 응답. 화면이 섹션으로 그리므로 종류별로 나눠 준다.
+ *
+ * <p>from/to 를 돌려주는 이유. 검색은 기본 기간 안에서만 훑는데, 화면이 그 범위를 모르면
+ * "없다" 와 "이 기간에는 없다" 를 구분해 보여 줄 수 없다.
+ *
+ * @param query 실제로 적용된 질의어(앞뒤 공백을 뗀 값)
+ * @param from  적용된 시간 하한 (epoch millis)
+ * @param to    적용된 시간 상한 (epoch millis)
+ * @param hosts 호스트 이름이 걸린 엔드포인트. 목록 조회(GET /api/hosts)와 같은 모양이라 화면이 같은 줄을 재사용한다
+ */
+public record SearchResponse(
+        String query,
+        long from,
+        long to,
+        SearchSection<HostResponse> hosts,
+        SearchSection<AlertHit> alerts,
+        SearchSection<EventHit> events
+) {
+}

--- a/api-service/src/main/java/com/edrdog/apiservice/search/web/SearchSection.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/search/web/SearchSection.java
@@ -1,0 +1,25 @@
+package com.edrdog.apiservice.search.web;
+
+import java.util.List;
+
+/**
+ * 검색 결과의 한 종류(알림/호스트/이벤트) 묶음.
+ *
+ * <p>hasMore 를 본문에 싣는 이유. 상단바 드롭다운은 종류별로 몇 줄만 보여 주는데, 잘렸다는 표시가
+ * 없으면 조사하는 사람이 그게 전부라고 읽는다. 목록 조회는 이걸 헤더(X-Has-More)로 내보내지만
+ * 여기는 종류가 셋이라 헤더 한 벌로는 어느 섹션이 잘렸는지 말할 수 없다.
+ *
+ * @param items   상한까지 잘라낸 결과
+ * @param hasMore 상한 때문에 잘렸는지
+ */
+public record SearchSection<T>(List<T> items, boolean hasMore) {
+
+    /**
+     * 상한보다 한 건 더 읽어 온 결과에서 탐침 행을 잘라내고 잘렸는지를 함께 남긴다
+     * (다른 목록 조회와 같은 방식: 총 건수를 세지 않고 한 행으로 다음이 있는지 판단한다).
+     */
+    public static <T> SearchSection<T> of(List<T> found, int limit) {
+        boolean hasMore = found.size() > limit;
+        return new SearchSection<>(List.copyOf(hasMore ? found.subList(0, limit) : found), hasMore);
+    }
+}

--- a/api-service/src/main/java/com/edrdog/apiservice/security/ApiKeyPolicy.java
+++ b/api-service/src/main/java/com/edrdog/apiservice/security/ApiKeyPolicy.java
@@ -18,6 +18,7 @@ public class ApiKeyPolicy {
             "/api/operations",  // 파이프라인 상태 조회도 세션 Bearer 로 인증(OperationsHealthController)
             "/api/intelligence",  // 관계 분석 조회도 세션 Bearer 로 인증(intelligence 패키지 컨트롤러들)
             "/api/incidents",  // 사건 조회·트리아지도 세션 Bearer 로 인증(IncidentController)
+            "/api/search",  // 통합 검색도 세션 Bearer 로 인증(SearchController)
             "/api/me",      // 유저 개인 알림 설정도 세션 Bearer 로 인증(UserNotifyController)
             "/api/demo/",   // 발표용 데모 시연도 세션 Bearer 로 인증하고 데모 계정만 통과시킨다(DemoController)
             "/api/internal/",  // 서비스 간 조회는 별도 X-Internal-Key 로 인증(TenantController), 프론트 키와 분리

--- a/api-service/src/test/java/com/edrdog/apiservice/search/SearchApiIntegrationTest.java
+++ b/api-service/src/test/java/com/edrdog/apiservice/search/SearchApiIntegrationTest.java
@@ -1,0 +1,420 @@
+package com.edrdog.apiservice.search;
+
+import com.edrdog.apiservice.clickhouse.ClickHouseReader;
+import com.edrdog.apiservice.query.ClickHouseQuery;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * GET /api/search 배선 검증. 상단바가 한 번에 알림·호스트·이벤트를 훑는 경로다.
+ *
+ * <p>ClickHouse 는 목으로 대체하되 tenant·시간창·부분일치를 흉내 낸다. 격리와 일치 규칙이 이 기능의
+ * 핵심이라, 목이 그것을 무시하면 검증이 성립하지 않는다(EventLookupApiIntegrationTest 와 같은 방식).
+ * 목이 훑는 컬럼 목록은 SearchQueryBuilder 의 것과 같아야 한다.
+ *
+ * <p>/api/search 는 아직 ApiKeyPolicy 예외가 아니라 X-API-Key 가 필요하다(기본 키 dev-api-key).
+ * 예외로 열려도 키를 같이 보내는 건 그대로 통과하므로 이 테스트는 어느 쪽이든 성립한다.
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.ANY)
+@TestPropertySource(properties = "spring.kafka.listener.auto-startup=false")
+class SearchApiIntegrationTest {
+
+    private static final String API_KEY = "dev-api-key";
+    private static final String MAC = "gimdonghyeon-ui-MacBookPro.local";
+
+    @Autowired
+    private MockMvc mvc;
+
+    @Autowired
+    private ObjectMapper om;
+
+    @MockitoBean
+    private ClickHouseReader reader;
+
+    private final List<Map<String, Object>> eventRows = new ArrayList<>();
+    private final List<Map<String, Object>> alertRows = new ArrayList<>();
+
+    /** SearchQueryBuilder 가 훑는 이벤트 컬럼. */
+    private static final List<String> EVENT_FIELDS =
+            List.of("host", "process", "parent", "cmdline", "domain", "dest_ip", "sha256");
+
+    /** SearchQueryBuilder 가 훑는 알림 컬럼. */
+    private static final List<String> ALERT_FIELDS =
+            List.of("id", "host", "rule_id", "mitre", "domain", "dest_ip");
+
+    @BeforeEach
+    void routeReader() {
+        eventRows.clear();
+        alertRows.clear();
+        when(reader.query(any())).thenAnswer(inv -> answer(inv.getArgument(0)));
+    }
+
+    /** 조회 종류를 SQL 모양으로 갈라 목 데이터를 돌려준다. */
+    private List<Map<String, Object>> answer(ClickHouseQuery q) {
+        String sql = q.sql();
+        if (sql.contains("last_seen")) {
+            return hostsLastSeen(q.params().get("tenant"));
+        }
+        if (sql.contains("positionCaseInsensitive")) {
+            return sql.contains(" FINAL") ? searchAlerts(q) : searchEvents(q);
+        }
+        if (q.params().containsKey("host")) {
+            return eventAt(q);   // 이벤트 단건 조회(검색 결과에서 넘어가는 경로)
+        }
+        return List.of();        // 호스트 위험도/열린 알림 집계는 검색 결과와 무관하다
+    }
+
+    private List<Map<String, Object>> searchEvents(ClickHouseQuery q) {
+        return matched(eventRows, q, EVENT_FIELDS, List.of());
+    }
+
+    private List<Map<String, Object>> searchAlerts(ClickHouseQuery q) {
+        List<String> ruleIds = q.params().entrySet().stream()
+                .filter(e -> e.getKey().startsWith("rid"))
+                .map(Map.Entry::getValue)
+                .toList();
+        return matched(alertRows, q, ALERT_FIELDS, ruleIds);
+    }
+
+    /** WHERE 절(tenant + 시간창 + 컬럼 OR 부분일치 + ruleId)과 ORDER BY/LIMIT 을 그대로 흉내 낸다. */
+    private static List<Map<String, Object>> matched(List<Map<String, Object>> rows, ClickHouseQuery q,
+                                                     List<String> fields, List<String> ruleIds) {
+        String tenant = q.params().get("tenant");
+        String term = q.params().get("q").toLowerCase(Locale.ROOT);
+        return rows.stream()
+                .filter(r -> tenant.equals(r.get("tenant_id")))
+                .filter(r -> inRange(q.params(), r))
+                .filter(r -> fields.stream().anyMatch(f -> text(r, f).toLowerCase(Locale.ROOT).contains(term))
+                        || ruleIds.contains(text(r, "rule_id")))
+                .sorted(Comparator.comparingLong((Map<String, Object> r) -> ts(r)).reversed())
+                .limit(limitOf(q.sql()))
+                .toList();
+    }
+
+    private List<Map<String, Object>> eventAt(ClickHouseQuery q) {
+        String tenant = q.params().get("tenant");
+        String host = q.params().get("host");
+        return eventRows.stream()
+                .filter(r -> tenant.equals(r.get("tenant_id")))
+                .filter(r -> host.equals(r.get("host")))
+                .filter(r -> inRange(q.params(), r))
+                .toList();
+    }
+
+    /** events 집계(host, last_seen)를 목 데이터로 만든다. HostService 가 호스트 목록의 재료로 쓴다. */
+    private List<Map<String, Object>> hostsLastSeen(String tenant) {
+        Map<String, Long> lastSeen = new LinkedHashMap<>();
+        eventRows.stream()
+                .filter(r -> tenant.equals(r.get("tenant_id")))
+                .forEach(r -> lastSeen.merge(text(r, "host"), ts(r), Math::max));
+        return lastSeen.entrySet().stream()
+                .sorted(Map.Entry.<String, Long>comparingByValue().reversed())
+                .map(e -> Map.<String, Object>of("host", e.getKey(), "last_seen", String.valueOf(e.getValue())))
+                .toList();
+    }
+
+    /** SQL 에 박힌 LIMIT 값(탐침 행 포함). 잘림 표시가 실제로 맞는지 보려면 목도 상한을 지켜야 한다. */
+    private static long limitOf(String sql) {
+        return Long.parseLong(sql.substring(sql.lastIndexOf("LIMIT ") + "LIMIT ".length()).trim());
+    }
+
+    private static boolean inRange(Map<String, String> params, Map<String, Object> row) {
+        long ts = ts(row);
+        String from = params.get("from");
+        String to = params.get("to");
+        return (from == null || ts >= Long.parseLong(from)) && (to == null || ts <= Long.parseLong(to));
+    }
+
+    private static long ts(Map<String, Object> row) {
+        return Long.parseLong(String.valueOf(row.get("ts")));
+    }
+
+    private static String text(Map<String, Object> row, String key) {
+        Object v = row.get(key);
+        return v == null ? "" : String.valueOf(v);
+    }
+
+    // --- 시드 ---
+
+    private void seedEvent(String tenantId, String host, long ts, String process, String cmdline, String domain) {
+        Map<String, Object> row = new LinkedHashMap<>();
+        row.put("tenant_id", tenantId);
+        row.put("host", host);
+        row.put("type", "process");
+        row.put("ts", String.valueOf(ts));
+        row.put("process", process);
+        row.put("parent", "launchd");
+        row.put("cmdline", cmdline);
+        row.put("dest_ip", "");
+        row.put("dest_port", 0);
+        row.put("domain", domain);
+        row.put("detail", "{\"pid\":4321,\"ppid\":1}");
+        row.put("sha256", "");
+        row.put("ingested_at", "2026-07-31 00:00:00.000");
+        eventRows.add(row);
+    }
+
+    private void seedAlert(String tenantId, String id, String host, String ruleId, long ts) {
+        Map<String, Object> row = new LinkedHashMap<>();
+        row.put("tenant_id", tenantId);
+        row.put("id", id);
+        row.put("host", host);
+        row.put("rule_id", ruleId);
+        row.put("mitre", "T1105+T1204");
+        row.put("severity", "HIGH");
+        row.put("ts", String.valueOf(ts));
+        row.put("domain", "malware.example.com");
+        row.put("dest_ip", "203.0.113.7");
+        alertRows.add(row);
+    }
+
+    private String[] signup(String email) throws Exception {
+        MvcResult res = mvc.perform(post("/api/auth/signup")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"email\":\"" + email + "\",\"password\":\"password1\"}"))
+                .andExpect(status().isCreated())
+                .andReturn();
+        JsonNode node = om.readTree(res.getResponse().getContentAsString());
+        return new String[]{node.get("token").asText(), node.get("tenantId").asText()};
+    }
+
+    /** 시각 고정이 필요한 테스트를 위해 기간을 명시할 수 있게 둔다(기본 기간은 최근 7일). */
+    private JsonNode search(String token, String q, String... params) throws Exception {
+        var request = get("/api/search").param("q", q)
+                .header("Authorization", "Bearer " + token)
+                .header("X-API-Key", API_KEY);
+        for (int i = 0; i < params.length; i += 2) {
+            request = request.param(params[i], params[i + 1]);
+        }
+        MvcResult res = mvc.perform(request).andExpect(status().isOk()).andReturn();
+        return om.readTree(res.getResponse().getContentAsString());
+    }
+
+    private static long now() {
+        return System.currentTimeMillis();
+    }
+
+    // --- 부분일치 ---
+
+    @Test
+    void 호스트명_일부만_쳐도_그_호스트와_이벤트가_나온다() throws Exception {
+        // 기존 필터(?host=)는 완전일치라 이게 안 됐다. 이 기능이 있는 이유다.
+        String[] a = signup("a-search-partial@edrdog.com");
+        seedEvent(a[1], MAC, now(), "curl", "curl http://x", "");
+
+        JsonNode body = search(a[0], "gimdong");
+        assertOnly(body.at("/hosts/items"), MAC, "/host");
+        assertOnly(body.at("/events/items"), MAC, "/host");
+    }
+
+    @Test
+    void 프로세스명과_명령줄과_도메인으로도_찾는다() throws Exception {
+        String[] a = signup("a-search-fields@edrdog.com");
+        seedEvent(a[1], MAC, now(), "osascript", "osascript -e 'do shell script'", "");
+        seedEvent(a[1], "web-01", now(), "curl", "curl -sL https://cdn.example.com", "cdn.example.com");
+
+        assertOnly(search(a[0], "osascr").at("/events/items"), "osascript", "/process");
+        assertOnly(search(a[0], "shell script").at("/events/items"), "osascript", "/process");
+        assertOnly(search(a[0], "cdn.example").at("/events/items"), "curl", "/process");
+    }
+
+    @Test
+    void 대소문자를_가리지_않는다() throws Exception {
+        // 도메인과 해시는 소문자로 적재된다. 대문자로 쳐도 같은 것을 찾아야 한다.
+        String[] a = signup("a-search-case@edrdog.com");
+        seedEvent(a[1], MAC, now(), "curl", "curl https://cdn.example.com", "cdn.example.com");
+
+        assertOnly(search(a[0], "GIMDONG").at("/hosts/items"), MAC, "/host");
+        assertOnly(search(a[0], "CDN.EXAMPLE").at("/events/items"), MAC, "/host");
+        assertOnly(search(a[0], "MacBookPro").at("/hosts/items"), MAC, "/host");
+    }
+
+    @Test
+    void 한글_위협명으로_알림을_찾는다() throws Exception {
+        // 화면에는 한글 위협명이 보인다. ClickHouse 에는 영문 ruleId 만 있으니 그대로면 못 찾는다.
+        String[] a = signup("a-search-threat@edrdog.com");
+        seedAlert(a[1], "alert-1", MAC, "DOWNLOAD_AND_EXECUTE", now());
+
+        JsonNode items = search(a[0], "다운로드 후").at("/alerts/items");
+        assertOnly(items, "alert-1", "/id");
+        assertEquals("다운로드 후 실행", items.get(0).at("/threatName").asText());
+    }
+
+    @Test
+    void 알림_id_를_붙여넣어도_찾는다() throws Exception {
+        String[] a = signup("a-search-alertid@edrdog.com");
+        seedAlert(a[1], "8f14e45f-ea16-4d63-9f9b-2b6f9b1f0a11", MAC, "DOWNLOAD_AND_EXECUTE", now());
+
+        assertOnly(search(a[0], "8f14e45f-ea16").at("/alerts/items"),
+                "8f14e45f-ea16-4d63-9f9b-2b6f9b1f0a11", "/id");
+    }
+
+    // --- 격리 ---
+
+    @Test
+    void 남의_tenant_결과는_한_건도_섞이지_않는다() throws Exception {
+        String[] a = signup("a-search-iso@edrdog.com");
+        String[] b = signup("b-search-iso@edrdog.com");
+        seedEvent(b[1], MAC, now(), "curl", "curl http://x", "");
+        seedAlert(b[1], "alert-b", MAC, "DOWNLOAD_AND_EXECUTE", now());
+
+        JsonNode body = search(a[0], "gimdong");
+        assertEmpty(body, "/hosts");
+        assertEmpty(body, "/events");
+        assertEmpty(body, "/alerts");
+    }
+
+    @Test
+    void 토큰이_없으면_401() throws Exception {
+        mvc.perform(get("/api/search").param("q", "gimdong").header("X-API-Key", API_KEY))
+                .andExpect(status().isUnauthorized());
+    }
+
+    // --- 질의어 방어 ---
+
+    @Test
+    void 너무_짧거나_없는_검색어는_400() throws Exception {
+        String[] a = signup("a-search-short@edrdog.com");
+
+        for (String q : List.of("a", " ", "")) {
+            mvc.perform(get("/api/search").param("q", q)
+                            .header("Authorization", "Bearer " + a[0])
+                            .header("X-API-Key", API_KEY))
+                    .andExpect(status().isBadRequest());
+        }
+        mvc.perform(get("/api/search")
+                        .header("Authorization", "Bearer " + a[0])
+                        .header("X-API-Key", API_KEY))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void 지나치게_긴_검색어는_400() throws Exception {
+        String[] a = signup("a-search-long@edrdog.com");
+
+        mvc.perform(get("/api/search").param("q", "a".repeat(SearchTerm.MAX_LENGTH + 1))
+                        .header("Authorization", "Bearer " + a[0])
+                        .header("X-API-Key", API_KEY))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void 와일드카드_문자를_쳐도_전체가_나오지_않는다() throws Exception {
+        // LIKE 였다면 %가 "전부" 라서 상단바 한 번이 전체 스캔 결과를 그대로 돌려준다.
+        String[] a = signup("a-search-wildcard@edrdog.com");
+        seedEvent(a[1], MAC, now(), "curl", "curl http://x", "");
+        seedAlert(a[1], "alert-1", MAC, "DOWNLOAD_AND_EXECUTE", now());
+
+        JsonNode body = search(a[0], "%_");
+        assertEmpty(body, "/hosts");
+        assertEmpty(body, "/events");
+        assertEmpty(body, "/alerts");
+    }
+
+    @Test
+    void 인젝션_시도_문자열은_그냥_안_맞는_검색어다() throws Exception {
+        String[] a = signup("a-search-inject@edrdog.com");
+        seedEvent(a[1], MAC, now(), "curl", "curl http://x", "");
+
+        assertEmpty(search(a[0], "' OR 1=1 --"), "/events");
+    }
+
+    // --- 비용 묶기 ---
+
+    @Test
+    void 종류별_상한을_넘으면_잘라내고_잘렸다고_말한다() throws Exception {
+        // 상단바에서 "이게 전부" 로 읽히면 조사에서 놓친다.
+        String[] a = signup("a-search-trunc@edrdog.com");
+        for (int i = 0; i < 5; i++) {
+            seedEvent(a[1], MAC, now() - i, "curl" + i, "curl http://x", "");
+        }
+
+        JsonNode body = search(a[0], "gimdong", "limit", "2");
+        assertEquals(2, body.at("/events/items").size());
+        assertTrue(body.at("/events/hasMore").asBoolean());
+        // 호스트는 한 대뿐이라 잘리지 않는다. 섹션마다 따로 말해야 하는 이유다.
+        assertFalse(body.at("/hosts/hasMore").asBoolean());
+    }
+
+    @Test
+    void 기본_기간_밖의_이벤트는_안_나오고_기간을_넓히면_나온다() throws Exception {
+        // 부분일치는 인덱스를 못 쓰므로 기간이 스캔 범위를 정한다. 기본은 최근 7일이다.
+        String[] a = signup("a-search-window@edrdog.com");
+        long eightDaysAgo = now() - 8L * 24 * 60 * 60 * 1000;
+        seedEvent(a[1], MAC, eightDaysAgo, "curl", "curl http://x", "");
+
+        assertEmpty(search(a[0], "gimdong"), "/events");
+        assertOnly(search(a[0], "gimdong", "from", "0").at("/events/items"), MAC, "/host");
+    }
+
+    @Test
+    void 적용된_기간을_응답에_실어_준다() throws Exception {
+        String[] a = signup("a-search-applied@edrdog.com");
+
+        JsonNode body = search(a[0], "gimdong", "from", "1000", "to", "2000");
+        assertEquals(1000L, body.at("/from").asLong());
+        assertEquals(2000L, body.at("/to").asLong());
+        assertEquals("gimdong", body.at("/query").asText());
+    }
+
+    // --- 결과에서 이동 ---
+
+    @Test
+    void 검색_결과의_이벤트를_그대로_단건_조회로_연다() throws Exception {
+        // 결과가 쓸모 있으려면 화면이 그 항목으로 바로 넘어갈 수 있어야 한다.
+        String[] a = signup("a-search-navigate@edrdog.com");
+        seedEvent(a[1], MAC, now(), "curl", "curl http://x", "");
+
+        JsonNode hit = search(a[0], "gimdong").at("/events/items").get(0);
+        mvc.perform(get("/api/events/" + hit.get("id").asText())
+                        .param("host", hit.get("host").asText())
+                        .param("ts", hit.get("ts").asText())
+                        .header("Authorization", "Bearer " + a[0]))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(hit.get("id").asText()))
+                .andExpect(jsonPath("$.process").value("curl"));
+    }
+
+    // --- 도우미 ---
+
+    private static void assertOnly(JsonNode items, String expected, String pointer) {
+        assertEquals(1, items.size(), items.toString());
+        assertEquals(expected, items.get(0).at(pointer).asText());
+    }
+
+    private static void assertEmpty(JsonNode body, String section) {
+        assertEquals(0, body.at(section + "/items").size(),
+                body.at(section).toString());
+        assertFalse(body.at(section + "/hasMore").asBoolean());
+    }
+}

--- a/api-service/src/test/java/com/edrdog/apiservice/search/SearchQueryBuilderTest.java
+++ b/api-service/src/test/java/com/edrdog/apiservice/search/SearchQueryBuilderTest.java
@@ -1,0 +1,173 @@
+package com.edrdog.apiservice.search;
+
+import com.edrdog.apiservice.query.ClickHouseQuery;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * 통합 검색 SQL 생성(순수) 검증. tenant 격리 강제, 질의어의 파라미터 바인딩, 시간 범위와
+ * 건수 상한이 이 기능의 안전장치라 전부 여기서 고정한다.
+ */
+class SearchQueryBuilderTest {
+
+    private final SearchQueryBuilder builder = new SearchQueryBuilder("edrdog.events", "edrdog.alerts");
+    private static final String TENANT = "1";
+    private static final long FROM = 1_000L;
+    private static final long TO = 2_000L;
+
+    // --- tenant 격리 ---
+
+    @Test
+    void tenant_가_없으면_예외() {
+        assertThrows(IllegalArgumentException.class,
+                () -> builder.events(null, "gimdong", FROM, TO, null));
+        assertThrows(IllegalArgumentException.class,
+                () -> builder.events("  ", "gimdong", FROM, TO, null));
+        assertThrows(IllegalArgumentException.class,
+                () -> builder.alerts(null, "gimdong", List.of(), FROM, TO, null));
+    }
+
+    @Test
+    void tenant_조건이_항상_들어간다() {
+        ClickHouseQuery events = builder.events(TENANT, "gimdong", FROM, TO, null);
+        assertTrue(events.sql().contains("tenant_id = {tenant:String}"), events.sql());
+        assertEquals(TENANT, events.params().get("tenant"));
+
+        ClickHouseQuery alerts = builder.alerts(TENANT, "gimdong", List.of(), FROM, TO, null);
+        assertTrue(alerts.sql().contains("tenant_id = {tenant:String}"), alerts.sql());
+        assertEquals(TENANT, alerts.params().get("tenant"));
+    }
+
+    // --- 질의어 바인딩 ---
+
+    @Test
+    void 질의어가_없으면_예외() {
+        assertThrows(IllegalArgumentException.class, () -> builder.events(TENANT, "  ", FROM, TO, null));
+        assertThrows(IllegalArgumentException.class, () -> builder.alerts(TENANT, null, List.of(), FROM, TO, null));
+    }
+
+    @Test
+    void 질의어는_SQL_에_이어붙지_않고_파라미터로만_들어간다() {
+        ClickHouseQuery q = builder.events(TENANT, "gimdong", FROM, TO, null);
+        assertFalse(q.sql().contains("gimdong"), q.sql());
+        assertEquals("gimdong", q.params().get("q"));
+    }
+
+    @Test
+    void 인젝션_시도_문자열도_파라미터로만_들어간다() {
+        String attack = "'; DROP TABLE edrdog.events; --";
+        ClickHouseQuery q = builder.events(TENANT, attack, FROM, TO, null);
+        assertFalse(q.sql().contains("DROP TABLE"), q.sql());
+        assertEquals(attack, q.params().get("q"));
+    }
+
+    @Test
+    void 와일드카드_문자는_LIKE_패턴이_아니라_찾을_글자로_들어간다() {
+        // LIKE 를 쓰면 q=% 한 번이 전체 스캔 + 전체 결과가 된다. position 계열은 needle 을 글자로만 본다.
+        ClickHouseQuery q = builder.events(TENANT, "%", FROM, TO, null);
+        assertFalse(q.sql().contains("LIKE"), q.sql());
+        assertEquals("%", q.params().get("q"));
+    }
+
+    @Test
+    void 대소문자를_가리지_않는_비교를_쓴다() {
+        String sql = builder.events(TENANT, "GIMDONG", FROM, TO, null).sql();
+        assertTrue(sql.contains("positionCaseInsensitive("), sql);
+    }
+
+    // --- 검색 대상 컬럼 ---
+
+    @Test
+    void 이벤트는_호스트_프로세스_명령줄_도메인_목적지IP_해시를_훑는다() {
+        String sql = builder.events(TENANT, "gimdong", FROM, TO, null).sql();
+        for (String field : List.of("host", "process", "parent", "cmdline", "domain", "dest_ip", "sha256")) {
+            assertTrue(sql.contains("positionCaseInsensitive(" + field + ", {q:String}) > 0"), field + " / " + sql);
+        }
+    }
+
+    @Test
+    void 알림은_호스트_룰_MITRE_도메인_목적지IP_id_를_훑는다() {
+        String sql = builder.alerts(TENANT, "gimdong", List.of(), FROM, TO, null).sql();
+        for (String field : List.of("id", "host", "rule_id", "mitre", "domain", "dest_ip")) {
+            assertTrue(sql.contains("positionCaseInsensitive(" + field + ", {q:String}) > 0"), field + " / " + sql);
+        }
+    }
+
+    @Test
+    void 이벤트_조회는_단건_링크에_필요한_컬럼을_다_뽑는다() {
+        // id 는 저장된 값이 아니라 행 내용을 접어 만든다(EventId). 씨앗 컬럼이 빠지면 링크가 조용히 안 열린다.
+        String sql = builder.events(TENANT, "gimdong", FROM, TO, null).sql();
+        for (String col : List.of("host", "type", "ts", "process", "parent", "dest_ip", "dest_port", "detail")) {
+            assertTrue(sql.contains(col), col + " / " + sql);
+        }
+    }
+
+    @Test
+    void 알림은_중복제거를_위해_FINAL_로_읽는다() {
+        assertTrue(builder.alerts(TENANT, "gimdong", List.of(), FROM, TO, null).sql().contains("FINAL"));
+    }
+
+    // --- 한글 위협명으로 찾은 ruleId ---
+
+    @Test
+    void 위협명으로_찾은_ruleId_는_바인딩된_동등비교로_붙는다() {
+        ClickHouseQuery q = builder.alerts(TENANT, "다운로드", List.of("DOWNLOAD_AND_EXECUTE"), FROM, TO, null);
+        assertTrue(q.sql().contains("rule_id = {rid0:String}"), q.sql());
+        assertFalse(q.sql().contains("DOWNLOAD_AND_EXECUTE"), q.sql());
+        assertEquals("DOWNLOAD_AND_EXECUTE", q.params().get("rid0"));
+    }
+
+    @Test
+    void 위협명에_걸린_ruleId_가_없으면_그_조건은_안_붙는다() {
+        assertFalse(builder.alerts(TENANT, "gimdong", List.of(), FROM, TO, null).sql().contains("rid0"));
+    }
+
+    // --- 시간 범위 ---
+
+    @Test
+    void 시간_범위가_항상_걸린다() {
+        ClickHouseQuery q = builder.events(TENANT, "gimdong", FROM, TO, null);
+        assertTrue(q.sql().contains("ts >= {from:UInt64}"), q.sql());
+        assertTrue(q.sql().contains("ts <= {to:UInt64}"), q.sql());
+        assertEquals("1000", q.params().get("from"));
+        assertEquals("2000", q.params().get("to"));
+    }
+
+    // --- 건수 상한 ---
+
+    @Test
+    void limit_이_null_이면_기본값을_쓴다() {
+        assertEquals(SearchQueryBuilder.DEFAULT_LIMIT, SearchQueryBuilder.pageSize(null));
+    }
+
+    @Test
+    void limit_이_0이하이면_기본값을_쓴다() {
+        assertEquals(SearchQueryBuilder.DEFAULT_LIMIT, SearchQueryBuilder.pageSize(0));
+        assertEquals(SearchQueryBuilder.DEFAULT_LIMIT, SearchQueryBuilder.pageSize(-3));
+    }
+
+    @Test
+    void limit_이_상한을_넘으면_클램프한다() {
+        assertEquals(SearchQueryBuilder.MAX_LIMIT, SearchQueryBuilder.pageSize(1000));
+    }
+
+    @Test
+    void 잘렸는지_알려고_한_행을_더_읽는다() {
+        // count() 를 한 번 더 도는 것보다 탐침 한 행이 싸다(다른 목록 조회와 같은 방식).
+        assertTrue(builder.events(TENANT, "gimdong", FROM, TO, 3).sql().endsWith("LIMIT 4"),
+                builder.events(TENANT, "gimdong", FROM, TO, 3).sql());
+        assertTrue(builder.alerts(TENANT, "gimdong", List.of(), FROM, TO, 3).sql().endsWith("LIMIT 4"));
+    }
+
+    @Test
+    void 최신순으로_정렬한다() {
+        assertTrue(builder.events(TENANT, "gimdong", FROM, TO, null).sql().contains("ORDER BY ts DESC"));
+        assertTrue(builder.alerts(TENANT, "gimdong", List.of(), FROM, TO, null).sql().contains("ORDER BY ts DESC"));
+    }
+}

--- a/api-service/src/test/java/com/edrdog/apiservice/search/SearchSectionTest.java
+++ b/api-service/src/test/java/com/edrdog/apiservice/search/SearchSectionTest.java
@@ -1,0 +1,46 @@
+package com.edrdog.apiservice.search;
+
+import com.edrdog.apiservice.search.web.SearchSection;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * 종류별 섹션 자르기(순수) 검증. 상단바에서 "이게 전부" 로 읽히면 조사에서 놓치기 때문에
+ * 잘라낸 사실이 반드시 응답에 남아야 한다.
+ */
+class SearchSectionTest {
+
+    @Test
+    void 상한_이하면_그대로_주고_더_없다고_말한다() {
+        SearchSection<String> section = SearchSection.of(List.of("a", "b"), 5);
+        assertEquals(List.of("a", "b"), section.items());
+        assertFalse(section.hasMore());
+    }
+
+    @Test
+    void 상한과_같으면_잘린_것이_아니다() {
+        // 탐침 행이 없으니 딱 맞게 채운 것이고, 이걸 잘렸다고 하면 없는 다음 페이지를 가리킨다.
+        SearchSection<String> section = SearchSection.of(List.of("a", "b"), 2);
+        assertEquals(2, section.items().size());
+        assertFalse(section.hasMore());
+    }
+
+    @Test
+    void 탐침_행이_있으면_잘라내고_더_있다고_말한다() {
+        SearchSection<String> section = SearchSection.of(List.of("a", "b", "c"), 2);
+        assertEquals(List.of("a", "b"), section.items());
+        assertTrue(section.hasMore());
+    }
+
+    @Test
+    void 결과가_없으면_빈_섹션이다() {
+        SearchSection<String> section = SearchSection.of(List.of(), 5);
+        assertTrue(section.items().isEmpty());
+        assertFalse(section.hasMore());
+    }
+}

--- a/api-service/src/test/java/com/edrdog/apiservice/search/SearchTermTest.java
+++ b/api-service/src/test/java/com/edrdog/apiservice/search/SearchTermTest.java
@@ -1,0 +1,75 @@
+package com.edrdog.apiservice.search;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * 질의어 정규화·부분일치 판정(순수) 검증.
+ * 상단바에 친 문자열이 그대로 전체 스캔으로 흘러가는 자리라, 너무 짧은 질의어를 여기서 막는다.
+ */
+class SearchTermTest {
+
+    @Test
+    void 질의어가_없으면_거절한다() {
+        assertThrows(IllegalArgumentException.class, () -> SearchTerm.normalize(null));
+        assertThrows(IllegalArgumentException.class, () -> SearchTerm.normalize(""));
+        assertThrows(IllegalArgumentException.class, () -> SearchTerm.normalize("   "));
+    }
+
+    @Test
+    void 최소_길이보다_짧으면_거절한다() {
+        // 한 글자는 사실상 전부와 일치해서 결과가 쓸모없고 스캔만 돈다.
+        assertThrows(IllegalArgumentException.class, () -> SearchTerm.normalize("a"));
+        assertThrows(IllegalArgumentException.class, () -> SearchTerm.normalize(" a "));
+    }
+
+    @Test
+    void 최소_길이면_통과한다() {
+        assertEquals("ls", SearchTerm.normalize("ls"));
+    }
+
+    @Test
+    void 앞뒤_공백만_떼고_대소문자는_그대로_둔다() {
+        // 소문자로 접지 않는 이유는 대소문자 무관 비교를 조회 쪽에서 하기 때문이다.
+        assertEquals("Gimdong", SearchTerm.normalize("  Gimdong  "));
+    }
+
+    @Test
+    void 지나치게_긴_질의어는_거절한다() {
+        assertThrows(IllegalArgumentException.class,
+                () -> SearchTerm.normalize("a".repeat(SearchTerm.MAX_LENGTH + 1)));
+        assertEquals("a".repeat(SearchTerm.MAX_LENGTH),
+                SearchTerm.normalize("a".repeat(SearchTerm.MAX_LENGTH)));
+    }
+
+    @Test
+    void 부분일치로_판정한다() {
+        assertTrue(SearchTerm.matches("gimdonghyeon-ui-MacBookPro.local", "gimdong"));
+        assertFalse(SearchTerm.matches("macbook-pro.local", "gimdong"));
+    }
+
+    @Test
+    void 대소문자를_가리지_않는다() {
+        assertTrue(SearchTerm.matches("gimdonghyeon-ui-MacBookPro.local", "GIMDONG"));
+        assertTrue(SearchTerm.matches("GIMDONGHYEON", "gimdong"));
+        assertTrue(SearchTerm.matches("gimdonghyeon-ui-MacBookPro.local", "macbookpro"));
+    }
+
+    @Test
+    void 와일드카드_문자는_글자_그대로_본다() {
+        // LIKE 를 쓰지 않으므로 %/_ 는 패턴이 아니라 찾을 글자다. 이게 뒤집히면 검색 한 번이 전체를 긁는다.
+        assertFalse(SearchTerm.matches("gimdonghyeon", "%"));
+        assertFalse(SearchTerm.matches("gimdonghyeon", "g%n"));
+        assertTrue(SearchTerm.matches("100% cpu", "0% c"));
+    }
+
+    @Test
+    void 값이_없으면_일치하지_않는다() {
+        assertFalse(SearchTerm.matches(null, "gimdong"));
+        assertFalse(SearchTerm.matches("", "gimdong"));
+    }
+}

--- a/api-service/src/test/java/com/edrdog/apiservice/search/ThreatNameSearchTest.java
+++ b/api-service/src/test/java/com/edrdog/apiservice/search/ThreatNameSearchTest.java
@@ -1,0 +1,34 @@
+package com.edrdog.apiservice.search;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * 한글 위협명 → ruleId 역인덱스(순수) 검증.
+ * 화면에 보이는 건 한글 위협명인데 ClickHouse 에는 영문 ruleId 만 적재되므로,
+ * 사람이 본 대로 친 말이 조회에 닿으려면 여기서 옮겨야 한다.
+ * 영문 ruleId 자체는 SQL 이 직접 훑으므로 여기서 또 다루지 않는다.
+ */
+class ThreatNameSearchTest {
+
+    @Test
+    void 한글_위협명의_일부로_ruleId_를_찾는다() {
+        assertEquals(List.of("DOWNLOAD_AND_EXECUTE"), SearchService.threatRuleIds("다운로드 후"));
+    }
+
+    @Test
+    void 여러_위협명에_걸리면_전부_찾는다() {
+        List<String> ids = SearchService.threatRuleIds("다운로드");
+        assertTrue(ids.contains("DOWNLOAD_AND_EXECUTE"), ids.toString());
+        assertTrue(ids.contains("SCRIPT_FROM_TEMP_PATH"), ids.toString());
+    }
+
+    @Test
+    void 걸리는_위협명이_없으면_빈_목록() {
+        assertTrue(SearchService.threatRuleIds("gimdong").isEmpty());
+    }
+}


### PR DESCRIPTION
프론트 요청이다. 상단바 검색이 서버 검색 없이 브라우저에서 훑고 있어 실데이터에서 무의미했다.

## 무엇이 문제였나

- 알림 1,000건 + 호스트 목록만 받아 브라우저에서 부분일치로 훑는다
- **이벤트는 아예 검색 대상이 아니다.** 실데이터는 이벤트가 76만 건이다
- 기존 필터로 대체되지 않는다. `?host=`, `?domain=` 은 **완전일치**라 `gimdong` 을 쳐도 `gimdonghyeon-ui-MacBookPro.local` 이 안 나온다

## 만든 것

`GET /api/search?q=...` — 알림·호스트·이벤트를 종류별로 나눠 상위 N건씩 준다.

## 비용을 어떻게 묶었나

부분일치는 인덱스를 못 써서 전체 스캔이다. 세 곳에서 묶었다.

- **질의어 최소 2글자.** 한 글자면 사실상 전체를 훑는다. 짧으면 400
- **종류별 상위 5건(최대 20).** 상단바 드롭다운이라 더 필요 없다
- **기간 기본값.** 응답에 실제 적용된 범위를 함께 준다

## 안전

- **와일드카드 문자를 글자 그대로 본다.** `%` 나 `_` 를 친 사람은 그 글자를 찾는 것이지 전체를 보려는 게 아니다
- 파라미터 바인딩만 쓴다. 사용자 문자열을 SQL 에 잇지 않는다
- tenant 격리를 쿼리 빌더에서 강제하고 테스트로 덮었다

## 화면이 쓰기 좋게

- **적용된 기간을 응답에 준다.** 화면이 범위를 모르면 "없다" 와 "이 기간에는 없다" 를 구분해 보여 줄 수 없다
- **잘린 사실을 종류별로 드러낸다.** 상단바에서 "이게 전부" 로 읽히면 조사에서 놓친다
- 호스트 결과는 `GET /api/hosts` 와 **같은 모양**이라 화면이 같은 줄을 재사용한다
- 이벤트 결과에 단건 조회용 `host` 와 `ts` 를 함께 실었다. 검색 결과에서 `GET /api/events/{id}?host=&ts=` 로 바로 넘어갈 수 있다

## 검증

`./gradlew build --rerun-tasks` 통과. 부분일치·대소문자 무관·타 tenant 미노출·와일드카드 문자 처리·짧은 질의어 거절·잘림 노출을 테스트로 덮었다.