### PR TITLE
fix: 에이전트 기동 시간을 startupProbe 로 받아낸다

### DIFF
--- a/k8s/alert-service.yaml
+++ b/k8s/alert-service.yaml
@@ -41,6 +41,15 @@ spec:
             # 로그도 에이전트가 보낸다(그래서 Alloy 를 뺐다). 기본값에 기대지 않고 명시한다.
             - name: NEW_RELIC_APPLICATION_LOGGING_FORWARDING_ENABLED
               value: "true"
+          # 뉴렐릭 자바 에이전트가 기동에 시간을 얹어서 liveness(30s + 20s*3)가 먼저 파드를 죽였다(#226).
+          # initialDelaySeconds 를 늘리면 기동 후 장애 감지까지 계속 둔해진다. startupProbe 는 기동 중에만
+          # 봐주고 통과하는 즉시 원래 프로브가 제 간격으로 돌아온다.
+          startupProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8083
+            periodSeconds: 10
+            failureThreshold: 30          # 최대 300초까지 기다린다
           readinessProbe:
             httpGet:
               path: /actuator/health

--- a/k8s/api-service.yaml
+++ b/k8s/api-service.yaml
@@ -66,6 +66,15 @@ spec:
               value: "https://edrdog-api.duckdns.org"
             - name: INSTALL_AGENT_SERVER
               value: "edrdog-api.duckdns.org:30443"
+          # 뉴렐릭 자바 에이전트가 기동에 시간을 얹어서 liveness(30s + 20s*3)가 먼저 파드를 죽였다(#226).
+          # initialDelaySeconds 를 늘리면 기동 후 장애 감지까지 계속 둔해진다. startupProbe 는 기동 중에만
+          # 봐주고 통과하는 즉시 원래 프로브가 제 간격으로 돌아온다.
+          startupProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8084
+            periodSeconds: 10
+            failureThreshold: 30          # 최대 300초까지 기다린다
           readinessProbe:
             httpGet:
               path: /actuator/health

--- a/k8s/archiver-service.yaml
+++ b/k8s/archiver-service.yaml
@@ -42,6 +42,15 @@ spec:
             # 로그도 에이전트가 보낸다(그래서 Alloy 를 뺐다). 기본값에 기대지 않고 명시한다.
             - name: NEW_RELIC_APPLICATION_LOGGING_FORWARDING_ENABLED
               value: "true"
+          # 뉴렐릭 자바 에이전트가 기동에 시간을 얹어서 liveness(30s + 20s*3)가 먼저 파드를 죽였다(#226).
+          # initialDelaySeconds 를 늘리면 기동 후 장애 감지까지 계속 둔해진다. startupProbe 는 기동 중에만
+          # 봐주고 통과하는 즉시 원래 프로브가 제 간격으로 돌아온다.
+          startupProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8083
+            periodSeconds: 10
+            failureThreshold: 30          # 최대 300초까지 기다린다
           readinessProbe:
             httpGet:
               path: /actuator/health

--- a/k8s/collector-service.yaml
+++ b/k8s/collector-service.yaml
@@ -71,6 +71,15 @@ spec:
             # 로그도 에이전트가 보낸다(그래서 Alloy 를 뺐다). 기본값에 기대지 않고 명시한다.
             - name: NEW_RELIC_APPLICATION_LOGGING_FORWARDING_ENABLED
               value: "true"
+          # 뉴렐릭 자바 에이전트가 기동에 시간을 얹어서 liveness(30s + 20s*3)가 먼저 파드를 죽였다(#226).
+          # initialDelaySeconds 를 늘리면 기동 후 장애 감지까지 계속 둔해진다. startupProbe 는 기동 중에만
+          # 봐주고 통과하는 즉시 원래 프로브가 제 간격으로 돌아온다.
+          startupProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8082
+            periodSeconds: 10
+            failureThreshold: 30          # 최대 300초까지 기다린다
           readinessProbe:
             httpGet:
               path: /actuator/health

