### PR TITLE
deploy: 전송량 실측용 지표

### DIFF
--- a/collector-service/build.gradle
+++ b/collector-service/build.gradle
@@ -5,6 +5,7 @@ dependencies {
     // /actuator/health 가 서빙되지 않는다(k8s probe 가 계속 실패해 컨테이너가 재시작된다).
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.kafka:spring-kafka'
+    implementation 'io.micrometer:micrometer-registry-otlp'            // 메트릭 OTLP 전송 (발행 페이로드 크기 관측)
     implementation 'com.fasterxml.jackson.core:jackson-databind'        // 에이전트가 보낸 검증 전 원본 JSON 파싱 (발행은 Protobuf)
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'    // 등록 노드(node_key 해시 → tenant/host) 저장
     runtimeOnly 'com.mysql:mysql-connector-j'                           // 등록 노드 저장용 MySQL 드라이버

--- a/collector-service/src/main/java/com/edrdog/collectorservice/agent/EventsProducer.java
+++ b/collector-service/src/main/java/com/edrdog/collectorservice/agent/EventsProducer.java
@@ -24,21 +24,26 @@ public class EventsProducer {
 
     private final KafkaTemplate<String, byte[]> template;
     private final String eventsTopic;
+    private final PayloadSizeMeter payloadSize;   // 측정용 임시 의존. 수치를 확정하면 같이 걷어낸다
 
     public EventsProducer(KafkaTemplate<String, byte[]> template,
-                          @Value("${edrdog.kafka.events-topic}") String eventsTopic) {
+                          @Value("${edrdog.kafka.events-topic}") String eventsTopic,
+                          PayloadSizeMeter payloadSize) {
         this.template = template;
         this.eventsTopic = eventsTopic;
+        this.payloadSize = payloadSize;
     }
 
     /** 1건 발행. 실패하면 false 를 돌려 응답 accepted 에서 빠지게 한다. */
     public boolean publish(Event event) {
         try {
             // 본문이 바이너리라 kafbat UI 로 못 읽는다. 헤더가 그 자리를 메우므로 ProducerRecord 로 직접 만든다.
+            byte[] payload = event.toByteArray();
             ProducerRecord<String, byte[]> record =
-                    new ProducerRecord<>(eventsTopic, event.getHost(), event.toByteArray());
+                    new ProducerRecord<>(eventsTopic, event.getHost(), payload);
             EventHeaders.stamp(record.headers(), event);
             template.send(record);
+            payloadSize.record(event, payload);
             return true;
         } catch (Exception e) {
             log.error("events 발행 실패: {}", event, e);

--- a/collector-service/src/main/java/com/edrdog/collectorservice/agent/PayloadSizeMeter.java
+++ b/collector-service/src/main/java/com/edrdog/collectorservice/agent/PayloadSizeMeter.java
@@ -1,0 +1,98 @@
+package com.edrdog.collectorservice.agent;
+
+import com.edrdog.schema.Event;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.micrometer.core.instrument.DistributionSummary;
+import io.micrometer.core.instrument.MeterRegistry;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * 측정용 임시 코드. Protobuf 전환이 전송량을 얼마나 줄였는지 재려고 잠깐 둔다.
+ *
+ * <p>발행되는 것은 Protobuf 하나뿐이고, JSON 쪽은 <b>같은 이벤트를 직렬화만 해 본 값</b>이다.
+ * 나가지 않는 바이트를 재는 것이라 그만큼 CPU 를 버린다. 그래서 기본값은 꺼짐이고,
+ * 부하 테스트를 돌리는 동안에만 켠다. 수치를 확정하면 이 파일과 짝인 대시보드를 같이 걷어낸다.
+ *
+ * <p>대시보드: scripts/loadtest/dashboard-payload.json
+ */
+@Component
+public class PayloadSizeMeter {
+
+    private static final Logger log = LoggerFactory.getLogger(PayloadSizeMeter.class);
+
+    /** 이름을 event.payload 로 두면 baseUnit 이 붙어 event_payload_bytes 로 나간다(기존 지표 규칙과 같다). */
+    private static final String METER = "event.payload";
+
+    private final MeterRegistry registry;
+    private final boolean enabled;
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    public PayloadSizeMeter(MeterRegistry registry,
+                            @Value("${edrdog.metrics.compare-json:false}") boolean enabled) {
+        this.registry = registry;
+        this.enabled = enabled;
+        if (enabled) {
+            log.warn("페이로드 크기 비교 측정이 켜져 있다. 이벤트마다 JSON 직렬화를 한 번 더 한다 (측정용 임시 기능)");
+        }
+    }
+
+    /** 발행 직전 호출. 실제 나가는 바이트와, 같은 이벤트를 JSON 으로 했을 때의 바이트를 같이 남긴다. */
+    public void record(Event event, byte[] published) {
+        if (!enabled) {
+            return;
+        }
+        String type = event.getType();
+        summary("protobuf", type).record(published.length);
+        try {
+            summary("json", type).record(asLegacyJson(event).length);
+        } catch (Exception e) {
+            log.debug("JSON 환산 실패 (측정만 건너뛴다)", e);
+        }
+    }
+
+    /**
+     * 전환 전 collector 가 실제로 보내던 형태를 그대로 되살린다.
+     *
+     * <p>그때는 12개 필드짜리 record 를 Jackson 이 통째로 직렬화했다. 안 채운 필드도 {@code null} 로
+     * 실려 나갔고, 그 바이트가 이번에 없어진 것의 일부다. proto 의 JSON 매핑을 쓰면 빈 필드가 빠져
+     * 실제보다 작게 잡히므로 여기서 손으로 맞춘다. 필드 순서도 그때 record 선언 순서다.
+     */
+    private byte[] asLegacyJson(Event e) throws Exception {
+        Map<String, Object> old = new LinkedHashMap<>();
+        old.put("host", e.getHost());
+        old.put("type", e.getType());
+        old.put("ts", e.getTs());
+        old.put("process", orNull(e.getProcess()));
+        old.put("parent", orNull(e.getParent()));
+        old.put("cmdline", orNull(e.getCmdline()));
+        old.put("destIp", orNull(e.getDestIp()));
+        old.put("destPort", e.getDestPort());
+        old.put("domain", orNull(e.getDomain()));
+        old.put("detail", orNull(e.getDetail()));
+        old.put("sha256", orNull(e.getSha256()));
+        old.put("tenantId", orNull(e.getTenantId()));
+        return mapper.writeValueAsBytes(old);
+    }
+
+    /** proto3 는 관측 못 한 값을 빈 문자열로 준다. 예전 record 는 그 자리에 null 을 담았다. */
+    private static String orNull(String value) {
+        return value.isEmpty() ? null : value;
+    }
+
+    /** micrometer 는 이름+태그가 같으면 같은 미터를 돌려준다. 매번 만들어도 새로 생기지 않는다. */
+    private DistributionSummary summary(String format, String type) {
+        return DistributionSummary.builder(METER)
+                .description("events 로 나가는 이벤트 한 건의 크기. format=json 은 실제로 나가지 않는 환산값이다")
+                .baseUnit("bytes")
+                .tag("format", format)
+                .tag("type", type)
+                .publishPercentiles(0.5, 0.95, 0.99)
+                .register(registry);
+    }
+}

--- a/collector-service/src/main/resources/application.yml
+++ b/collector-service/src/main/resources/application.yml
@@ -4,8 +4,7 @@ spring:
   config:
     import:
       - classpath:observability.yml
-      # 메트릭 익스포터 꺼짐: observability-metrics.yml 을 넣지 않는다.
-      # micrometer-registry-otlp 가 없는 서비스라 트레이스만 보낸다(메트릭은 api/detector/archiver 에만).
+      - classpath:observability-metrics.yml   # 메트릭 익스포터 켜짐 (build.gradle 에 micrometer-registry-otlp 있음)
   datasource:
     url: ${DB_URL:jdbc:mysql://localhost:3306/edrdog_collector}
     username: ${DB_USER:edrdog}
@@ -28,6 +27,12 @@ server:
   port: 8082
 
 edrdog:
+  metrics:
+    # 측정용 임시 스위치. 켜면 이벤트마다 JSON 으로도 직렬화해 크기를 같이 남긴다(발행은 Protobuf 하나뿐).
+    # 나가지 않는 바이트를 재느라 CPU 를 버리므로 부하 테스트를 도는 동안에만 켠다.
+    #   sudo kubectl -n edrdog set env deploy/collector-service EDRDOG_COMPARE_JSON=true
+    # 대시보드는 scripts/loadtest/dashboard-payload.json, 수치를 확정하면 둘 다 걷어낸다.
+    compare-json: ${EDRDOG_COMPARE_JSON:false}
   kafka:
     events-topic: events                # 검증 통과 이벤트 (발행 출력, detector/archiver 입력)
   agent:

--- a/collector-service/src/test/java/com/edrdog/collectorservice/agent/PayloadSizeMeterTest.java
+++ b/collector-service/src/test/java/com/edrdog/collectorservice/agent/PayloadSizeMeterTest.java
@@ -1,0 +1,91 @@
+package com.edrdog.collectorservice.agent;
+
+import com.edrdog.schema.Event;
+import com.edrdog.schema.EventTypes;
+import io.micrometer.core.instrument.DistributionSummary;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * 감소율의 분모가 되는 JSON 환산값을 확인한다.
+ * 여기가 틀리면 글에 실리는 숫자가 통째로 틀리는데, 어디서도 에러가 나지 않는다.
+ */
+class PayloadSizeMeterTest {
+
+    private final MeterRegistry registry = new SimpleMeterRegistry();
+
+    /** 글 본문에 실린 process 샘플과 같은 이벤트. */
+    private static Event sample() {
+        return Event.newBuilder()
+                .setHost("mac-01")
+                .setType(EventTypes.PROCESS)
+                .setTs(1_754_300_000_000L)
+                .setProcess("/usr/bin/curl")
+                .setParent("zsh")
+                .setCmdline("curl -s http://example.com/payload.sh")
+                .setDetail("{\"pid\":41233,\"ppid\":980}")
+                .setSha256("a".repeat(64))
+                .setTenantId("11111111-1111-1111-1111-111111111111")
+                .build();
+    }
+
+    private double total(String format) {
+        DistributionSummary s = registry.find("event.payload").tag("format", format).summary();
+        return s == null ? -1 : s.totalAmount();
+    }
+
+    @Test
+    @DisplayName("꺼져 있으면 아무것도 재지 않는다 (기본값)")
+    void disabledByDefault() {
+        new PayloadSizeMeter(registry, false).record(sample(), sample().toByteArray());
+
+        assertThat(registry.find("event.payload").summaries()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("전환 전 형태를 그대로 되살린다 (빈 필드도 null 로 실린다)")
+    void legacyJsonKeepsNullFields() {
+        Event e = sample();
+
+        new PayloadSizeMeter(registry, true).record(e, e.toByteArray());
+
+        // 본문 표의 351 B 와 같은 값이어야 한다. 빈 destIp/domain 을 빼면 여기서 어긋난다.
+        assertThat(total("json")).isEqualTo(351);
+        assertThat(total("protobuf")).isEqualTo(e.toByteArray().length);
+    }
+
+    @Test
+    @DisplayName("값이 짧은 이벤트일수록 많이 준다")
+    void shorterValuesShrinkMore() {
+        Event network = Event.newBuilder()
+                .setHost("mac-01").setType(EventTypes.NETWORK).setTs(1_754_300_000_000L)
+                .setProcess("/usr/bin/curl").setDestIp("203.0.113.24").setDestPort(443)
+                .setDetail("{\"pid\":41233,\"protocol\":\"tcp\"}")
+                .setTenantId("11111111-1111-1111-1111-111111111111")
+                .build();
+
+        PayloadSizeMeter meter = new PayloadSizeMeter(registry, true);
+        meter.record(network, network.toByteArray());
+
+        double jsonBytes = total("json");
+        double protoBytes = total("protobuf");
+        // sha256 이 없어 값이 짧다. 본문 주장대로면 process(-39%)보다 많이 줄어야 한다.
+        assertThat(1 - protoBytes / jsonBytes).isGreaterThan(0.45);
+    }
+
+    @Test
+    @DisplayName("이벤트 종류를 태그로 남긴다 (종류별 감소율 패널의 근거)")
+    void tagsEventType() {
+        Event e = sample();
+
+        new PayloadSizeMeter(registry, true).record(e, e.toByteArray());
+
+        assertThat(registry.find("event.payload")
+                .tag("format", "protobuf").tag("type", EventTypes.PROCESS).summary())
+                .isNotNull();
+    }
+}

--- a/scripts/loadtest/dashboard-payload.json
+++ b/scripts/loadtest/dashboard-payload.json
@@ -1,0 +1,199 @@
+{
+  "uid": "edrdog-payload",
+  "title": "EDRdog - 이벤트 전송량 (JSON vs Protobuf)",
+  "description": "같은 이벤트를 두 형식으로 재서 전송량 감소를 확인하는 대시보드. collector 의 측정용 임시 코드와 짝이며, 측정이 끝나면 그 코드와 함께 걷어낸다. 발행되는 것은 Protobuf 하나뿐이고 JSON 쪽은 같은 이벤트를 직렬화만 해 본 값이다.",
+  "tags": ["edrdog", "protobuf"],
+  "timezone": "browser",
+  "editable": true,
+  "schemaVersion": 39,
+  "refresh": "",
+  "time": { "from": "now-15m", "to": "now" },
+  "panels": [
+    {
+      "id": 1,
+      "type": "stat",
+      "title": "전송량 감소율",
+      "description": "부하 구간 누적 기준. 1 - Protobuf 총바이트 / JSON 총바이트.",
+      "gridPos": { "h": 9, "w": 6, "x": 0, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "1 - sum(event_payload_bytes_sum{format=\"protobuf\"}) / sum(event_payload_bytes_sum{format=\"json\"})",
+          "legendFormat": "감소율",
+          "instant": false
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "decimals": 1,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "text", "value": null },
+              { "color": "green", "value": 0.3 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "auto"
+      }
+    },
+    {
+      "id": 2,
+      "type": "timeseries",
+      "title": "누적 전송량 (같은 이벤트, 두 형식)",
+      "description": "두 선이 벌어지는 폭이 곧 아낀 양이다. JSON 선은 실제로 나간 것이 아니라 같은 이벤트를 JSON 으로 직렬화했을 때의 크기다.",
+      "gridPos": { "h": 9, "w": 18, "x": 6, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "sum(event_payload_bytes_sum{format=\"json\"})",
+          "legendFormat": "JSON (환산)"
+        },
+        {
+          "refId": "B",
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "sum(event_payload_bytes_sum{format=\"protobuf\"})",
+          "legendFormat": "Protobuf (실제 발행)"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "decbytes",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 10,
+            "showPoints": "never"
+          }
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "JSON (환산)" },
+            "properties": [{ "id": "color", "value": { "mode": "fixed", "fixedColor": "orange" } }]
+          },
+          {
+            "matcher": { "id": "byName", "options": "Protobuf (실제 발행)" },
+            "properties": [{ "id": "color", "value": { "mode": "fixed", "fixedColor": "green" } }]
+          }
+        ]
+      },
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true, "calcs": ["max"] },
+        "tooltip": { "mode": "multi", "sort": "none" }
+      }
+    },
+    {
+      "id": 3,
+      "type": "bargauge",
+      "title": "이벤트 종류별 감소율",
+      "description": "값이 긴 이벤트(sha256, cmdline 이 붙는 process)일수록 덜 준다. 줄어드는 것은 키와 포장이지 값이 아니기 때문이다.",
+      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 9 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "1 - sum by (type) (event_payload_bytes_sum{format=\"protobuf\"}) / sum by (type) (event_payload_bytes_sum{format=\"json\"})",
+          "legendFormat": "{{type}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "decimals": 1,
+          "min": 0,
+          "max": 1,
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "displayMode": "gradient",
+        "orientation": "horizontal",
+        "showUnfilled": true
+      }
+    },
+    {
+      "id": 4,
+      "type": "timeseries",
+      "title": "건당 크기 백분위별 감소율",
+      "description": "p50 보다 p99 가 낮게 나와야 위 설명과 맞는다. 큰 이벤트일수록 값이 차지하는 비중이 커서 덜 준다.",
+      "gridPos": { "h": 8, "w": 10, "x": 8, "y": 9 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "1 - max(event_payload_bytes{format=\"protobuf\", quantile=\"0.5\"}) / max(event_payload_bytes{format=\"json\", quantile=\"0.5\"})",
+          "legendFormat": "p50"
+        },
+        {
+          "refId": "B",
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "1 - max(event_payload_bytes{format=\"protobuf\", quantile=\"0.95\"}) / max(event_payload_bytes{format=\"json\", quantile=\"0.95\"})",
+          "legendFormat": "p95"
+        },
+        {
+          "refId": "C",
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "1 - max(event_payload_bytes{format=\"protobuf\", quantile=\"0.99\"}) / max(event_payload_bytes{format=\"json\", quantile=\"0.99\"})",
+          "legendFormat": "p99"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "decimals": 1,
+          "min": 0,
+          "max": 1,
+          "custom": { "drawStyle": "line", "lineWidth": 2, "fillOpacity": 0, "showPoints": "never" }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true, "calcs": ["mean"] },
+        "tooltip": { "mode": "multi", "sort": "none" }
+      }
+    },
+    {
+      "id": 5,
+      "type": "timeseries",
+      "title": "발행 처리량 (초당 건수)",
+      "description": "부하가 실제로 걸렸다는 증거. 이 값이 0 이면 위 숫자들은 아무것도 말하지 않는다.",
+      "gridPos": { "h": 8, "w": 6, "x": 18, "y": 9 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "sum(rate(event_payload_bytes_count{format=\"protobuf\"}[30s]))",
+          "legendFormat": "발행"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "decimals": 1,
+          "custom": { "drawStyle": "line", "lineWidth": 2, "fillOpacity": 10, "showPoints": "never" }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom", "showLegend": false },
+        "tooltip": { "mode": "single", "sort": "none" }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
#207 배포. collector 발행 페이로드 크기를 지표로 낸다.

기본값이 꺼짐이라 **배포만으로는 아무 일도 일어나지 않는다.** 포맷이 안 바뀌므로 Kafka 초기화도 필요 없다.

측정할 때만 켠다.

```bash
sudo kubectl -n edrdog set env deploy/collector-service EDRDOG_COMPARE_JSON=true
```

대시보드는 `scripts/loadtest/dashboard-payload.json` 을 Grafana 에 import 한다.

수치를 확정하면 지표 코드와 대시보드를 같이 걷어낸다.