### PR TITLE
feat: 컨슈머 스레드를 파티션 수에 맞춘다

### DIFF
--- a/alert-service/src/main/java/com/edrdog/alertservice/Cooldown.java
+++ b/alert-service/src/main/java/com/edrdog/alertservice/Cooldown.java
@@ -10,7 +10,7 @@ import java.util.concurrent.ConcurrentHashMap;
 public class Cooldown {
 
     private final long windowMs;
-    // 컨슈머 concurrency 를 올려도 안전해야 하므로 ConcurrentHashMap 이다.
+    // 컨슈머 concurrency 가 3이라 여러 스레드가 동시에 allow 를 부른다.
     private final Map<String, Long> lastSent = new ConcurrentHashMap<>();
 
     public Cooldown(long windowMs) {
@@ -19,12 +19,16 @@ public class Cooldown {
 
     /** 키가 윈도우 밖이면 통과시키고 시각을 갱신, 윈도우 안이면 억제. */
     public boolean allow(String key, long nowMs) {
-        Long last = lastSent.get(key);
-        if (last != null && nowMs - last < windowMs) {
-            return false;
-        }
-        lastSent.put(key, nowMs);
-        return true;
+        boolean[] allowed = new boolean[1];
+        // 판정과 갱신은 compute 로 한 번에 한다. get 후 put 으로 쪼개면 두 스레드가 같이 통과해 Slack 이 두 번 나간다.
+        lastSent.compute(key, (k, last) -> {
+            if (last != null && nowMs - last < windowMs) {
+                return last;
+            }
+            allowed[0] = true;
+            return nowMs;
+        });
+        return allowed[0];
     }
 
     /** 기록을 지워 다음 요청이 다시 통과하게 한다. 실패한 발송이 쿨다운 창을 태우는 것을 막는다. */

--- a/alert-service/src/main/resources/application.yml
+++ b/alert-service/src/main/resources/application.yml
@@ -18,6 +18,7 @@ spring:
         spring.json.trusted.packages: com.edrdog.alertservice.dto
     listener:
       observation-enabled: true         # 컨슈머 스팬 생성 → 발행 측 traceId 를 이어받아 한 트레이스로 연결
+      concurrency: 3                    # 파티션 수(3)와 맞춘다. 1이면 스레드 하나가 파티션 3개를 순서대로 훑는다
 
 server:
   port: 8083

--- a/alert-service/src/test/java/com/edrdog/alertservice/CooldownTest.java
+++ b/alert-service/src/test/java/com/edrdog/alertservice/CooldownTest.java
@@ -3,6 +3,12 @@ package com.edrdog.alertservice;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicIntegerArray;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** 키별 쿨다운 억제 검증 (순수 로직). */
@@ -69,5 +75,34 @@ class CooldownTest {
         cooldown.forget("t1|host-1|RULE");
 
         assertThat(cooldown.allow("t1|host-2|RULE", 2_000)).isFalse();
+    }
+
+    @Test
+    @DisplayName("같은 키로 동시에 호출해도 정확히 하나만 통과한다")
+    void concurrentSameKey_onlyOnePasses() throws Exception {
+        int threads = 8;
+        int rounds = 500;
+        Cooldown cooldown = new Cooldown(60_000);
+        AtomicIntegerArray passed = new AtomicIntegerArray(rounds);
+        // 라운드마다 배리어로 출발선을 맞춰야 판정과 갱신 사이의 경합이 실제로 생긴다.
+        CyclicBarrier barrier = new CyclicBarrier(threads);
+        ExecutorService pool = Executors.newFixedThreadPool(threads);
+        for (int t = 0; t < threads; t++) {
+            pool.submit(() -> {
+                for (int round = 0; round < rounds; round++) {
+                    barrier.await();
+                    if (cooldown.allow("t1|host-" + round + "|RULE", 1_000)) {
+                        passed.incrementAndGet(round);
+                    }
+                }
+                return null;
+            });
+        }
+        pool.shutdown();
+        assertThat(pool.awaitTermination(30, TimeUnit.SECONDS)).isTrue();
+
+        for (int round = 0; round < rounds; round++) {
+            assertThat(passed.get(round)).as("round %d", round).isEqualTo(1);
+        }
     }
 }

--- a/api-service/src/main/resources/application.yml
+++ b/api-service/src/main/resources/application.yml
@@ -31,6 +31,7 @@ spring:
       observation-enabled: true
     listener:
       observation-enabled: true
+      concurrency: 3                    # 파티션 수(3)와 맞춘다. 1이면 스레드 하나가 파티션 3개를 순서대로 훑는다
 
 server:
   port: 8084

--- a/archiver-service/src/main/java/com/edrdog/archiverservice/alert/AlertKafkaConfig.java
+++ b/archiver-service/src/main/java/com/edrdog/archiverservice/alert/AlertKafkaConfig.java
@@ -37,6 +37,8 @@ public class AlertKafkaConfig {
             ConsumerFactory<String, String> alertConsumerFactory) {
         ConcurrentKafkaListenerContainerFactory<String, String> factory = new ConcurrentKafkaListenerContainerFactory<>();
         factory.setConsumerFactory(alertConsumerFactory);
+        // 전용 팩토리라 spring.kafka.listener.concurrency 가 안 먹는다. alerts 파티션 수(3)에 맞춰 여기서 직접 준다.
+        factory.setConcurrency(3);
         // 발행 측 traceId 를 이어받아 한 트레이스로 연결한다.
         factory.getContainerProperties().setObservationEnabled(true);
         return factory;

--- a/archiver-service/src/main/resources/application.yml
+++ b/archiver-service/src/main/resources/application.yml
@@ -19,6 +19,7 @@ spring:
     listener:
       type: batch                       # poll 단위로 묶어 ClickHouse INSERT 1회 → 파트가 이벤트 건수만큼 안 생긴다
       observation-enabled: true         # 컨슈머 스팬 생성 → 발행 측 traceId 를 이어받아 한 트레이스로 연결
+      concurrency: 3                    # 파티션 수(3)와 맞춘다. 1이면 스레드 하나가 파티션 3개를 순서대로 훑는다
 
 server:
   port: 8083

--- a/detector-service/src/main/resources/application.yml
+++ b/detector-service/src/main/resources/application.yml
@@ -12,6 +12,7 @@ spring:
       properties:
         default.key.serde: org.apache.kafka.common.serialization.Serdes$StringSerde
         default.value.serde: org.apache.kafka.common.serialization.Serdes$StringSerde
+        num.stream.threads: 3           # events 파티션 3개를 3개 태스크로 나눠 처리 (기본 1이면 순차)
     # 데모 발행 경로: events 로 JSON 문자열 전송
     producer:
       key-serializer: org.apache.kafka.common.serialization.StringSerializer
@@ -26,6 +27,7 @@ spring:
       observation-enabled: true
     listener:
       observation-enabled: true
+      concurrency: 3                    # 파티션 수(3)와 맞춘다. 1이면 스레드 하나가 파티션 3개를 순서대로 훑는다
 
 server:
   port: 8081

--- a/responder-service/src/main/resources/application.yml
+++ b/responder-service/src/main/resources/application.yml
@@ -18,6 +18,7 @@ spring:
         spring.json.trusted.packages: com.edrdog.responderservice.dto
     listener:
       observation-enabled: true         # 컨슈머 스팬 생성 → 발행 측 traceId 를 이어받아 한 트레이스로 연결
+      concurrency: 3                    # 파티션 수(3)와 맞춘다. 1이면 스레드 하나가 파티션 3개를 순서대로 훑는다
 
 server:
   port: 8082


### PR DESCRIPTION
이슈 #179.

파티션은 3개인데 컨슈머 스레드가 1개라 파티션을 나눈 효과가 없었다. 전 서비스 `listener.concurrency: 3`, detector Streams `num.stream.threads: 3` 으로 맞췄다.

작업하면서 이슈에 없던 것 두 개를 같이 처리했다.

- archiver 의 alerts 리스너는 전용 `alertListenerContainerFactory` 를 쓴다. 전역 `spring.kafka.listener.concurrency` 가 안 먹어서 yml 만 고쳤으면 이 경로만 스레드 1개로 남는다. 팩토리에서 직접 3을 준다
- alert-service `Cooldown.allow` 가 get 후 put 이라 같은 키가 동시에 들어오면 둘 다 통과했다. Slack 이 두 번 나간다. responder 쪽 `Cooldown` 과 같이 `compute` 로 판정과 갱신을 한 번에 한다

순서 보장은 안 깨진다. events 도 alerts 도 key 가 host 라 같은 host 는 같은 파티션이고, 한 파티션은 여전히 스레드 하나가 순서대로 처리한다.

## 검증

- 같은 키 동시 호출 시 하나만 통과하는 테스트를 먼저 넣어 실패를 확인한 뒤 `Cooldown` 을 고쳤다
- `./gradlew test` 전체 통과

Closes #179