### PR TITLE
deploy: punctuate 가 state store 전체 대신 대기 host 만 본다

### DIFF
--- a/detector-service/src/main/java/com/edrdog/detectorservice/kafkastreams/topology/CorrelationProcessor.java
+++ b/detector-service/src/main/java/com/edrdog/detectorservice/kafkastreams/topology/CorrelationProcessor.java
@@ -15,7 +15,9 @@ import org.apache.kafka.streams.state.KeyValueStore;
 
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * host(key) 별 이벤트 버퍼를 유지하며 시퀀스 상관분석을 수행.
@@ -32,7 +34,7 @@ public class CorrelationProcessor implements Processor<String, Event, String, Al
 
     static final String STORE = "event-buffer";
 
-    /** 워터마크 진행을 확인하는 주기. 짧을수록 판정이 빠르지만 store 전체 순회가 잦아진다. */
+    /** 워터마크 진행을 확인하는 주기. 짧을수록 판정이 빠르다. */
     static final long PUNCTUATE_INTERVAL_MS = 500;
 
     private final long windowMs;
@@ -42,6 +44,16 @@ public class CorrelationProcessor implements Processor<String, Event, String, Al
 
     private KeyValueStore<String, EventBuffer> store;
     private ProcessorContext<String, Alert> ctx;
