### PR TITLE
fix: 레포에서 뺀 Service 가 서버에 남아 NodePort 를 붙들던 문제

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -242,6 +242,16 @@ jobs:
           # 이미지 태그는 매니페스트의 placeholder 를 쓰지 않고 여기서 끼워 넣는다.
           #   이번에 구운 모듈  -> :$SHA
           #   안 구운 모듈      -> 지금 떠 있는 태그 그대로 (그 :$SHA 이미지는 아예 없다)
+
+          # 레포에서 없앤 리소스는 여기 적어야 서버에서도 사라진다. apply 는 매니페스트에 없는 것을
+          # 지우지 않아서, 그냥 두면 서버에만 유령으로 남는다. NodePort 처럼 클러스터에서 하나뿐인
+          # 자원을 쥐고 있으면 새 Service 가 "port is already allocated" 로 아예 안 만들어진다.
+          # api-service-agent: 수집 입구가 collector 로 가면서 30443 이 collector-service-agent 로
+          #   옮겨갔는데, 옛 Service 가 그 포트를 붙들고 있었다(#184).
+          # 배포서버에서 한 번 지워지고 나면 이 줄은 없어도 된다. 그래도 남겨 두는 편이 안전하다.
+          # 클러스터를 새로 세우면 없는 이름이라 --ignore-not-found 로 조용히 지나간다.
+          sudo kubectl -n "$NS" delete service api-service-agent --ignore-not-found
+
           DEPLOYED=""
           for m in $MODULES; do
           CUR=$(sudo kubectl -n "$NS" get deploy "$m" -o jsonpath='{.spec.template.spec.containers[0].image}' 2>/dev/null || true)


### PR DESCRIPTION
#188 배포 실패 수습. **에이전트 수집이 끊긴 상태라 빨리 들어가야 한다.**

## 무엇이 터졌나

```
The Service "collector-service-agent" is invalid:
spec.ports[0].nodePort: 30443: provided port is already allocated
```

수집 입구가 collector 로 가면서 `k8s/api-service.yaml` 에서 에이전트용 NodePort Service 를 뺐다.
그런데 `kubectl apply` 는 매니페스트에서 사라진 리소스를 서버에서 지우지 않는다. 옛
`api-service-agent` Service 가 30443 을 붙든 채 남아 collector 쪽 Service 가 안 만들어졌다.

## 왜 장애인가

실패한 시점에 api-service 는 **이미 새 이미지로 롤링이 끝나 있었다.** 새 이미지에는 8443 커넥터가
없다(collector 로 갔다). 그래서 지금 상태가 이렇다.

- 30443 은 열려 있지만 뒤에서 받아 줄 것이 없다
- `collector-service-agent` 는 만들어지지 못했다
- **에이전트가 붙을 곳이 없다**

수집만 끊겼다. 대시보드 조회와 이미 쌓인 데이터는 정상이다.

## 고침

apply 로 안 지워지는 리소스는 CD 에 명시해서 지운다. NodePort 처럼 클러스터에서 하나뿐인 자원을
쥔 채 남으면 새 것이 아예 안 만들어진다. 서비스 apply 루프보다 앞에 둬서 collector Service 가
만들어지기 전에 포트가 풀리게 했다.

배포서버에서 한 번 지워지면 이 줄은 없어도 되지만, 새로 세운 클러스터에서는 없는 이름이라
`--ignore-not-found` 로 조용히 지나간다. 남겨 두는 편이 안전하다.

## 왜 미리 못 잡았나

`apply` 가 선언적이라고 생각했지만 삭제에는 그렇지 않다. 매니페스트에서 리소스를 빼는 변경은
서버에 반영되지 않는다는 것을 계산에 넣지 않았다.

## 검증

- 워크플로 YAML 파싱, 원격 스크립트 `bash -n` 통과
- 삭제가 서비스 apply 루프보다 앞인지 확인 (253행 삭제, 256행 루프 시작)
- 실제 동작은 CD 가 돌아야 확인된다