### PR TITLE
fix: Kafka Streams 가 죽으면 readiness 가 DOWN 이 되게 한다

### DIFF
--- a/detector-service/src/main/java/com/edrdog/detectorservice/kafkastreams/health/KafkaStreamsHealthIndicator.java
+++ b/detector-service/src/main/java/com/edrdog/detectorservice/kafkastreams/health/KafkaStreamsHealthIndicator.java
@@ -1,0 +1,43 @@
+package com.edrdog.detectorservice.kafkastreams.health;
+
+import org.apache.kafka.streams.KafkaStreams;
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.HealthIndicator;
+import org.springframework.kafka.config.StreamsBuilderFactoryBean;
+import org.springframework.stereotype.Component;
+
+/**
+ * Kafka Streams 상태를 health 에 싣는다.
+ * actuator 기본 항목에는 Streams 가 없어서 태스크가 ERROR 로 죽어도 /actuator/health 는 UP 이었고,
+ * 탐지가 통째로 멈춘 채 배포가 초록으로 끝났다(이슈 #214).
+ * 빈 이름이 kafkaStreamsHealthIndicator 라 health 항목 이름은 kafkaStreams 가 된다.
+ * application.yml 의 readiness 그룹 include 가 이 이름을 가리킨다.
+ */
+@Component
+public class KafkaStreamsHealthIndicator implements HealthIndicator {
+
+    private final StreamsBuilderFactoryBean factoryBean;
+
+    public KafkaStreamsHealthIndicator(StreamsBuilderFactoryBean factoryBean) {
+        this.factoryBean = factoryBean;
+    }
+
+    @Override
+    public Health health() {
+        KafkaStreams streams = factoryBean.getKafkaStreams();
+        // 기동 초기엔 인스턴스가 아직 없다. 아직 준비가 안 된 것이므로 DOWN 이되, NPE 로 health 자체를 깨뜨리지는 않는다.
+        if (streams == null) {
+            return Health.down().withDetail("state", "NOT_STARTED").build();
+        }
+
+        KafkaStreams.State state = streams.state();
+        // RUNNING 과 REBALANCING 만 UP 이다. 리밸런싱은 태스크 재배치라 정상 과정이고,
+        // 이걸 DOWN 으로 보면 리밸런싱이 일어날 때마다 파드가 엔드포인트에서 빠진다.
+        // 나머지(CREATED, PENDING_SHUTDOWN, NOT_RUNNING, PENDING_ERROR, ERROR)는 판정이 안 도는 상태다.
+        // CREATED 는 고장은 아니지만 아직 이벤트를 처리하지 않으므로 readiness 기준으로는 DOWN 이다.
+        // 판정을 enum 자체 헬퍼에 맡겨야 Streams 가 상태를 늘려도 여기가 어긋나지 않는다.
+        return (state.isRunningOrRebalancing() ? Health.up() : Health.down())
+                .withDetail("state", state.name())
+                .build();
+    }
+}

--- a/detector-service/src/main/resources/application.yml
+++ b/detector-service/src/main/resources/application.yml
@@ -32,6 +32,21 @@ spring:
 server:
   port: 8081
 
+# Streams 가 죽으면 readiness 가 DOWN 이어야 파드가 트래픽에서 빠지고 배포도 거기서 멈춘다(이슈 #214).
+# liveness 는 건드리지 않는다. 리밸런싱 같은 정상 과정에서 재시작 루프에 빠질 수 있다.
+# 공용 observability.yml 이 아니라 여기 두는 이유: Streams 를 쓰는 서비스는 detector 뿐이다.
+management:
+  endpoint:
+    health:
+      probes:
+        enabled: true     # k8s 안에서는 자동으로 켜지지만, 로컬/테스트에서도 그룹이 뜨도록 명시한다
+      group:
+        readiness:
+          # kafkaStreams 는 KafkaStreamsHealthIndicator 빈 이름에서 접미사를 뗀 항목 이름이다.
+          # readinessState 를 같이 적어야 한다. include 를 쓰면 기본 구성원을 덮어쓴다.
+          # 없는 이름을 적으면 기동이 깨지므로(NoSuchHealthContributorException) 오타는 배포 전에 드러난다.
+          include: readinessState, kafkaStreams
+
 edrdog:
   kafka:
     events-topic: events      # 검증을 거친 엔드포인트 이벤트 (판정 입력)

