### PR TITLE
도착 순서를 뒤섞은 부하로 순서 보장을 검증한다

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,6 @@ notes/
 *.tmp
 *.bak
 *.pid
+
+# k6 실행 산출물 (스크립트만 버전 관리한다)
+scripts/loadtest/result-*.json

--- a/detector-service/src/main/java/com/edrdog/detectorservice/kafkastreams/topology/CorrelationProcessor.java
+++ b/detector-service/src/main/java/com/edrdog/detectorservice/kafkastreams/topology/CorrelationProcessor.java
@@ -165,6 +165,9 @@ public class CorrelationProcessor implements Processor<String, Event, String, Al
 
     /** 알림의 레코드 시각은 트리거 이벤트 시각으로 둔다. 발행이 늦어도 하류의 event-time 은 어긋나지 않는다. */
     private void forward(String host, Alert alert) {
+        // 도착 순서를 뒤섞어도 탐지 건수가 같다는 것을 보이려면 발행 건수가 지표로 나와야 한다.
+        // 태그는 룰과 심각도까지만 둔다. host 나 tenant 를 붙이면 카디널리티가 단말 수만큼 늘어난다.
+        metrics.counter("cep.alerts", "rule", alert.ruleId(), "severity", alert.severity()).increment();
         ctx.forward(new Record<>(host, alert, alert.ts()));
     }
 

--- a/detector-service/src/test/java/com/edrdog/detectorservice/kafkastreams/topology/DetectionTopologyTest.java
+++ b/detector-service/src/test/java/com/edrdog/detectorservice/kafkastreams/topology/DetectionTopologyTest.java
@@ -85,6 +85,11 @@ class DetectionTopologyTest {
                 .mapToDouble(c -> c.count()).sum();
     }
 