+
+    /**
+     * pending 이 남은 host → 그 host 의 마지막 갱신 시각(wall clock).
+     * punctuate 가 볼 후보를 여기로 좁힌다. 이게 없으면 store 전체를 초당 두 번 역직렬화하며 훑어야 하고,
+     * 비용이 단말 수에 정비례한다. 시퀀스 트리거는 드물어서 대부분 host 는 여기 없다.
+     *
+     * <p>메모리에만 두지만 대기 트리거를 잃지 않는다. 재시작·리밸런싱이면 프로세서가 새로 만들어지고
+     * init() 이 store 를 한 번 훑어 복원한다 (Kafka Streams 는 상태 복원이 끝난 뒤에야 init() 을 부른다).
+     */
+    private final Map<String, Long> pendingHosts = new LinkedHashMap<>();
 
     public CorrelationProcessor(long windowMs, long graceMs, MeterRegistry metrics) {
         this.windowMs = windowMs;
@@ -58,8 +70,26 @@ public class CorrelationProcessor implements Processor<String, Event, String, Al
     public void init(ProcessorContext<String, Alert> context) {
         this.ctx = context;
         this.store = context.getStateStore(STORE);
+        restorePendingHosts();
         context.schedule(Duration.ofMillis(PUNCTUATE_INTERVAL_MS), PunctuationType.WALL_CLOCK_TIME,
                 this::flushQuietHosts);
+    }
+
+    /**
+     * 복원된 state store 를 한 번만 훑어 pendingHosts 를 되살린다.
+     * 이 스캔이 없으면 재시작 직전 대기 중이던 트리거는 그 host 가 다시 이벤트를 보낼 때까지,
+     * 단말이 꺼졌다면 영영 판정되지 않는다. 태스크 할당당 한 번이라 punctuate 순회와 달리 누적되지 않는다.
+     */
+    private void restorePendingHosts() {
+        pendingHosts.clear();
+        try (KeyValueIterator<String, EventBuffer> it = store.all()) {
+            while (it.hasNext()) {
+                KeyValue<String, EventBuffer> kv = it.next();
+                if (kv.value != null && !kv.value.pending.isEmpty()) {
+                    pendingHosts.put(kv.key, kv.value.lastUpdatedWallMs);
+                }
+            }
+        }
     }
 
     @Override
@@ -145,21 +175,23 @@ public class CorrelationProcessor implements Processor<String, Event, String, Al
      * 여기서 wall clock 으로 끊어주지 않으면 탐지가 전송 주기만큼 늦고, 단말이 꺼지면 아예 안 나온다.
      */
     private void flushQuietHosts(long nowWallMs) {
-        List<KeyValue<String, EventBuffer>> quiet = new ArrayList<>();
-        try (KeyValueIterator<String, EventBuffer> it = store.all()) {
-            while (it.hasNext()) {
-                KeyValue<String, EventBuffer> kv = it.next();
-                if (kv.value != null && !kv.value.pending.isEmpty()
-                        && nowWallMs - kv.value.lastUpdatedWallMs >= graceMs) {
-                    quiet.add(kv);   // 순회 중 store 를 건드리지 않으려고 먼저 모은다
-                }
+        List<String> quiet = new ArrayList<>();
+        for (Map.Entry<String, Long> e : pendingHosts.entrySet()) {
+            if (nowWallMs - e.getValue() >= graceMs) {
+                quiet.add(e.getKey());   // 순회 중 pendingHosts 를 건드리지 않으려고 먼저 모은다
             }
         }
-        for (KeyValue<String, EventBuffer> kv : quiet) {
+        // 조용해진 host 만 역직렬화한다. 아직 이벤트가 흐르는 host 는 store 를 읽지도 않는다.
+        for (String host : quiet) {
+            EventBuffer buffer = store.get(host);
+            if (buffer == null) {
+                pendingHosts.remove(host);
+                continue;
+            }
             // grace 를 이미 실제 시간으로 기다렸으니 그 host 가 본 마지막 시각까지 판정한다
-            flushPending(kv.key, kv.value, kv.value.maxTs);
-            prune(kv.value, kv.value.maxTs - graceMs);
-            save(kv.key, kv.value);
+            flushPending(host, buffer, buffer.maxTs);
+            prune(buffer, buffer.maxTs - graceMs);
+            save(host, buffer);
         }
     }
 
@@ -173,6 +205,12 @@ public class CorrelationProcessor implements Processor<String, Event, String, Al
 
     /** 빈 버퍼는 지운다. 남겨두면 스쳐간 host 마다 상태가 하나씩 쌓인다. */
     private void save(String host, EventBuffer buffer) {
+        // store 에 pending 이 남는 유일한 경로가 여기다. 여기서 같이 갱신해야 pendingHosts 가 store 와 어긋나지 않는다.
+        if (buffer.pending.isEmpty()) {
+            pendingHosts.remove(host);
+        } else {
+            pendingHosts.put(host, buffer.lastUpdatedWallMs);
+        }
         if (buffer.events.isEmpty() && buffer.pending.isEmpty()) {
             store.delete(host);
         } else {

--- a/detector-service/src/main/java/com/edrdog/detectorservice/kafkastreams/topology/CorrelationProcessor.java
+++ b/detector-service/src/main/java/com/edrdog/detectorservice/kafkastreams/topology/CorrelationProcessor.java
@@ -203,7 +203,19 @@ public class CorrelationProcessor implements Processor<String, Event, String, Al
         ctx.forward(new Record<>(host, alert, alert.ts()));
     }
 
-    /** 빈 버퍼는 지운다. 남겨두면 스쳐간 host 마다 상태가 하나씩 쌓인다. */
+    /**
+     * 빈 버퍼는 지운다. 남겨두면 스쳐간 host 마다 상태가 하나씩 쌓인다.
+     *
+     * <p>이벤트 1건마다 버퍼 전체가 다시 직렬화된다(RocksDB 는 값의 부분 갱신이 없다). 그래도 그냥 둔다.
+     * "내용이 안 바뀌었으면 put 을 거른다"는 손쉬운 절약이 안 되기 때문이다. maxTs 는 매 이벤트 갱신되고,
+     * 그걸 안 남기면 다음 이벤트의 워터마크가 뒤로 밀려 late/pending 분류가 달라진다.
+     * 실제로 걸러 보면 lateTrigger_isCountedAndStillEvaluated 가 깨진다.
+     *
+     * <p>(host, ts) 개별 키로 쪼개는 정공법은 store 구성(DetectionTopology)과 상태 스키마를 바꿔야 하고
+     * 워터마크·pending·상한 판정을 다시 짜야 한다. 판정이 바뀔 위험이 이득보다 크다.
+     * 참고로 매 이벤트 비용은 직렬화 한 번이 아니라 store.get 의 역직렬화까지 한 쌍이다.
+     * 손대야 할 만큼 비싼지는 지표로 먼저 확인할 것.
+     */
     private void save(String host, EventBuffer buffer) {
         // store 에 pending 이 남는 유일한 경로가 여기다. 여기서 같이 갱신해야 pendingHosts 가 store 와 어긋나지 않는다.
         if (buffer.pending.isEmpty()) {

--- a/detector-service/src/test/java/com/edrdog/detectorservice/kafkastreams/topology/CorrelationProcessorRestartTest.java
+++ b/detector-service/src/test/java/com/edrdog/detectorservice/kafkastreams/topology/CorrelationProcessorRestartTest.java
@@ -1,0 +1,132 @@
+package com.edrdog.detectorservice.kafkastreams.topology;
+
+import com.edrdog.detectorservice.dto.Alert;
+import com.edrdog.detectorservice.kafkastreams.serde.EventBufferSerde;
+import com.edrdog.detectorservice.support.TestEvents;
+import com.edrdog.schema.Event;
+import com.edrdog.schema.EventTypes;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.streams.processor.PunctuationType;
+import org.apache.kafka.streams.processor.api.MockProcessorContext;
+import org.apache.kafka.streams.processor.api.Record;
+import org.apache.kafka.streams.state.KeyValueStore;
+import org.apache.kafka.streams.state.Stores;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * 프로세서를 새로 만들었을 때(재시작·리밸런싱) 대기 중이던 트리거가 그대로 판정되는지 검증.
+ *
+ * <p>punctuate 가 보는 후보 목록(pendingHosts)은 프로세서 메모리에 있다. 그래서 프로세서가 새로 생기면
+ * init() 이 state store 를 훑어 복원해야 하고, 그게 안 되면 재시작 직전 대기 중이던 트리거가
+ * 단말이 다시 이벤트를 보낼 때까지 — 꺼졌다면 영영 — 판정되지 않는다. 여기서 막는다.
+ *
+ * <p>TopologyTestDriver 로는 이 시나리오를 못 만든다. driver.close() 가 상태 디렉터리를 지우고,
+ * 드라이버 안의 프로세서 인스턴스를 다시 init 할 방법도 없다. 그래서 프로세서를 직접 돌린다.
+ * store 는 값을 바이트로 들고 있어(serde 왕복) 복원된 상태를 읽는 상황과 같다.
+ */
+class CorrelationProcessorRestartTest {
+
+    private static final long WINDOW_MS = DetectionTopology.WINDOW_MS;
+    private static final long GRACE_MS = DetectionTopology.GRACE_MS;
+
+    private MockProcessorContext<String, Alert> ctx;
+    private KeyValueStore<String, EventBuffer> store;
+
+    @BeforeEach
+    void setUp() {
+        ctx = new MockProcessorContext<>();
+        store = Stores.keyValueStoreBuilder(
+                        Stores.inMemoryKeyValueStore(CorrelationProcessor.STORE),
+                        Serdes.String(),
+                        new EventBufferSerde())
+                .withLoggingDisabled()
+                .build();
+        store.init(ctx.getStateStoreContext(), store);
+        ctx.addStateStore(store);
+        ctx.setCurrentSystemTimeMs(10_000);
+    }
+
+    @AfterEach
+    void tearDown() {
+        store.close();
+    }
+
+    /** 새 프로세서를 붙인다. 재시작하면 실제로 이 일이 일어난다. */
+    private CorrelationProcessor startProcessor() {
+        CorrelationProcessor processor = new CorrelationProcessor(WINDOW_MS, GRACE_MS, new SimpleMeterRegistry());
+        processor.init(ctx);
+        return processor;
+    }
+
+    /** 마지막으로 붙은 프로세서가 등록한 punctuator 를 돌린다. */
+    private void punctuate(long nowWallMs) {
+        ctx.setCurrentSystemTimeMs(nowWallMs);
+        var punctuators = ctx.scheduledPunctuators();
+        var last = punctuators.get(punctuators.size() - 1);
+        assertThat(last.getType()).isEqualTo(PunctuationType.WALL_CLOCK_TIME);
+        last.getPunctuator().punctuate(nowWallMs);
+    }
+
+    private static Event process(String host, String proc, String parent, long ts) {
+        return TestEvents.of(host, EventTypes.PROCESS, ts, proc, parent, proc, null, 0, null, null, null, "tenant-a");
+    }
+
+    private List<String> forwardedRules() {
+        return ctx.forwarded().stream().map(f -> f.record().value().ruleId()).toList();
+    }
+
+    @Test
+    @DisplayName("재시작해도 대기 중이던 트리거는 grace 후 판정된다")
+    void pendingSurvivesRestart() {
+        CorrelationProcessor before = startProcessor();
+        before.process(new Record<>("host-1", process("host-1", "winword.exe", "explorer.exe", 1000), 1000));
+        before.process(new Record<>("host-1", process("host-1", "powershell.exe", "winword.exe", 2000), 2000));
+        assertThat(ctx.forwarded()).isEmpty();   // 아직 워터마크 전이라 대기 중이어야 한다
+        before.close();
+
+        // 재시작: 새 프로세서가 붙고, 남아 있는 state store 만으로 대기 목록을 되찾아야 한다
+        startProcessor();
+        punctuate(10_000 + GRACE_MS * 2);
+
+        assertThat(forwardedRules()).containsExactly("SUSPICIOUS_PROCESS_CHAIN");
+    }
+
+    @Test
+    @DisplayName("재시작 후에도 같은 트리거를 두 번 판정하지 않는다")
+    void restoredPendingIsEvaluatedOnce() {
+        // 중복 발행되면 responder 가 같은 프로세스에 kill 을 여러 번 쏜다.
+        CorrelationProcessor before = startProcessor();
+        before.process(new Record<>("host-1", process("host-1", "winword.exe", "explorer.exe", 1000), 1000));
+        before.process(new Record<>("host-1", process("host-1", "powershell.exe", "winword.exe", 2000), 2000));
+        before.close();
+
+        startProcessor();
+        punctuate(10_000 + GRACE_MS * 2);
+        punctuate(10_000 + GRACE_MS * 4);
+
+        assertThat(forwardedRules()).containsExactly("SUSPICIOUS_PROCESS_CHAIN");
+    }
+
+    @Test
+    @DisplayName("대기 트리거가 없는 host 는 복원 대상이 아니라 punctuate 가 아무것도 하지 않는다")
+    void hostWithoutPendingIsNotRestored() {
+        // 선행 근거만 쌓인 host 는 store 에 남지만 판정할 것이 없다. 여기서 알림이 나오면 오탐이다.
+        CorrelationProcessor before = startProcessor();
+        before.process(new Record<>("host-2", process("host-2", "winword.exe", "explorer.exe", 1000), 1000));
+        before.close();
+        assertThat(store.get("host-2")).isNotNull();
+
+        startProcessor();
+        punctuate(10_000 + GRACE_MS * 4);
+
+        assertThat(ctx.forwarded()).isEmpty();
+    }
+}


### PR DESCRIPTION
#211 의 2번. detector 만 바뀐다.

## 무엇이 바뀌나

`CorrelationProcessor` 의 punctuate 가 500ms 마다 `store.all()` 로 전 host 버퍼를 훑던 것을, pending 이 남은 host 만 보도록 좁혔다. 기존에는 pending 이 비었는지 확인하려고 모든 단말의 버퍼를 protobuf 로 역직렬화해야 했고, 비용이 단말 수에 정비례했다.

판정 결과는 바뀌지 않는다. 도착 순서를 뒤섞어도 탐지가 같은 것, 조용해진 단말의 대기 트리거가 grace 후 판정되는 것, 늦게 도착한 트리거 처리 모두 기존 테스트가 그대로 통과한다.

## 배포 관점

- **인프라 매니페스트 변경 없음.** `k8s/` 를 건드리지 않아 Job immutable, NodePort 재할당 같은 함정에 걸릴 자리가 없다. 변경은 `CorrelationProcessor.java` 와 신규 테스트 파일뿐이다.
- 롤아웃 시 detector 가 재시작하면서 state store 를 changelog 로 복원한 뒤, `init()` 이 store 를 한 번 훑어 대기 host 목록을 되살린다. 이 스캔이 없으면 재시작 직전 대기 중이던 트리거가 판정되지 않는다. `CorrelationProcessorRestartTest` 가 이 경로를 덮는다.
- 그 스캔은 태스크 할당당 한 번이라 기존 punctuate 순회와 달리 누적되지 않는다.

## 검증

`./gradlew :detector-service:cleanTest :detector-service:test` 로 캐시를 지우고 실행. 8개 클래스 86건 전부 통과, 실패 0, 스킵 0. PR #212 CI 도 통과했다.

## 함께 정리한 것

이슈 #211 은 원래 3건이었다.

- 1번(중복 repartition 제거)은 폐기했다. README 에 "생산자가 키를 수정하거나 삭제해도 상관분석이 깨지지 않게" 일부러 둔다고 적힌 의도적 설계였다. 실제로 rekey 를 없애보니 기존 테스트가 더미 키에 기대고 있어 2건이 깨졌고, 그 방어가 작동 중이었음이 드러났다.
- 3번(이벤트마다 버퍼 전체 재직렬화)은 손대지 않고 근거를 주석으로 남겼다. `maxTs` 가 매 이벤트 갱신되어 put 을 거를 수 없고, `(host, ts)` 분할은 판정 로직 재작성이라 위험이 이득보다 크다.
