### PR TITLE
fix: Job 내용이 바뀌면 배포가 통째로 멈추던 문제

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -181,7 +181,18 @@ jobs:
           for f in $(git -C ~/Backend ls-tree --name-only FETCH_HEAD k8s/ | grep '\.yaml$'); do
           case "$(basename "$f" .yaml)" in *-service|kind-cluster|infisical) continue ;; esac
           echo "apply $f" >&2
-          APPLIED=$(git -C ~/Backend show "FETCH_HEAD:$f" | sudo kubectl apply -f - -o name)
+          MANIFEST=$(git -C ~/Backend show "FETCH_HEAD:$f")
+          # Job 은 spec.template 이 immutable 이라 내용이 바뀌면 apply 가 "field is immutable" 로 죽는다.
+          # 그러면 set -e 때문에 뒤따르는 mysql apply 와 서비스 롤링까지 통째로 안 돈다(실제로 토픽 생성
+          # Job 에서 events-raw 줄을 지웠을 때 배포가 여기서 멈췄다). 여기 있는 Job 은 부트스트랩용이라
+          # 다시 돌려도 안전하므로 지우고 새로 만든다. --dry-run=client 로는 안 잡힌다(서버의 기존
+          # 오브젝트와 대조하지 않는다). 파일 목록을 따로 적지 않는 이유는 위 apply 규칙과 같다.
+          EXISTING_JOBS=$(echo "$MANIFEST" | sudo kubectl get -f - -o name 2>/dev/null | grep '^job\.batch/' || true)
+          if [ -n "$EXISTING_JOBS" ]; then
+          echo "$EXISTING_JOBS 을(를) 지우고 다시 만든다 (Job 은 수정 불가)" >&2
+          echo "$EXISTING_JOBS" | xargs sudo kubectl -n "$NS" delete --ignore-not-found
+          fi
+          APPLIED=$(echo "$MANIFEST" | sudo kubectl apply -f - -o name)
           echo "$APPLIED" >&2
           INFRA_DEPLOYS="$INFRA_DEPLOYS $(echo "$APPLIED" | grep '^deployment' || true)"
           done


### PR DESCRIPTION
#186 배포 실패 수습.

## 무엇이 터졌나

`kafka-topic-init` Job 에서 `events-raw` 생성 줄을 지웠더니 apply 가 이렇게 죽었다.

```
The Job "kafka-topic-init" is invalid: spec.template: ... field is immutable
```

쿠버네티스 Job 은 `spec.template` 을 고칠 수 없다. 새로 만들어야 한다.

## 왜 배포 전체가 멈췄나

apply 루프가 `set -e` 아래에 있어서 이 한 줄이 죽자 뒤가 전부 안 돌았다. `k8s/mysql.yaml` apply 도,
서비스 롤링도 시작조차 못 했다. 인프라 매니페스트 절반만 들어간 채로 배포가 끝났다.

**서비스 장애는 없다.** 앱이 예전 이미지 그대로 돌고 있어 api-service 가 아직 수집 입구다.
배포만 안 된 상태다.

## 고침

apply 전에 같은 이름의 Job 이 서버에 있으면 지우고 새로 만든다. 여기 있는 Job 은 토픽 생성과
스키마 생성처럼 다시 돌려도 안전한 부트스트랩용이라 지워도 잃을 상태가 없다.

Job 이 든 파일을 목록으로 적지 않았다. 목록을 적으면 다음에 Job 을 추가한 사람이 여기를 같이 못
고치고 그때 또 배포가 멈춘다. 기존 apply 규칙이 목록을 안 적는 이유와 같다.

## 왜 미리 못 잡았나

`kubectl apply --dry-run=client` 로 검증했는데 이건 서버의 기존 오브젝트와 대조하지 않는다.
매니페스트 문법만 본다. `--dry-run=server` 였으면 잡혔다.

## 검증

- 원격 스크립트 `bash -n` 문법 통과
- 워크플로 YAML 파싱 통과
- 실제 동작은 이 PR 이 main 에 들어가 CD 가 돌아야 확인된다