--- a/detector-service/src/test/java/com/edrdog/detectorservice/kafkastreams/health/KafkaStreamsHealthIndicatorTest.java
+++ b/detector-service/src/test/java/com/edrdog/detectorservice/kafkastreams/health/KafkaStreamsHealthIndicatorTest.java
@@ -1,0 +1,61 @@
+package com.edrdog.detectorservice.kafkastreams.health;
+
+import org.apache.kafka.streams.KafkaStreams;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.Status;
+import org.springframework.kafka.config.StreamsBuilderFactoryBean;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/** Streams 상태를 readiness 관점으로 옮기는 규칙. 리밸런싱은 정상, 나머지 비정상 상태는 트래픽을 받으면 안 된다. */
+class KafkaStreamsHealthIndicatorTest {
+
+    private final StreamsBuilderFactoryBean factoryBean = mock(StreamsBuilderFactoryBean.class);
+    private final KafkaStreamsHealthIndicator indicator = new KafkaStreamsHealthIndicator(factoryBean);
+
+    @Test
+    @DisplayName("RUNNING 이면 UP")
+    void running_up() {
+        assertThat(healthOf(KafkaStreams.State.RUNNING).getStatus()).isEqualTo(Status.UP);
+    }
+
+    @Test
+    @DisplayName("REBALANCING 은 정상 과정이라 UP (DOWN 이면 리밸런싱마다 파드가 빠진다)")
+    void rebalancing_up() {
+        assertThat(healthOf(KafkaStreams.State.REBALANCING).getStatus()).isEqualTo(Status.UP);
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = KafkaStreams.State.class,
+            names = {"CREATED", "PENDING_SHUTDOWN", "NOT_RUNNING", "PENDING_ERROR", "ERROR"})
+    @DisplayName("판정이 안 도는 상태는 모두 DOWN")
+    void notProcessing_down(KafkaStreams.State state) {
+        Health health = healthOf(state);
+        assertThat(health.getStatus()).isEqualTo(Status.DOWN);
+        assertThat(health.getDetails()).containsEntry("state", state.name());
+    }
+
+    @Test
+    @DisplayName("기동 초기라 Streams 인스턴스가 아직 없으면 예외 없이 DOWN")
+    void notStarted_down() {
+        when(factoryBean.getKafkaStreams()).thenReturn(null);
+
+        Health health = indicator.health();
+
+        assertThat(health.getStatus()).isEqualTo(Status.DOWN);
+        assertThat(health.getDetails()).containsEntry("state", "NOT_STARTED");
+    }
+
+    private Health healthOf(KafkaStreams.State state) {
+        KafkaStreams streams = mock(KafkaStreams.class);
+        when(streams.state()).thenReturn(state);
+        when(factoryBean.getKafkaStreams()).thenReturn(streams);
+        return indicator.health();
+    }
+}

