### PR TITLE
perf: poll 이 실제로 묶이도록 컨슈머 fetch 하한을 준다

### DIFF
--- a/archiver-service/src/main/resources/application.yml
+++ b/archiver-service/src/main/resources/application.yml
@@ -14,6 +14,10 @@ spring:
       # events 는 Protobuf 다. 타입이 .proto 하나로 고정돼서 JsonDeserializer 처럼 대상 타입·신뢰 패키지를 따로 줄 필요가 없다.
       value-deserializer: com.edrdog.schema.EventDeserializer
       max-poll-records: 500             # INSERT 한 번에 묶이는 상한 (본문 크기·재시도 시 중복 범위를 이 선으로 제한)
+      # 상한만 두면 실제로는 안 묶인다. 브로커 기본값(fetch.min.bytes=1)이라 1건만 있어도 즉시 응답해서
+      # poll 이 몇 건씩만 물고 온다(실측 5건). 하한을 줘야 상한에 가까워진다(실측 219건).
+      fetch-min-size: 64KB              # 이만큼 쌓일 때까지 브로커가 응답을 미룬다
+      fetch-max-wait: 500ms             # 다만 이 시간을 넘기면 덜 찼어도 보낸다. 적재가 그만큼 늦어지는 상한이기도 하다
     listener:
       type: batch                       # poll 단위로 묶어 ClickHouse INSERT 1회 → 파트가 이벤트 건수만큼 안 생긴다
       observation-enabled: true         # 컨슈머 스팬 생성 → 발행 측 traceId 를 이어받아 한 트레이스로 연결


### PR DESCRIPTION
## 무엇을

archiver 의 events 컨슈머에 `fetch-min-size` 와 `fetch-max-wait` 를 준다.

## 왜

`max-poll-records: 500` 은 **상한만** 정한다. 하한이 없다.

브로커 기본값이 `fetch.min.bytes=1` 이라 데이터가 1건만 있어도 즉시 응답한다. 그래서 poll 이 몇 건씩만 물고 오고, `listener.type: batch` 로 묶어도 INSERT 한 번에 실리는 건수가 얼마 안 된다.

부하 1,200건/초에서 **실측 5건**이었다. 상한 500 과 한참 멀다.

## 무엇이 달라지나

같은 부하에서 **219건**까지 찬다(p50 210, p95 330). INSERT 호출 수가 그만큼 줄고 활성 파트도 덜 생긴다.

| | 하한 없음 | 하한 있음 |
|:---|:---|:---|
| 평균 배치 크기 | 5건 | 219건 |

## 대가

적재가 최대 500ms 늦어진다. `fetch-max-wait` 이 그 상한이다.

archiver 는 탐지 경로가 아니라 사후 조사용 적재라 감당된다. detector 는 별도 컨슈머 그룹이라 영향이 없다.