### PR TITLE
release: 에이전트 수집 복구 (#184)

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -242,6 +242,16 @@ jobs:
           # 이미지 태그는 매니페스트의 placeholder 를 쓰지 않고 여기서 끼워 넣는다.
           #   이번에 구운 모듈  -> :$SHA
           #   안 구운 모듈      -> 지금 떠 있는 태그 그대로 (그 :$SHA 이미지는 아예 없다)
+
+          # 레포에서 없앤 리소스는 여기 적어야 서버에서도 사라진다. apply 는 매니페스트에 없는 것을
+          # 지우지 않아서, 그냥 두면 서버에만 유령으로 남는다. NodePort 처럼 클러스터에서 하나뿐인
+          # 자원을 쥐고 있으면 새 Service 가 "port is already allocated" 로 아예 안 만들어진다.
+          # api-service-agent: 수집 입구가 collector 로 가면서 30443 이 collector-service-agent 로
+          #   옮겨갔는데, 옛 Service 가 그 포트를 붙들고 있었다(#184).
+          # 배포서버에서 한 번 지워지고 나면 이 줄은 없어도 된다. 그래도 남겨 두는 편이 안전하다.
+          # 클러스터를 새로 세우면 없는 이름이라 --ignore-not-found 로 조용히 지나간다.
+          sudo kubectl -n "$NS" delete service api-service-agent --ignore-not-found
+
           DEPLOYED=""
           for m in $MODULES; do
           CUR=$(sudo kubectl -n "$NS" get deploy "$m" -o jsonpath='{.spec.template.spec.containers[0].image}' 2>/dev/null || true)


### PR DESCRIPTION
#188 배포 실패 수습. **에이전트 수집이 끊긴 상태를 되돌린다.**

## 지금 서버 상태

#188 배포가 마지막 단계에서 죽었다. 죽기 전까지 인프라와 6개 서비스가 전부 새 이미지로 롤링됐다.
그래서 api-service 에는 이미 8443 커넥터가 없는데(collector 로 갔다), 30443 을 붙들고 있는
옛 `api-service-agent` Service 가 남아 `collector-service-agent` 가 만들어지지 못했다.

```
The Service "collector-service-agent" is invalid:
spec.ports[0].nodePort: 30443: provided port is already allocated
```

- 에이전트가 붙을 곳이 없다 (수집 중단)
- 대시보드 조회와 이미 쌓인 데이터는 정상

## 고침

`kubectl apply` 는 매니페스트에서 사라진 리소스를 서버에서 지우지 않는다. 없앤 리소스는 CD 에
명시해서 지운다. 서비스 apply 루프보다 앞에 둬서 collector Service 가 만들어지기 전에 포트가 풀린다.

## 이 머지로 일어나는 일

1. `api-service-agent` Service 삭제 → 30443 해제
2. `collector-service-agent` 생성 → 30443 을 collector 가 받음
3. 에이전트 수집 복구

앱 이미지는 이미 새것이라 롤링은 변화가 없다.

## 배포 후 확인

```
kubectl -n edrdog get svc collector-service-agent
kubectl -n edrdog logs job/mysql-schema-init
kubectl -n edrdog get pods
```

기존 에이전트는 401 을 받고 자동으로 다시 enroll 한다. 그 사이 호스트 목록에서 등록 기기가
잠깐 비어 보일 수 있다.