--- a/detector-service/src/test/java/com/edrdog/detectorservice/kafkastreams/health/StreamsHealthGroupTest.java
+++ b/detector-service/src/test/java/com/edrdog/detectorservice/kafkastreams/health/StreamsHealthGroupTest.java
@@ -1,0 +1,123 @@
+package com.edrdog.detectorservice.kafkastreams.health;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.streams.KafkaStreams;
+import org.apache.kafka.streams.StreamsConfig;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.actuate.autoconfigure.availability.AvailabilityHealthContributorAutoConfiguration;
+import org.springframework.boot.actuate.autoconfigure.availability.AvailabilityProbesAutoConfiguration;
+import org.springframework.boot.actuate.autoconfigure.health.HealthEndpointAutoConfiguration;
+import org.springframework.boot.actuate.health.HealthEndpoint;
+import org.springframework.boot.actuate.health.HealthEndpointGroups;
+import org.springframework.boot.actuate.health.Status;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.autoconfigure.availability.ApplicationAvailabilityAutoConfiguration;
+import org.springframework.boot.availability.AvailabilityChangeEvent;
+import org.springframework.boot.availability.LivenessState;
+import org.springframework.boot.availability.ReadinessState;
+import org.springframework.boot.test.context.ConfigDataApplicationContextInitializer;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.kafka.config.KafkaStreamsConfiguration;
+import org.springframework.kafka.config.StreamsBuilderFactoryBean;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * health group 설정이 실제로 먹는지 본다. 지표만 만들고 그룹에 안 들어가면 probe 는 여전히 UP 이라
+ * 아무것도 안 하는 코드가 된다.
+ * 프로퍼티를 테스트에 다시 적지 않고 ConfigData 로 실제 application.yml 을 읽는 이유가 이것이다.
+ * 이름이 없는 항목을 include 하면 컨텍스트 기동 자체가 깨지므로(NoSuchHealthContributorException)
+ * 오타는 이 테스트가 뜨는 것만으로도 걸린다.
+ */
+class StreamsHealthGroupTest {
+
+    private final ApplicationContextRunner runner = new ApplicationContextRunner()
+            .withInitializer(new ConfigDataApplicationContextInitializer())
+            .withConfiguration(AutoConfigurations.of(
+                    ApplicationAvailabilityAutoConfiguration.class,
+                    AvailabilityHealthContributorAutoConfiguration.class,
+                    AvailabilityProbesAutoConfiguration.class,   // probes 를 켜야 livenessState/readinessState 지표가 생긴다
+                    HealthEndpointAutoConfiguration.class))
+            .withBean(StubStreamsFactoryBean.class)
+            .withUserConfiguration(KafkaStreamsHealthIndicator.class);
+
+    @Test
+    @DisplayName("readiness 그룹에 kafkaStreams 가 들어가고 liveness 에는 안 들어간다")
+    void groupMembership() {
+        runner.run(ctx -> {
+            HealthEndpointGroups groups = ctx.getBean(HealthEndpointGroups.class);
+            assertThat(groups.get("readiness").isMember("kafkaStreams")).isTrue();
+            assertThat(groups.get("liveness").isMember("kafkaStreams")).isFalse();
+        });
+    }
+
+    @Test
+    @DisplayName("Streams 가 ERROR 면 readiness 가 DOWN, liveness 는 UP 그대로")
+    void streamsError_readinessDown() {
+        runner.run(ctx -> {
+            started(ctx);
+            streamsState(ctx, KafkaStreams.State.ERROR);
+
+            HealthEndpoint endpoint = ctx.getBean(HealthEndpoint.class);
+            assertThat(endpoint.healthForPath("readiness").getStatus()).isEqualTo(Status.DOWN);
+            assertThat(endpoint.healthForPath("liveness").getStatus()).isEqualTo(Status.UP);
+        });
+    }
+
+    @Test
+    @DisplayName("Streams 가 RUNNING 이면 readiness 가 UP")
+    void streamsRunning_readinessUp() {
+        runner.run(ctx -> {
+            started(ctx);
+            streamsState(ctx, KafkaStreams.State.RUNNING);
+
+            assertThat(ctx.getBean(HealthEndpoint.class).healthForPath("readiness").getStatus())
+                    .isEqualTo(Status.UP);
+        });
+    }
+
+    /**
+     * 기동이 끝난 상태를 만든다. 두 상태 모두 초기값(BROKEN / REFUSING_TRAFFIC)이라 그냥 두면
+     * 그룹이 늘 DOWN 이고 Streams 판정이 거기 묻힌다.
+     */
+    private static void started(org.springframework.context.ApplicationContext ctx) {
+        AvailabilityChangeEvent.publish(ctx, LivenessState.CORRECT);
+        AvailabilityChangeEvent.publish(ctx, ReadinessState.ACCEPTING_TRAFFIC);
+    }
+
+    private static void streamsState(org.springframework.context.ApplicationContext ctx, KafkaStreams.State state) {
+        KafkaStreams streams = mock(KafkaStreams.class);
+        when(streams.state()).thenReturn(state);
+        ctx.getBean(StubStreamsFactoryBean.class).setKafkaStreams(streams);
+    }
+
+    /**
+     * 목이 아니라 실제 FactoryBean 을 상속한다. 목으로 바꾸면 지표가 FactoryBean 을 타입으로 주입받는 게
+     * 실제로 되는지(FactoryBean 은 &이름으로 등록된다) 확인이 안 된다.
+     */
+    static class StubStreamsFactoryBean extends StreamsBuilderFactoryBean {
+
+        private KafkaStreams streams;
+
+        StubStreamsFactoryBean() {
+            super(new KafkaStreamsConfiguration(Map.of(
+                    StreamsConfig.APPLICATION_ID_CONFIG, "detector-test",
+                    ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092")));
+            setAutoStartup(false);   // 테스트에서 Kafka 에 붙지 않는다
+        }
+
+        void setKafkaStreams(KafkaStreams streams) {
+            this.streams = streams;
+        }
+
+        @Override
+        public synchronized KafkaStreams getKafkaStreams() {
+            return streams;   // 세팅 전에는 null 이라 기동 초기 상황과 같다
+        }
+    }
+}

--- a/k8s/detector-service.yaml
+++ b/k8s/detector-service.yaml
@@ -28,15 +28,17 @@ spec:
             # 메트릭/트레이스 OTLP 수집기 (k8s/otel-lgtm.yaml)
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: "http://otel-lgtm:4318"
+          # 경로를 그룹별로 나눠야 Kafka Streams 항목이 readiness 에만 걸린다(이슈 #214).
+          # 루트 /actuator/health 를 그대로 두면 Streams 가 죽어도 liveness 까지 DOWN 이 되어 재시작 루프에 빠진다.
           readinessProbe:
             httpGet:
-              path: /actuator/health
+              path: /actuator/health/readiness
               port: 8081
             initialDelaySeconds: 15
             periodSeconds: 10
           livenessProbe:
             httpGet:
-              path: /actuator/health
+              path: /actuator/health/liveness
               port: 8081
             initialDelaySeconds: 30
             periodSeconds: 20


### PR DESCRIPTION
## 문제

detector 는 Kafka Streams 가 ERROR 로 죽어도 `/actuator/health` 가 UP 이었다. 배포서버에서 확인한 실제 응답이다.

```
$ sudo kubectl -n edrdog exec deploy/detector-service -- curl -s localhost:8081/actuator/health
{"status":"UP","groups":["liveness","readiness"]}
```

Spring Boot Actuator 에는 Kafka Streams health indicator 가 없다. 그건 Spring Cloud Stream 바인더가 제공하는데 의존성에 없다. probe 는 통과하고 파드는 `1/1 Running` 을 유지하며 CD 의 `rollout status` 도 초록으로 끝난다. 탐지가 통째로 멈춘 채로.

`cd.yml:273-276` 이 archiver 에서 같은 함정을 겪은 기록을 남기고 있다. detector 가 멈추면 조회가 아니라 탐지가 멈추므로 영향이 더 크다.

## 무엇을 했나

Streams 상태를 읽는 `KafkaStreamsHealthIndicator` 를 추가하고 readiness 그룹에 넣었다.

판정은 `state.isRunningOrRebalancing()` 에 맡긴다. 상태 목록을 직접 나열하면 Streams 가 값을 늘렸을 때 여기가 조용히 어긋난다.

- `RUNNING`, `REBALANCING` → UP. 리밸런싱은 태스크 재배치라 정상 과정이고, 이걸 DOWN 으로 보면 리밸런싱마다 파드가 엔드포인트에서 빠진다
- `CREATED`, `PENDING_SHUTDOWN`, `NOT_RUNNING`, `PENDING_ERROR`, `ERROR` → DOWN. 판정이 안 도는 상태다
- 기동 초기라 인스턴스가 아직 없으면 DOWN. NPE 로 health 자체를 깨뜨리지 않는다

**liveness 는 건드리지 않았다.** 거기까지 DOWN 이 되면 리밸런싱 같은 정상 과정에서 재시작 루프에 빠진다. 운영 중 자동 재시작이 필요한지는 별개 판단이라 이 PR 범위가 아니다.

## 동작 변화 (주의)

probe 경로를 그룹별로 나눴다. 그래야 Streams 항목이 readiness 에만 걸린다.

| | 이전 | 이후 |
|:---|:---|:---|
| readinessProbe | `/actuator/health` | `/actuator/health/readiness` |
| livenessProbe | `/actuator/health` | `/actuator/health/liveness` |

그 결과 **검사 범위가 좁아진다.** 이전에는 루트 경로라 `diskSpace`, `ping` 등 모든 지표가 probe 에 걸렸다. 이제 liveness 는 `livenessState` 만, readiness 는 `readinessState` 와 `kafkaStreams` 만 본다.

의도한 방향이다. 디스크가 찼다고 파드를 재시작하거나 트래픽에서 빼는 것은 부작용이 더 크고, Spring Boot 의 k8s probe 지원이 정확히 이 형태를 전제한다.

## 검증

`./gradlew :detector-service:cleanTest :detector-service:test` (캐시 스킵 없이 실제 실행). 10개 클래스 97건 전부 통과, 실패 0, 스킵 0.

`StreamsHealthGroupTest` 는 프로퍼티를 테스트에 다시 적지 않고 `ConfigDataApplicationContextInitializer` 로 실제 `application.yml` 을 읽는다. 지표만 만들고 그룹에 안 들어가면 probe 는 여전히 UP 이라 아무것도 안 하는 코드가 되는데, 그걸 막기 위해서다.

- readiness 그룹에 `kafkaStreams` 가 들어가고 liveness 에는 안 들어간다
- Streams 가 ERROR 면 readiness 는 DOWN, liveness 는 UP 그대로
- 상태 5종에 대한 DOWN 판정, RUNNING/REBALANCING 의 UP 판정, 인스턴스 부재 시 예외 없음

include 에 없는 이름을 적으면 컨텍스트 기동이 `NoSuchHealthContributorException` 으로 깨지므로 오타는 이 테스트가 뜨는 것만으로 걸린다.

## 배포 함정

`k8s/detector-service.yaml` 의 Deployment probe 경로만 바꾼다. Job 의 immutable `spec.template` 도, 없앤 리소스도 없어서 두 함정 모두 해당하지 않는다.

Closes #214
