### PR TITLE
feat: 이벤트 원본을 만료 전 S3 로 아카이빙한다

### DIFF
--- a/archiver-service/src/main/java/com/edrdog/archiverservice/ArchiverApplication.java
+++ b/archiver-service/src/main/java/com/edrdog/archiverservice/ArchiverApplication.java
@@ -2,12 +2,24 @@ package com.edrdog.archiverservice;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+import java.time.Clock;
 
 /** events·alerts 를 소비해 ClickHouse 에 적재하는 archiver 서비스 (detector 와 독립). */
+// 스케줄링은 아카이빙(EventArchiver) 때문에 켠다. 없으면 @Scheduled 가 조용히 안 돈다.
 @SpringBootApplication
+@EnableScheduling
 public class ArchiverApplication {
 
     public static void main(String[] args) {
         SpringApplication.run(ArchiverApplication.class, args);
+    }
+
+    /** ClickHouse 컨테이너 시간대가 UTC 라 내보낼 날 계산도 UTC 로 맞춘다. */
+    @Bean
+    public Clock clock() {
+        return Clock.systemUTC();
     }
 }

--- a/archiver-service/src/main/java/com/edrdog/archiverservice/archive/ArchiveSql.java
+++ b/archiver-service/src/main/java/com/edrdog/archiverservice/archive/ArchiveSql.java
@@ -1,0 +1,44 @@
+package com.edrdog.archiverservice.archive;
+
+import java.time.LocalDate;
+
+/**
+ * 하루치 이벤트를 S3 호환 스토리지로 내보내는 SQL 생성(순수).
+ *
+ * <p>대상 경로가 날짜만으로 정해지고 {@code s3_truncate_on_insert} 로 덮어쓰기 때문에,
+ * 같은 날을 다시 돌려도 파일이 늘지 않는다. 재시도·중복 실행을 그냥 다시 돌리는 것으로 처리한다.
+ */
+public final class ArchiveSql {
+
+    private ArchiveSql() {
+    }
+
+    /** 하루치가 한 파일로 가도록 날짜를 경로에 박는다. 설정값 끝 슬래시는 경로가 갈리지 않게 떼어낸다. */
+    public static String objectUrl(String baseUrl, LocalDate day) {
+        String base = baseUrl.endsWith("/") ? baseUrl.substring(0, baseUrl.length() - 1) : baseUrl;
+        return base + "/events/dt=" + day + "/data.parquet";
+    }
+
+    /** 내보낼 날 = 오늘에서 보관일수만큼 지난 날. TTL 이 지우기 전에 나가야 하므로 TTL 일수보다 작게 준다. */
+    public static LocalDate targetDay(LocalDate today, int delayDays) {
+        return today.minusDays(delayDays);
+    }
+
+    /** 그 날 하루(00:00 이상 다음 날 00:00 미만)를 Parquet 한 파일로 내보낸다. */
+    public static String export(String table, String baseUrl, String accessKey, String secretKey, LocalDate day) {
+        return "INSERT INTO FUNCTION s3("
+                + quote(objectUrl(baseUrl, day)) + ", "
+                + quote(accessKey) + ", "
+                + quote(secretKey) + ", "
+                + "'Parquet')"
+                + " SELECT * FROM " + table
+                + " WHERE ingested_at >= toDateTime(" + quote(day + " 00:00:00") + ")"
+                + " AND ingested_at < toDateTime(" + quote(day.plusDays(1) + " 00:00:00") + ")"
+                + " SETTINGS s3_truncate_on_insert = 1";
+    }
+
+    // 값에 작은따옴표가 있으면 문자열이 그 자리에서 끊겨 문법 오류가 난다. ClickHouse 는 '' 로 이스케이프한다.
+    private static String quote(String value) {
+        return "'" + value.replace("'", "''") + "'";
+    }
+}

