### PR TITLE
fix: dev 반영 (startupProbe)

### DIFF
--- a/k8s/alert-service.yaml
+++ b/k8s/alert-service.yaml
@@ -41,6 +41,15 @@ spec:
             # 로그도 에이전트가 보낸다(그래서 Alloy 를 뺐다). 기본값에 기대지 않고 명시한다.
             - name: NEW_RELIC_APPLICATION_LOGGING_FORWARDING_ENABLED
               value: "true"
+          # 뉴렐릭 자바 에이전트가 기동에 시간을 얹어서 liveness(30s + 20s*3)가 먼저 파드를 죽였다(#226).
+          # initialDelaySeconds 를 늘리면 기동 후 장애 감지까지 계속 둔해진다. startupProbe 는 기동 중에만
+          # 봐주고 통과하는 즉시 원래 프로브가 제 간격으로 돌아온다.
+          startupProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8083
+            periodSeconds: 10
+            failureThreshold: 30          # 최대 300초까지 기다린다
           readinessProbe:
             httpGet:
               path: /actuator/health

--- a/k8s/api-service.yaml
+++ b/k8s/api-service.yaml
@@ -66,6 +66,15 @@ spec:
               value: "https://edrdog-api.duckdns.org"
             - name: INSTALL_AGENT_SERVER
               value: "edrdog-api.duckdns.org:30443"
+          # 뉴렐릭 자바 에이전트가 기동에 시간을 얹어서 liveness(30s + 20s*3)가 먼저 파드를 죽였다(#226).
+          # initialDelaySeconds 를 늘리면 기동 후 장애 감지까지 계속 둔해진다. startupProbe 는 기동 중에만
+          # 봐주고 통과하는 즉시 원래 프로브가 제 간격으로 돌아온다.
+          startupProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8084
+            periodSeconds: 10
+            failureThreshold: 30          # 최대 300초까지 기다린다
           readinessProbe:
             httpGet:
               path: /actuator/health

--- a/k8s/archiver-service.yaml
+++ b/k8s/archiver-service.yaml
@@ -42,6 +42,15 @@ spec:
             # 로그도 에이전트가 보낸다(그래서 Alloy 를 뺐다). 기본값에 기대지 않고 명시한다.
             - name: NEW_RELIC_APPLICATION_LOGGING_FORWARDING_ENABLED
               value: "true"
+          # 뉴렐릭 자바 에이전트가 기동에 시간을 얹어서 liveness(30s + 20s*3)가 먼저 파드를 죽였다(#226).
+          # initialDelaySeconds 를 늘리면 기동 후 장애 감지까지 계속 둔해진다. startupProbe 는 기동 중에만
+          # 봐주고 통과하는 즉시 원래 프로브가 제 간격으로 돌아온다.
+          startupProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8083
+            periodSeconds: 10
+            failureThreshold: 30          # 최대 300초까지 기다린다
           readinessProbe:
             httpGet:
               path: /actuator/health

--- a/k8s/collector-service.yaml
+++ b/k8s/collector-service.yaml
@@ -71,6 +71,15 @@ spec:
             # 로그도 에이전트가 보낸다(그래서 Alloy 를 뺐다). 기본값에 기대지 않고 명시한다.
             - name: NEW_RELIC_APPLICATION_LOGGING_FORWARDING_ENABLED
               value: "true"
+          # 뉴렐릭 자바 에이전트가 기동에 시간을 얹어서 liveness(30s + 20s*3)가 먼저 파드를 죽였다(#226).
+          # initialDelaySeconds 를 늘리면 기동 후 장애 감지까지 계속 둔해진다. startupProbe 는 기동 중에만
+          # 봐주고 통과하는 즉시 원래 프로브가 제 간격으로 돌아온다.
+          startupProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8082
+            periodSeconds: 10
+            failureThreshold: 30          # 최대 300초까지 기다린다
           readinessProbe:
             httpGet:
               path: /actuator/health

--- a/k8s/detector-service.yaml
+++ b/k8s/detector-service.yaml
@@ -41,6 +41,15 @@ spec:
               value: "true"
           # 경로를 그룹별로 나눠야 Kafka Streams 항목이 readiness 에만 걸린다(이슈 #214).
           # 루트 /actuator/health 를 그대로 두면 Streams 가 죽어도 liveness 까지 DOWN 이 되어 재시작 루프에 빠진다.
+          # 뉴렐릭 자바 에이전트가 기동에 시간을 얹어서 liveness(30s + 20s*3)가 먼저 파드를 죽였다(#226).
+          # initialDelaySeconds 를 늘리면 기동 후 장애 감지까지 계속 둔해진다. startupProbe 는 기동 중에만
+          # 봐주고 통과하는 즉시 원래 프로브가 제 간격으로 돌아온다.
+          startupProbe:
+            httpGet:
+              path: /actuator/health/readiness
+              port: 8081
+            periodSeconds: 10
+            failureThreshold: 30          # 최대 300초까지 기다린다
           readinessProbe:
             httpGet:
               path: /actuator/health/readiness

--- a/k8s/responder-service.yaml
+++ b/k8s/responder-service.yaml
@@ -42,6 +42,15 @@ spec:
             # 로그도 에이전트가 보낸다(그래서 Alloy 를 뺐다). 기본값에 기대지 않고 명시한다.
             - name: NEW_RELIC_APPLICATION_LOGGING_FORWARDING_ENABLED
               value: "true"
+          # 뉴렐릭 자바 에이전트가 기동에 시간을 얹어서 liveness(30s + 20s*3)가 먼저 파드를 죽였다(#226).
+          # initialDelaySeconds 를 늘리면 기동 후 장애 감지까지 계속 둔해진다. startupProbe 는 기동 중에만
+          # 봐주고 통과하는 즉시 원래 프로브가 제 간격으로 돌아온다.
+          startupProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8082
+            periodSeconds: 10
+            failureThreshold: 30          # 최대 300초까지 기다린다
           readinessProbe:
             httpGet:
               path: /actuator/health


### PR DESCRIPTION
`dev` 의 #226 을 `main` 에 반영한다. 머지 시 CD 가 배포한다.

#223 배포가 롤아웃 타임아웃으로 실패한 것을 고친다. 뉴렐릭 에이전트가 얹은 기동 시간 때문에 liveness 가 파드를 죽이고 있었다. 상세는 #227.

Dockerfile 이 안 바뀌었으므로 이미지는 다시 굽지 않는다. 매니페스트만 다시 적용된다.

## 배포 후 확인

```bash
sudo kubectl -n edrdog get pods    # RESTARTS 0, 전부 1/1
```

## 아직 남은 수동 작업

Alloy 삭제 (#223 에서 제거했으나 apply 는 삭제를 안 한다)

```bash
sudo kubectl -n edrdog delete deploy/alloy sa/alloy cm/alloy-config
sudo kubectl delete clusterrole edrdog-alloy-logs
sudo kubectl delete clusterrolebinding edrdog-alloy-logs
```