### PR TITLE
release: Job immutable 로 멈춘 배포 수습 (#184)

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -181,7 +181,18 @@ jobs:
           for f in $(git -C ~/Backend ls-tree --name-only FETCH_HEAD k8s/ | grep '\.yaml$'); do
           case "$(basename "$f" .yaml)" in *-service|kind-cluster|infisical) continue ;; esac
           echo "apply $f" >&2
-          APPLIED=$(git -C ~/Backend show "FETCH_HEAD:$f" | sudo kubectl apply -f - -o name)
+          MANIFEST=$(git -C ~/Backend show "FETCH_HEAD:$f")
+          # Job 은 spec.template 이 immutable 이라 내용이 바뀌면 apply 가 "field is immutable" 로 죽는다.
+          # 그러면 set -e 때문에 뒤따르는 mysql apply 와 서비스 롤링까지 통째로 안 돈다(실제로 토픽 생성
+          # Job 에서 events-raw 줄을 지웠을 때 배포가 여기서 멈췄다). 여기 있는 Job 은 부트스트랩용이라
+          # 다시 돌려도 안전하므로 지우고 새로 만든다. --dry-run=client 로는 안 잡힌다(서버의 기존
+          # 오브젝트와 대조하지 않는다). 파일 목록을 따로 적지 않는 이유는 위 apply 규칙과 같다.
+          EXISTING_JOBS=$(echo "$MANIFEST" | sudo kubectl get -f - -o name 2>/dev/null | grep '^job\.batch/' || true)
+          if [ -n "$EXISTING_JOBS" ]; then
+          echo "$EXISTING_JOBS 을(를) 지우고 다시 만든다 (Job 은 수정 불가)" >&2
+          echo "$EXISTING_JOBS" | xargs sudo kubectl -n "$NS" delete --ignore-not-found
+          fi
+          APPLIED=$(echo "$MANIFEST" | sudo kubectl apply -f - -o name)
           echo "$APPLIED" >&2
           INFRA_DEPLOYS="$INFRA_DEPLOYS $(echo "$APPLIED" | grep '^deployment' || true)"
           done


### PR DESCRIPTION
#186 배포 실패 수습. #187 이 들어간다.

## 무엇이 터졌나

`kafka-topic-init` Job 에서 `events-raw` 생성 줄을 지웠더니 apply 가 죽었다.

```
The Job "kafka-topic-init" is invalid: spec.template: ... field is immutable
```

apply 루프가 `set -e` 아래라 이 한 줄이 죽자 뒤가 전부 안 돌았다. `k8s/mysql.yaml` apply 도,
서비스 롤링도 시작조차 못 했다. **그래서 #186 의 코드 변경은 아직 배포되지 않았다.**

서비스 장애는 없었다. 앱이 예전 이미지 그대로 돌고 있어 api-service 가 아직 수집 입구다.

## 고침

apply 전에 같은 이름의 Job 이 서버에 있으면 지우고 새로 만든다. 토픽 생성과 스키마 생성처럼
다시 돌려도 안전한 부트스트랩 Job 이라 지워도 잃을 상태가 없다.

`--dry-run=client` 로는 이걸 못 잡는다. 서버의 기존 오브젝트와 대조하지 않기 때문이다.

## 이 머지로 실제 일어나는 일

#186 이 못 한 배포가 이번에 처음 돈다. 아래가 한 번에 적용된다.

1. `kafka-topic-init` 재생성 (events-raw 토픽 생성 제외)
2. `mysql-schema-init` Job 신규 생성 → `edrdog_collector` 스키마
3. 6개 서비스 롤링 → 수집 입구가 collector 로 이동
4. NodePort 30443 이 api-service 에서 collector 로 이동

## 배포 후 확인

```
kubectl -n edrdog logs job/mysql-schema-init
kubectl -n edrdog get svc collector-service-agent
kubectl -n edrdog get pods
```

`mysql-schema-init` 이 실패하면 collector 가 기동하지 못해 수집이 멈춘다.

기존 에이전트는 401 을 받고 자동으로 다시 enroll 한다. 그 사이 호스트 목록에서 등록 기기가
잠깐 비어 보일 수 있다. 이벤트가 있는 호스트는 ClickHouse 로 계속 보인다.