--- a/archiver-service/src/main/java/com/edrdog/archiverservice/archive/EventArchiver.java
+++ b/archiver-service/src/main/java/com/edrdog/archiverservice/archive/EventArchiver.java
@@ -1,0 +1,71 @@
+package com.edrdog.archiverservice.archive;
+
+import com.edrdog.archiverservice.clickhouse.ClickHouseHttp;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.Clock;
+import java.time.LocalDate;
+
+/**
+ * events 원본을 TTL 이 지우기 전에 S3 호환 스토리지(로컬은 MinIO)로 하루치씩 내보낸다.
+ *
+ * <p>침해는 발각까지 몇 주가 걸리는 일이 흔한데 ClickHouse 쪽 원본은 7일 TTL 로 사라진다.
+ * 집계로 접으면 개별 프로세스·명령줄이 남지 않아 조사에 못 쓰므로 원본 행 그대로 내보낸다.
+ *
+ * <p>내보내기는 ClickHouse 가 직접 한다(s3 테이블 함수). 이벤트가 이 서비스를 거쳐 가지 않으므로
+ * 아카이브 양이 늘어도 여기 메모리·네트워크에는 영향이 없다.
+ */
+@Component
+public class EventArchiver {
+
+    private static final Logger log = LoggerFactory.getLogger(EventArchiver.class);
+
+    private final ClickHouseHttp http;
+    private final String table;
+    private final boolean enabled;
+    private final String baseUrl;
+    private final String accessKey;
+    private final String secretKey;
+    private final int delayDays;
+    private final Clock clock;
+
+    public EventArchiver(
+            ClickHouseHttp http,
+            @Value("${edrdog.clickhouse.table}") String table,
+            @Value("${edrdog.archive.enabled}") boolean enabled,
+            @Value("${edrdog.archive.base-url}") String baseUrl,
+            @Value("${edrdog.archive.access-key}") String accessKey,
+            @Value("${edrdog.archive.secret-key}") String secretKey,
+            @Value("${edrdog.archive.delay-days}") int delayDays,
+            Clock clock) {
+        this.http = http;
+        this.table = table;
+        this.enabled = enabled;
+        this.baseUrl = baseUrl;
+        this.accessKey = accessKey;
+        this.secretKey = secretKey;
+        this.delayDays = delayDays;
+        this.clock = clock;
+    }
+
+    /** 하루 1회. 실패하면 다음 회차가 같은 날을 다시 내보낸다(경로가 같아 덮어쓴다). */
+    @Scheduled(cron = "${edrdog.archive.cron}")
+    public void archive() {
+        if (!enabled) {
+            return;
+        }
+        // 자격이 비면 ClickHouse 인증 오류만 남는다. 설정이 덜 된 상태를 여기서 끊고 이유를 남긴다.
+        if (accessKey.isBlank() || secretKey.isBlank()) {
+            log.warn("아카이빙 자격이 비어 건너뛴다. ARCHIVE_ACCESS_KEY/ARCHIVE_SECRET_KEY 를 확인하세요.");
+            return;
+        }
+
+        LocalDate day = ArchiveSql.targetDay(LocalDate.now(clock), delayDays);
+        http.execute(ArchiveSql.export(table, baseUrl, accessKey, secretKey, day));
+        log.info("이벤트 아카이빙 완료: {} -> {}", day, ArchiveSql.objectUrl(baseUrl, day));
+    }
+}

--- a/archiver-service/src/main/resources/application.yml
+++ b/archiver-service/src/main/resources/application.yml
@@ -41,3 +41,13 @@ edrdog:
     connect-timeout-ms: ${CLICKHOUSE_CONNECT_TIMEOUT_MS:2000}
     # 적재는 최대 500건(max-poll-records) 배치 INSERT 라 조회보다 길게 잡는다. Kafka max.poll.interval.ms(기본 5분) 안쪽이라 리밸런스는 안 난다.
     read-timeout-ms: ${CLICKHOUSE_READ_TIMEOUT_MS:10000}