--- a/k8s/detector-service.yaml
+++ b/k8s/detector-service.yaml
@@ -41,6 +41,15 @@ spec:
               value: "true"
           # 경로를 그룹별로 나눠야 Kafka Streams 항목이 readiness 에만 걸린다(이슈 #214).
           # 루트 /actuator/health 를 그대로 두면 Streams 가 죽어도 liveness 까지 DOWN 이 되어 재시작 루프에 빠진다.
+          # 뉴렐릭 자바 에이전트가 기동에 시간을 얹어서 liveness(30s + 20s*3)가 먼저 파드를 죽였다(#226).
+          # initialDelaySeconds 를 늘리면 기동 후 장애 감지까지 계속 둔해진다. startupProbe 는 기동 중에만
+          # 봐주고 통과하는 즉시 원래 프로브가 제 간격으로 돌아온다.
+          startupProbe:
+            httpGet:
+              path: /actuator/health/readiness
+              port: 8081
+            periodSeconds: 10
+            failureThreshold: 30          # 최대 300초까지 기다린다
           readinessProbe:
             httpGet:
               path: /actuator/health/readiness

--- a/k8s/responder-service.yaml
+++ b/k8s/responder-service.yaml
@@ -42,6 +42,15 @@ spec:
             # 로그도 에이전트가 보낸다(그래서 Alloy 를 뺐다). 기본값에 기대지 않고 명시한다.
             - name: NEW_RELIC_APPLICATION_LOGGING_FORWARDING_ENABLED
               value: "true"
+          # 뉴렐릭 자바 에이전트가 기동에 시간을 얹어서 liveness(30s + 20s*3)가 먼저 파드를 죽였다(#226).
+          # initialDelaySeconds 를 늘리면 기동 후 장애 감지까지 계속 둔해진다. startupProbe 는 기동 중에만
+          # 봐주고 통과하는 즉시 원래 프로브가 제 간격으로 돌아온다.
+          startupProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8082
+            periodSeconds: 10
+            failureThreshold: 30          # 최대 300초까지 기다린다
           readinessProbe:
             httpGet:
               path: /actuator/health


### PR DESCRIPTION
Closes #226

#223 배포가 롤아웃 타임아웃으로 실패한 것을 고친다.

## 원인

기동이 느린 게 아니라 liveness 가 파드를 죽이고 있었다.

```
api-service-849d47dff8-tbnhp        0/1  Running  2 (39s ago)
collector-service-7cc94b95d4-ggjbd  0/1  Running  2 (79s ago)
detector-service-7c9d4b5d67-2xtrs   1/1  Running  2 (98s ago)
```

detector 로그상 Kafka Streams 는 `REBALANCING → RUNNING` 까지 정상으로 간다. 앱은 멀쩡한데 그 전에 죽은 것이다. liveness 가 `30s + 20s × 3 = 90초` 안에 응답을 요구하는데 에이전트가 얹은 기동 시간이 그걸 넘겼다. 가벼운 alert/archiver/responder 만 간신히 통과했다.

## 해결

`startupProbe` (`periodSeconds: 10`, `failureThreshold: 30`, 최대 300초).

기동 중에는 liveness·readiness 가 아예 돌지 않고, 통과하는 즉시 원래 프로브가 제 간격으로 돌아온다.

**`initialDelaySeconds` 를 늘리지 않은 이유**: 그러면 기동을 넘긴 뒤에도 장애 감지가 계속 둔해진다. 문제는 기동 구간에만 있으므로 그 구간에만 느슨하게 하는 게 맞다.

경로는 각 서비스의 readinessProbe 와 같게 뒀다. 그래야 "기동 완료"가 "실제로 받을 준비가 됨"과 같은 뜻이 된다. detector 는 `/actuator/health/readiness` 라 Streams 가 RUNNING 이어야 통과한다.

## 검증

- 6개 매니페스트 YAML 파싱 + `startupProbe` 존재 확인
- 실제 롤아웃은 배포 후 확인