+    private double alertCount(String ruleId) {
+        return metrics.find("cep.alerts").tag("rule", ruleId).counters().stream()
+                .mapToDouble(c -> c.count()).sum();
+    }
+
     @Test
     @DisplayName("office → shell 시퀀스 → alerts 에 T1059 1건 발행")
     void processChain_emitsAlert() {
@@ -97,6 +102,33 @@ class DetectionTopologyTest {
         assertThat(record.key).isEqualTo("host-1");
         assertThat(record.value.ruleId()).isEqualTo("SUSPICIOUS_PROCESS_CHAIN");
         assertThat(record.value.action()).isEqualTo(Alert.ACTION_KILL);
+    }
+
+    @Test
+    @DisplayName("알림을 발행하면 룰별 카운터가 오른다")
+    void alertCounter_incrementsByRule() {
+        // 도착 순서를 뒤섞어도 탐지 건수가 같다는 것을 지표로 보여주려면 이 카운터가 있어야 한다.
+        events.pipeInput("k", process("host-1", "winword.exe", "explorer.exe", 1000));
+        events.pipeInput("k", process("host-1", "powershell.exe", "winword.exe", 2000));
+        settle();
+
+        assertThat(alertCount("SUSPICIOUS_PROCESS_CHAIN")).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("도착 순서를 뒤집어도 룰별 탐지 건수는 같다")
+    void alertCounter_isIndependentOfArrivalOrder() {
+        // 부하테스트에서 증명할 명제를 테스트로 먼저 고정한다.
+        events.pipeInput("k", network("host-1", 443, 1000));
+        events.pipeInput("k", processFrom("host-1", "a.exe", "C:\\Users\\u\\AppData\\Local\\Temp\\a.exe", 2000));
+        settle();
+        assertThat(alertCount("DOWNLOAD_AND_EXECUTE")).isEqualTo(1);
+
+        events.pipeInput("k", processFrom("host-2", "a.exe", "C:\\Users\\u\\AppData\\Local\\Temp\\a.exe", 4000));
+        events.pipeInput("k", network("host-2", 443, 3000));
+        settle();
+
+        assertThat(alertCount("DOWNLOAD_AND_EXECUTE")).isEqualTo(2);
     }
 
     @Test

--- a/scripts/loadtest/dashboard-ordering.json
+++ b/scripts/loadtest/dashboard-ordering.json
@@ -1,0 +1,392 @@
+{
+  "uid": "edrdog-ordering",
+  "title": "EDRdog - 도착 순서와 탐지",
+  "description": "도착 순서를 뒤섞어도 탐지 건수가 같은지 확인하는 대시보드. scripts/loadtest/ordering.js 와 짝이다.",
+  "tags": [
+    "edrdog",
+    "cep"
+  ],
+  "timezone": "browser",
+  "editable": true,
+  "schemaVersion": 39,
+  "refresh": "",
+  "time": {
+    "from": "now-15m",
+    "to": "now"
+  },
+  "panels": [
+    {
+      "id": 1,
+      "type": "timeseries",
+      "title": "탐지 건수 (룰별, 초당)",
+      "description": "이 대시보드의 결론. inorder 구간과 shuffled 구간의 높이가 같아야 도착 순서와 무관하게 탐지된다는 주장이 성립한다. late 구간은 0 이 정상이다.",
+      "gridPos": {
+        "h": 10,
+        "w": 16,
+        "x": 0,
+        "y": 0
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum by (rule) (rate(cep_alerts_total[30s]))",
+          "legendFormat": "{{rule}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "min": 0,
+          "custom": {
+            "fillOpacity": 12,
+            "lineWidth": 2,
+            "showPoints": "never"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "calcs": [
+            "mean",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "interval": "10s",
+      "maxDataPoints": 800
+    },
+    {
+      "id": 6,
+      "type": "stat",
+      "title": "누적 탐지 건수 (이번 런)",
+      "description": "선택한 시간 범위에서 룰별로 몇 건이 나갔는지. k6 가 출력한 기대치와 직접 비교한다.",
+      "gridPos": {
+        "h": 10,
+        "w": 8,
+        "x": 16,
+        "y": 0
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum by (rule) (cep_alerts_total)",
+          "legendFormat": "{{rule}}",
+          "instant": true
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "decimals": 0
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "none",
+        "textMode": "auto"
+      }
+    },
+    {
+      "id": 2,
+      "type": "timeseries",
+      "title": "도착 지연 분포 (같은 단말의 최신 이벤트 대비)",
+      "description": "실제로 순서가 뒤섞여 도착했다는 증거. p99 가 올라간 구간이 뒤섞인 구간이다. grace(1500ms) 를 넘으면 미탐 위험이 생긴다.",
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 0,
+        "y": 10
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "cep_event_lateness_milliseconds{quantile=\"0.5\"}",
+          "legendFormat": "p50"
+        },
+        {
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "cep_event_lateness_milliseconds{quantile=\"0.95\"}",
+          "legendFormat": "p95"
+        },
+        {
+          "refId": "C",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "cep_event_lateness_milliseconds{quantile=\"0.99\"}",
+          "legendFormat": "p99"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ms",
+          "min": 0,
+          "custom": {
+            "fillOpacity": 0,
+            "lineWidth": 2,
+            "showPoints": "never"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1500
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "calcs": [
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "interval": "10s",
+      "maxDataPoints": 800
+    },
+    {
+      "id": 3,
+      "type": "timeseries",
+      "title": "기준선을 넘겨 도착한 트리거 (초당)",
+      "description": "판정을 시작시키는 이벤트가 기준선보다 과거인 채로 도착한 건수. 버리지 않고 그 자리에서 판정하므로 탐지는 유지되지만, 여기가 오르면 grace 1.5초가 부족하다는 신호다. 근거가 늦게 온 경우는 여기 안 잡힌다.",
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 6,
+        "y": 10
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum by (type) (rate(cep_late_events_total[30s]))",
+          "legendFormat": "{{type}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "min": 0,
+          "custom": {
+            "fillOpacity": 20,
+            "lineWidth": 2,
+            "showPoints": "never"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "calcs": [
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "interval": "10s",
+      "maxDataPoints": 800
+    },
+    {
+      "id": 4,
+      "type": "timeseries",
+      "title": "처리량 / 스트림 스레드",
+      "description": "토폴로지가 실제로 소화한 이벤트 수. 모든 이벤트가 지연 분포에 기록되므로 그 건수의 증가율이 곧 처리량이다.",
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 12,
+        "y": 10
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(rate(cep_event_lateness_milliseconds_count[30s]))",
+          "legendFormat": "events/sec"
+        },
+        {
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "max(kafka_stream_alive_stream_threads)",
+          "legendFormat": "스트림 스레드"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "min": 0,
+          "custom": {
+            "fillOpacity": 15,
+            "lineWidth": 2,
+            "showPoints": "never"
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "스트림 스레드"
+            },
+            "properties": [
+              {
+                "id": "custom.axisPlacement",
+                "value": "right"
+              },
+              {
+                "id": "custom.fillOpacity",
+                "value": 0
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "calcs": [
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "interval": "10s",
+      "maxDataPoints": 800
+    },
+    {
+      "id": 5,
+      "type": "timeseries",
+      "title": "컨슈머 랙 (처리 컨슈머만)",
+      "description": "상태저장소 복구용 restore-consumer 는 제외한다. 그쪽 랙은 처리 밀림이 아니라 changelog 가 쌓인 양이라 섞으면 한계에 부딪힌 것처럼 보인다.",
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 18,
+        "y": 10
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "max(kafka_consumer_fetch_manager_records_lag_max{job=\"detector\", client_id!~\".*restore-consumer\"})",
+          "legendFormat": "최대 랙 (건)"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "min": 0,
+          "custom": {
+            "fillOpacity": 0,
+            "lineWidth": 2,
+            "showPoints": "never"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "calcs": [
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "interval": "10s",
+      "maxDataPoints": 800
+    }
+  ]
+}

--- a/scripts/loadtest/ordering.js
+++ b/scripts/loadtest/ordering.js
@@ -1,0 +1,163 @@
+// 도착 순서가 뒤바뀌어도 탐지 건수가 같은지 부하로 확인하는 k6 시나리오.
+//
+// 같은 공격 시퀀스(R2 다운로드 → 실행)를 같은 양으로 보내되 도착 순서만 바꾼다.
+// 구간마다 그래프가 어떤 모양이어야 하는지 먼저 정하고, 그대로 나오는지 본다.
+//
+//   구간           방법                              기대 탐지  기대 late 카운터
+//   inorder        발생 순서대로                     N          0
+//   shuffled       실행이 먼저 도착                  N          0        <- 이 글의 주장
+//   lateTrigger    트리거가 기준선 넘겨 도착         N          N        <- 버리지 않는다
+//   lateEvidence   근거가 grace 넘겨 도착            0          0        <- 한계 지점
+//
+// 단말은 반복마다 새로 만든다. 단말을 공유하면 다른 반복이 남긴 근거로 판정돼 구간의 의미가 사라진다.
+//
+//   실행: k6 run scripts/loadtest/ordering.js
+//   대상: detector 의 데모 발행 경로(POST /api/events). host 를 파티션 키로 events 토픽에 넣는다.
+
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+import { Counter } from 'k6/metrics';
+
+const BASE = __ENV.BASE_URL || 'http://localhost:8081';
+const RATE = Number(__ENV.RATE || 20);          // 초당 시퀀스 수
+const PHASE_S = Number(__ENV.PHASE_SECONDS || 60);
+const GAP_S = Number(__ENV.GAP_SECONDS || 30);  // 구간 사이 공백 (그래프에서 단계를 가른다)
+const NOISE = Number(__ENV.NOISE || 3);         // 시퀀스당 무해한 이벤트 수
+const LATE_MS = Number(__ENV.LATE_MS || 2500);  // 근거를 늦추는 시간. grace(1500ms)보다 커야 미탐이 난다
+const TENANT = __ENV.TENANT_ID || '1';
+
+const sent = new Counter('edrdog_sequences_sent');
+
+const phase = (name, order, exec) => ({
+    executor: 'constant-arrival-rate',
+    rate: RATE,
+    timeUnit: '1s',
+    duration: `${PHASE_S}s`,
+    startTime: `${order * (PHASE_S + GAP_S)}s`,
+    // lateEvidence 는 한 반복이 LATE_MS 만큼 머무르므로 VU 가 rate × LATE_MS 만큼 동시에 필요하다
+    preAllocatedVUs: 80,
+    maxVUs: 300,
+    exec,
+    tags: { phase: name },
+});
+
+export const options = {
+    scenarios: {
+        inorder: phase('inorder', 0, 'inOrder'),
+        shuffled: phase('shuffled', 1, 'shuffled'),
+        lateTrigger: phase('lateTrigger', 2, 'lateTrigger'),
+        lateEvidence: phase('lateEvidence', 3, 'lateEvidence'),
+    },
+    // 발행이 막히면 결과를 믿을 수 없다. 실패가 보이면 바로 알도록 임계값을 건다.
+    thresholds: {
+        http_req_failed: ['rate<0.01'],
+    },
+};
+
+function post(event) {
+    const res = http.post(`${BASE}/api/events`, JSON.stringify(event), {
+        headers: { 'Content-Type': 'application/json' },
+    });
+    check(res, { 'accepted': (r) => r.status === 202 });
+}
+
+/** 반복마다 새 단말. 반복끼리 근거를 빌려주지 않게 한다. */
+function newHost(name) {
+    return `h-${name}-${__VU}-${__ITER}`;
+}
+
+/** R2 의 선행 근거. 다운로드 포트여야 근거로 인정된다. */
+function download(host, ts) {
+    return { host, type: 'network', ts, destIp: '203.0.113.9', destPort: 443, tenantId: TENANT };
+}
+
+/** R2 의 트리거. argv[0] 이 시스템 임시 경로여야 한다. */
+function execFromTemp(host, ts) {
+    return {
+        host, type: 'process', ts,
+        process: 'payload.bin', parent: 'bash', cmdline: '/tmp/payload.bin',
+        tenantId: TENANT,
+    };
+}
+
+/** 룰에 안 걸리는 평범한 실행. 부하를 만들고 기준선을 밀어준다. */
+function benign(host, ts) {
+    return {
+        host, type: 'process', ts,
+        process: 'chrome.exe', parent: 'launchd',
+        cmdline: '/applications/chrome.app/contents/macos/chrome',
+        tenantId: TENANT,
+    };
+}
+
+function noise(host, ts) {
+    for (let i = 0; i < NOISE; i++) {
+        post(benign(host, ts - i * 10));
+    }
+}
+
+// 1) 발생 순서대로 도착. 기준값이 되는 구간이다
+export function inOrder() {
+    const host = newHost('inorder');
+    const now = Date.now();
+    post(download(host, now - 2000));
+    post(execFromTemp(host, now));
+    noise(host, now);
+    sent.add(1, { phase: 'inorder' });
+}
+
+// 2) 실행이 먼저 도착하고 근거가 뒤따라온다. 발생 시각은 그대로다
+export function shuffled() {
+    const host = newHost('shuffled');
+    const now = Date.now();
+    post(execFromTemp(host, now));
+    post(download(host, now - 2000));
+    noise(host, now);
+    sent.add(1, { phase: 'shuffled' });
+}
+
+// 3) 최신 이벤트가 기준선을 먼저 밀어버린 뒤 트리거가 도착한다.
+//    버리면 확정 미탐이라 그 자리에서 판정한다. 탐지는 되고 late 카운터가 오르는 게 정상이다
+export function lateTrigger() {
+    const host = newHost('latetrigger');
+    const now = Date.now();
+    // 기준선을 미는 이벤트는 근거로 쌓이는 종류여야 한다. 무해한 이벤트로 밀면 버퍼가 비어
+    // 그 자리에서 상태가 삭제되고(CorrelationProcessor.save) 기준선도 같이 초기화된다
+    post(download(host, now));                 // 기준선을 now-1500 으로 민다
+    post(download(host, now - 6000));          // 실제 근거
+    post(execFromTemp(host, now - 4000));      // 기준선보다 과거 → late
+    noise(host, now);
+    sent.add(1, { phase: 'lateTrigger' });
+}
+
+// 4) 근거가 grace 를 넘겨 도착한다. 트리거가 이미 판정된 뒤라 미탐이 정상이다
+export function lateEvidence() {
+    const host = newHost('lateevidence');
+    const now = Date.now();
+    post(execFromTemp(host, now));
+    noise(host, now);
+    sleep(LATE_MS / 1000);
+    post(download(host, now - 2000));
+    sent.add(1, { phase: 'lateEvidence' });
+}
+
+export function handleSummary(data) {
+    const total = data.metrics.edrdog_sequences_sent?.values?.count ?? 0;
+    const n = Math.round(RATE * PHASE_S);
+    const lines = [
+        '',
+        `보낸 시퀀스 합계 ${total} (구간당 ${n} = rate ${RATE}/s × ${PHASE_S}s)`,
+        '',
+        '구간별 기대 모양 — 그라파나가 이대로 나와야 한다',
+        '',
+        `  inorder        탐지 ${n}    late 0`,
+        `  shuffled       탐지 ${n}    late 0      <- inorder 와 같아야 주장이 성립한다`,
+        `  lateTrigger    탐지 ${n}    late ${n}    <- 늦게 온 트리거도 버리지 않는다`,
+        `  lateEvidence   탐지 0${' '.repeat(String(n).length - 1)}    late 0      <- grace 를 넘긴 근거는 못 살린다`,
+        '',
+    ];
+    return {
+        stdout: lines.join('\n'),
+        'scripts/loadtest/result-ordering.json': JSON.stringify(data, null, 2),
+    };
+}


### PR DESCRIPTION
dev 에 쌓인 것을 main 으로 올린다. 순서 보장이 부하에서도 성립하는지 확인한 것이다.

## 도착 순서 검증 (PR #203)

#200 에서 상관 판정을 이벤트 시각 기준으로 바꿨지만, 부하에서도 성립하는지는 확인한 적이 없었다. `TopologyTestDriver` 는 이벤트 몇 건짜리 검증이다.

같은 공격 시퀀스를 초당 20개씩 60초 동안 보내되 **도착 순서만 바꿔** 네 구간을 이어 돌렸다. 구간별로 그래프가 어떻게 나와야 하는지 먼저 적어두고 대조했다.

| 구간 | 방법 | 기대 탐지 | 실측 |
|---|---|---|---|
| inorder | 발생 순서대로 | 1200 | 20.3/s 고원 |
| shuffled | 실행이 먼저 도착 | inorder 와 동일 | 20.1/s 고원 |
| lateTrigger | 트리거가 기준선 넘겨 도착 | 1200 (late 도 1200) | 20.0/s, late 1201 |
| lateEvidence | 근거가 grace 넘겨 도착 | 0 | 0 |

합계 4803 시퀀스 / 25216 이벤트. 총 탐지 3602건(기대 3600), 처리 이벤트 25216건으로 유실 없음, 처리 컨슈머 랙 최대 0, 처리량 최대 136 events/sec.

## 함께 들어간 것

- `cep.alerts` 카운터 (룰·심각도 태그). 알림 쪽 지표가 없어 "그래서 잡았나" 를 말할 수 없었다
- `scripts/loadtest/ordering.js` k6 시나리오, `dashboard-ordering.json` 그라파나 대시보드
- 테스트 2건 (카운터 증가, 도착 순서를 뒤집어도 룰별 건수 동일)

운영 코드 변경은 카운터 3줄뿐이다. 나머지는 테스트와 도구다.

## 남은 것

- `cep.late.events` 는 **늦게 온 트리거만** 센다. 실제 미탐 위험은 근거가 늦게 오는 쪽에 있는데 그 방향을 보는 지표가 없다
- 합성 부하라 도착 지연 분포가 넣은 값을 그대로 되돌려준다. grace 1.5초 확정 근거로는 못 쓴다
- 용량 한계는 이 시나리오로 안 나온다. 랙이 0이라 한계 근처에도 안 갔다