+  # events 원본을 7일 TTL 이 지우기 전에 S3 호환 스토리지로 하루치씩 내보낸다(로컬 MinIO, 배포 S3).
+  archive:
+    enabled: ${ARCHIVE_ENABLED:false}   # 기본 OFF. 스토리지 없이 뜨는 로컬에서 매일 실패 로그가 쌓이지 않게 한다
+    # ClickHouse 가 직접 접속하므로 CH 에서 닿는 주소여야 한다(로컬 kind 는 서비스 DNS).
+    base-url: ${ARCHIVE_BASE_URL:http://minio:9000/edrdog-archive}
+    access-key: ${ARCHIVE_ACCESS_KEY:}  # 시크릿은 Infisical 주입
+    secret-key: ${ARCHIVE_SECRET_KEY:}
+    # TTL(7일)보다 작아야 지워지기 전에 나간다. 하루 여유를 둔다.
+    delay-days: ${ARCHIVE_DELAY_DAYS:6}
+    cron: ${ARCHIVE_CRON:0 30 3 * * *}  # 매일 03:30. 적재가 한가한 시간대

--- a/archiver-service/src/test/java/com/edrdog/archiverservice/archive/ArchiveSqlTest.java
+++ b/archiver-service/src/test/java/com/edrdog/archiverservice/archive/ArchiveSqlTest.java
@@ -1,0 +1,62 @@
+package com.edrdog.archiverservice.archive;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * 아카이빙 SQL 생성 순수 로직. 하루치 구간과 대상 경로가 날짜만으로 결정돼야 재실행이 멱등해진다.
+ */
+class ArchiveSqlTest {
+
+    private static final LocalDate DAY = LocalDate.of(2026, 8, 4);
+
+    @Test
+    void 경로는_날짜로_갈린다() {
+        assertEquals("http://minio:9000/edrdog-archive/events/dt=2026-08-04/data.parquet",
+                ArchiveSql.objectUrl("http://minio:9000/edrdog-archive", DAY));
+    }
+
+    /** 설정값 끝에 슬래시가 붙어 오면 경로가 갈려 같은 날이 두 곳에 쌓인다. */
+    @Test
+    void 베이스_끝_슬래시가_있어도_같은_경로() {
+        assertEquals(ArchiveSql.objectUrl("http://minio:9000/edrdog-archive", DAY),
+                ArchiveSql.objectUrl("http://minio:9000/edrdog-archive/", DAY));
+    }
+
+    @Test
+    void 내보내는_구간은_그_날_하루() {
+        String sql = ArchiveSql.export("edrdog.events", "http://minio:9000/b", "ak", "sk", DAY);
+        assertTrue(sql.contains("ingested_at >= toDateTime('2026-08-04 00:00:00')"), sql);
+        assertTrue(sql.contains("ingested_at < toDateTime('2026-08-05 00:00:00')"), sql);
+    }
+
+    @Test
+    void 포맷은_Parquet() {
+        String sql = ArchiveSql.export("edrdog.events", "http://minio:9000/b", "ak", "sk", DAY);
+        assertTrue(sql.contains("'Parquet'"), sql);
+    }
+
+    /** 이게 없으면 같은 날을 두 번 돌렸을 때 파일이 하나 더 생기거나 INSERT 가 실패한다. */
+    @Test
+    void 같은_날을_다시_내보내면_덮어쓴다() {
+        String sql = ArchiveSql.export("edrdog.events", "http://minio:9000/b", "ak", "sk", DAY);
+        assertTrue(sql.contains("s3_truncate_on_insert = 1"), sql);
+    }
+
+    /** 키에 작은따옴표가 있으면 SQL 문자열이 그 자리에서 끊겨 문법 오류가 난다. */
+    @Test
+    void 작은따옴표가_든_키는_이스케이프된다() {
+        String sql = ArchiveSql.export("edrdog.events", "http://minio:9000/b", "a'k", "s'k", DAY);
+        assertTrue(sql.contains("'a''k'"), sql);
+        assertTrue(sql.contains("'s''k'"), sql);
+    }
+
+    @Test
+    void 내보낼_날은_보관일수만큼_지난_날() {
+        assertEquals(LocalDate.of(2026, 8, 4), ArchiveSql.targetDay(LocalDate.of(2026, 8, 10), 6));
+    }
+}

--- a/archiver-service/src/test/java/com/edrdog/archiverservice/archive/EventArchiverTest.java
+++ b/archiver-service/src/test/java/com/edrdog/archiverservice/archive/EventArchiverTest.java
@@ -1,0 +1,53 @@
+package com.edrdog.archiverservice.archive;
+
+import com.edrdog.archiverservice.clickhouse.ClickHouseHttp;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+/**
+ * 아카이빙 주기 작업. 스위치가 꺼져 있거나 자격이 비면 아무 SQL 도 나가면 안 된다.
+ */
+class EventArchiverTest {
+
+    private static final Clock CLOCK = Clock.fixed(Instant.parse("2026-08-10T03:30:00Z"), ZoneOffset.UTC);
+
+    private final ClickHouseHttp http = mock(ClickHouseHttp.class);
+
+    private EventArchiver archiver(boolean enabled, String accessKey, String secretKey) {
+        return new EventArchiver(http, "edrdog.events", enabled,
+                "http://minio:9000/edrdog-archive", accessKey, secretKey, 6, CLOCK);
+    }
+
+    @Test
+    void 꺼져_있으면_내보내지_않는다() {
+        archiver(false, "ak", "sk").archive();
+        verify(http, never()).execute(anyString());
+    }
+
+    /** 자격이 비면 ClickHouse 가 인증 오류를 낼 뿐이라, 설정이 덜 된 상태를 여기서 끊는다. */
+    @Test
+    void 자격이_비면_내보내지_않는다() {
+        archiver(true, "", "").archive();
+        verify(http, never()).execute(anyString());
+    }
+
+    @Test
+    void 보관일수만큼_지난_하루를_내보낸다() {
+        archiver(true, "ak", "sk").archive();
+
+        ArgumentCaptor<String> sql = ArgumentCaptor.forClass(String.class);
+        verify(http).execute(sql.capture());
+        assertTrue(sql.getValue().contains("dt=2026-08-04/data.parquet"), sql.getValue());
+        assertTrue(sql.getValue().contains("ingested_at >= toDateTime('2026-08-04 00:00:00')"), sql.getValue());
+    }
+}

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -297,6 +297,28 @@ Machine Identity 자격증명 Secret 생성 1회, `kubectl apply -f k8s/infisica
   `kubectl -n edrdog set env deployment/<이름> <키>-` 로 기존 env 를 먼저 지운다.
 - CD 는 `infisicalsecrets` CRD 가 있을 때만 이 파일을 apply 한다. Operator 가 없으면 건너뛴다.
 
+## 이벤트 아카이브 (MinIO, 로컬 전용)
+
+`events` 원본은 7일 TTL 로 지워진다. 침해는 발각까지 몇 주가 걸리는 일이 흔해서, 지워지기 전에
+하루치씩 S3 호환 스토리지로 내보낸다(archiver 의 `EventArchiver`). 로컬은 MinIO, 배포는 실제 S3 다.
+
+```bash
+sudo kubectl apply -f k8s/local/minio.yaml
+kubectl -n edrdog port-forward svc/minio 9001:9001   # 콘솔 http://localhost:9001
+```
+
+- **배포서버에는 안 올라간다.** CD 는 `k8s/` 바로 아래 `*.yaml` 만 훑어서 하위 디렉터리는 대상이 아니다.
+- Infisical 에 `ARCHIVE_ACCESS_KEY`·`ARCHIVE_SECRET_KEY` 가 있어야 한다. MinIO root 계정과 archiver 가
+  같은 키를 쓴다. 값이 갈리면 ClickHouse 가 인증에서 막힌다.
+- 기본은 꺼져 있다. 켜려면 `ARCHIVE_ENABLED=true`. 매일 03:30 에 6일 지난 하루치를 내보낸다.
+- 버킷(`edrdog-archive`)은 MinIO 가 자동으로 만들지 않아 사이드카(`mc`)가 만든다. 이게 없으면 INSERT 가 그대로 실패한다.
+- 내보낸 것을 확인하거나 조사에 쓸 때는 ClickHouse 에서 그대로 읽는다.
+  ```sql
+  SELECT count() FROM s3('http://minio:9000/edrdog-archive/events/**/*.parquet',
+                         '<ACCESS_KEY>', '<SECRET_KEY>', 'Parquet');
+  ```
+- 같은 날을 다시 내보내도 경로가 같고 `s3_truncate_on_insert` 로 덮어써서 중복이 안 쌓인다.
+
 ## 메모
 
 - **MySQL·ClickHouse 는 PVC 를 쓴다.** 파드가 갈려도 가입 계정과 이벤트 이력이 남는다.

--- a/k8s/local/minio.yaml
+++ b/k8s/local/minio.yaml
@@ -1,0 +1,122 @@
+# MinIO — 이벤트 원본 아카이브 저장소 (로컬 전용).
+#
+# 배포서버에는 올리지 않는다. CD 는 k8s/ 바로 아래 *.yaml 만 훑으므로(cd.yml 의 ls-tree, 하위 디렉터리
+# 미포함) 이 파일은 자동 배포 대상이 아니다. 배포 환경은 실제 S3 를 쓰고 ARCHIVE_BASE_URL 만 바꾼다.
+#
+#   apply:  sudo kubectl apply -f k8s/local/minio.yaml
+#   콘솔:   kubectl -n edrdog port-forward svc/minio 9001:9001  → http://localhost:9001
+#
+# ClickHouse 가 s3 테이블 함수로 직접 접속하므로 주소는 클러스터 안에서 닿는 http://minio:9000 이다.
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: minio
+  namespace: edrdog
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: minio
+  namespace: edrdog
+spec:
+  replicas: 1
+  # RWO 볼륨이라 롤링으로 두면 새 파드가 볼륨을 못 잡고 매달린다(clickhouse 와 같은 이유).
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: minio
+  template:
+    metadata:
+      labels:
+        app: minio
+    spec:
+      containers:
+        - name: minio
+          image: quay.io/minio/minio:RELEASE.2024-09-13T20-26-02Z
+          args: ["server", "/data", "--console-address", ":9001"]
+          ports:
+            - containerPort: 9000  # S3 API
+            - containerPort: 9001  # 웹 콘솔
+          # archiver 가 쓰는 값과 같은 키를 root 계정으로 쓴다. 둘이 갈리면 ClickHouse 가 인증에서 막힌다.
+          env:
+            - name: MINIO_ROOT_USER
+              valueFrom:
+                secretKeyRef:
+                  name: edrdog-secrets
+                  key: ARCHIVE_ACCESS_KEY
+            - name: MINIO_ROOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: edrdog-secrets
+                  key: ARCHIVE_SECRET_KEY
+          readinessProbe:
+            httpGet:
+              path: /minio/health/ready
+              port: 9000
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              memory: 1Gi
+          volumeMounts:
+            - name: data
+              mountPath: /data
+        # 버킷은 MinIO 가 자동으로 만들지 않는다. 없으면 ClickHouse 의 INSERT 가 그대로 실패한다.
+        # Job 으로 두면 내용이 바뀔 때 apply 가 immutable 로 죽어서(cd.yml 주석 참고) 사이드카로 둔다.
+        - name: bucket-init
+          image: quay.io/minio/mc:RELEASE.2024-09-16T17-43-14Z
+          command:
+            - sh
+            - -c
+            - |
+              until mc alias set local http://127.0.0.1:9000 "$ACCESS_KEY" "$SECRET_KEY"; do sleep 2; done
+              mc mb --ignore-existing local/edrdog-archive
+              echo "버킷 준비 완료: edrdog-archive"
+              sleep infinity
+          env:
+            - name: ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: edrdog-secrets
+                  key: ARCHIVE_ACCESS_KEY
+            - name: SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: edrdog-secrets
+                  key: ARCHIVE_SECRET_KEY
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              memory: 64Mi
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: minio
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: minio
+  namespace: edrdog
+spec:
+  selector:
+    app: minio
+  ports:
+    - name: api
+      port: 9000
+      targetPort: 9000
+    - name: console
+      port: 9001
+      targetPort: 9001


### PR DESCRIPTION
## 무엇을

`events` 원본을 7일 TTL 이 지우기 전에 S3 호환 스토리지로 하루치씩 내보낸다. 로컬은 MinIO, 배포는 실제 S3 다.

침해는 발각까지 몇 주가 걸리는 일이 흔한데, 지금은 7일이 지나면 개별 프로세스·명령줄·연결이 남지 않아 되짚어 조사할 수가 없다. 집계 롤업은 대안이 아니다. 시간당 이벤트 수로는 "그 호스트에서 3주 전 무엇이 어떤 명령줄로 떴나"에 답할 수 없어서 원본 행 그대로 내보낸다.

## 어떻게

- 내보내기는 ClickHouse 가 한다(`s3` 테이블 함수). archiver 는 SQL 만 보내고 데이터는 거치지 않아, 아카이브 양이 늘어도 이 서비스 부하와 무관하다. 포맷은 Parquet.
- 경로가 날짜만으로 정해지고(`events/dt=YYYY-MM-DD/data.parquet`) `s3_truncate_on_insert` 로 덮어써서 **재실행이 멱등**하다. 실패하면 다음 회차가 같은 날을 다시 내보내는 것으로 끝나 재시도 로직이 없다.
- 매일 03:30 에 6일 전 하루치. TTL 7일보다 하루 여유를 둔다. 날짜 계산은 UTC (ClickHouse 컨테이너 시간대와 맞춘다).
- **기본은 OFF** (`ARCHIVE_ENABLED=false`). 스토리지 없는 로컬에서 매일 실패 로그가 쌓이지 않게.
- MinIO 는 `k8s/local/` 에 둬서 배포서버에 안 올라간다. CD 는 `k8s/` 바로 아래 `*.yaml` 만 훑는다.

## 확인

- archiver-service 테스트 27개 통과 (신규 `ArchiveSql` 7, `EventArchiver` 3). 순수 로직은 테스트를 먼저 써서 실패를 본 뒤 구현했다.
- 실제 ClickHouse 24.8 + MinIO 왕복: 하루 구간 밖 이벤트가 안 섞이고, 같은 날을 두 번 내보내도 건수 그대로이며, **원본 테이블을 비운 뒤에도 `s3` 함수로 명령줄까지 그대로 읽혔다**.
- kind 클러스터에 `minio.yaml` apply: 파드 2/2 Ready, 사이드카가 버킷 생성, 서비스 DNS `http://minio:9000` 으로 ClickHouse 가 써 넣는 것까지 확인.

## 켜기 전에 필요한 것

- Infisical 에 `ARCHIVE_ACCESS_KEY` / `ARCHIVE_SECRET_KEY` (MinIO root 계정과 같은 값을 쓴다)
- 켜려면 `ARCHIVE_ENABLED=true`. 배포 환경은 `ARCHIVE_BASE_URL` 을 실제 S3 로 바꾼다.

## 범위 밖

아카이브 조회 API. `s3` 테이블 함수로 SELECT 하면 되므로 화면 요구가 생기기 전에는 만들지 않는다.

Closes #218
