### PR TITLE
feat: Kafka 구간 분산추적을 켜 서비스 맵을 잇는다

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -77,14 +77,11 @@ jobs:
         with:
           name: boot-jars
           # 안 바꾼 모듈은 굽지도 않으니 jar 가 없다. 없는 경로는 넘어간다.
+          # jar 만 넘기면 이미지 빌드 때 newrelic.yml 이 없어 Dockerfile 의 COPY 가 깨진다.
           if-no-files-found: ignore
           path: |
-            detector-service/build/libs/*.jar
-            responder-service/build/libs/*.jar
-            archiver-service/build/libs/*.jar
-            api-service/build/libs/*.jar
-            alert-service/build/libs/*.jar
-            collector-service/build/libs/*.jar
+            *-service/build/libs/*.jar
+            *-service/build/libs/*.yml
 
   # 이미지 빌드 + GHCR 푸시 (바뀐 모듈만)
   image:

--- a/alert-service/Dockerfile
+++ b/alert-service/Dockerfile
@@ -5,5 +5,7 @@ WORKDIR /app
 ADD https://repo1.maven.org/maven2/com/newrelic/agent/java/newrelic-agent/8.21.0/newrelic-agent-8.21.0.jar /app/newrelic.jar
 # CI가 build/libs 에 boot jar 하나만 남겨 전달 (plain jar 는 제거됨)
 COPY build/libs/*.jar app.jar
+# 에이전트 설정(Kafka 분산추적). 에이전트는 자기 jar 와 같은 디렉터리의 newrelic.yml 을 읽는다.
+COPY build/libs/newrelic.yml /app/newrelic.yml
 EXPOSE 8083
 ENTRYPOINT ["java", "-javaagent:/app/newrelic.jar", "-jar", "/app/app.jar"]

--- a/api-service/Dockerfile
+++ b/api-service/Dockerfile
@@ -5,5 +5,7 @@ WORKDIR /app
 ADD https://repo1.maven.org/maven2/com/newrelic/agent/java/newrelic-agent/8.21.0/newrelic-agent-8.21.0.jar /app/newrelic.jar
 # CI가 build/libs 에 boot jar 하나만 남겨 전달 (plain jar 는 제거됨)
 COPY build/libs/*.jar app.jar
+# 에이전트 설정(Kafka 분산추적). 에이전트는 자기 jar 와 같은 디렉터리의 newrelic.yml 을 읽는다.
+COPY build/libs/newrelic.yml /app/newrelic.yml
 EXPOSE 8084
 ENTRYPOINT ["java", "-javaagent:/app/newrelic.jar", "-jar", "/app/app.jar"]

--- a/archiver-service/Dockerfile
+++ b/archiver-service/Dockerfile
@@ -5,5 +5,7 @@ WORKDIR /app
 ADD https://repo1.maven.org/maven2/com/newrelic/agent/java/newrelic-agent/8.21.0/newrelic-agent-8.21.0.jar /app/newrelic.jar
 # CI가 build/libs 에 boot jar 하나만 남겨 전달 (plain jar 는 제거됨)
 COPY build/libs/*.jar app.jar
+# 에이전트 설정(Kafka 분산추적). 에이전트는 자기 jar 와 같은 디렉터리의 newrelic.yml 을 읽는다.
+COPY build/libs/newrelic.yml /app/newrelic.yml
 EXPOSE 8083
 ENTRYPOINT ["java", "-javaagent:/app/newrelic.jar", "-jar", "/app/app.jar"]

--- a/build.gradle
+++ b/build.gradle
@@ -45,4 +45,16 @@ subprojects {
     tasks.named('test') {
         useJUnitPlatform()
     }
+
+    // 뉴렐릭 에이전트 설정을 이미지 빌드 컨텍스트로 옮긴다.
+    // 이미지 빌드 컨텍스트가 모듈 디렉터리라(cd.yml 의 context) Dockerfile 이 루트의 shared-resources 를
+    // 직접 COPY 할 수 없다. 에이전트는 자기 jar 옆의 newrelic.yml 을 읽으므로 이미지에서 /app/newrelic.yml 이 된다.
+    tasks.named('bootJar') {
+        doLast {
+            copy {
+                from rootProject.file('shared-resources/newrelic.yml')
+                into layout.buildDirectory.dir('libs')
+            }
+        }
+    }
 }

--- a/collector-service/Dockerfile
+++ b/collector-service/Dockerfile
@@ -5,5 +5,7 @@ WORKDIR /app
 ADD https://repo1.maven.org/maven2/com/newrelic/agent/java/newrelic-agent/8.21.0/newrelic-agent-8.21.0.jar /app/newrelic.jar
 # CI가 build/libs 에 boot jar 하나만 남겨 전달 (plain jar 는 제거됨)
 COPY build/libs/*.jar app.jar
+# 에이전트 설정(Kafka 분산추적). 에이전트는 자기 jar 와 같은 디렉터리의 newrelic.yml 을 읽는다.
+COPY build/libs/newrelic.yml /app/newrelic.yml
 EXPOSE 8082
 ENTRYPOINT ["java", "-javaagent:/app/newrelic.jar", "-jar", "/app/app.jar"]

--- a/detector-service/Dockerfile
+++ b/detector-service/Dockerfile
@@ -5,5 +5,7 @@ WORKDIR /app
 ADD https://repo1.maven.org/maven2/com/newrelic/agent/java/newrelic-agent/8.21.0/newrelic-agent-8.21.0.jar /app/newrelic.jar
 # CI가 build/libs 에 boot jar 하나만 남겨 전달 (plain jar 는 제거됨)
 COPY build/libs/*.jar app.jar
+# 에이전트 설정(Kafka 분산추적). 에이전트는 자기 jar 와 같은 디렉터리의 newrelic.yml 을 읽는다.
+COPY build/libs/newrelic.yml /app/newrelic.yml
 EXPOSE 8081
 ENTRYPOINT ["java", "-javaagent:/app/newrelic.jar", "-jar", "/app/app.jar"]

--- a/responder-service/Dockerfile
+++ b/responder-service/Dockerfile
@@ -5,5 +5,7 @@ WORKDIR /app
 ADD https://repo1.maven.org/maven2/com/newrelic/agent/java/newrelic-agent/8.21.0/newrelic-agent-8.21.0.jar /app/newrelic.jar
 # CI가 build/libs 에 boot jar 하나만 남겨 전달 (plain jar 는 제거됨)
 COPY build/libs/*.jar app.jar
+# 에이전트 설정(Kafka 분산추적). 에이전트는 자기 jar 와 같은 디렉터리의 newrelic.yml 을 읽는다.
+COPY build/libs/newrelic.yml /app/newrelic.yml
 EXPOSE 8082
 ENTRYPOINT ["java", "-javaagent:/app/newrelic.jar", "-jar", "/app/app.jar"]

--- a/shared-resources/newrelic.yml
+++ b/shared-resources/newrelic.yml
@@ -1,0 +1,31 @@
+# 뉴렐릭 자바 에이전트 설정 — 운영 전용(로컬은 에이전트를 안 붙인다).
+#
+# 라이선스 키와 앱 이름은 여기 두지 않는다. 매니페스트의 NEW_RELIC_LICENSE_KEY / NEW_RELIC_APP_NAME
+# 환경변수가 이 파일보다 우선하고, 시크릿을 깃에 넣지 않는다는 원칙과도 맞다.
+common: &default_settings
+  # Kafka 구간에서 트레이스가 끊겨 서비스 맵에 노드가 하나만 뜬다(이슈 #229).
+  # 프로듀서가 메시지 헤더에 트레이스 컨텍스트를 싣고 컨슈머가 이어받아야 이어진다.
+  # 아래 둘 다 에이전트 기본값이 꺼짐이다(Kafka 가 고처리량이라 뉴렐릭이 꺼 뒀다).
+  #
+  # 모듈 이름은 문서가 아니라 에이전트 jar 안 Implementation-Title 을 확인해 적었다.
+  # 문서에는 kafka-clients-spans-0.11.0.0 처럼 판번호가 붙어 있는데 실제 이름에는 없다. 틀리면 조용히 무시된다.
+  #
+  # kafka-streams-spans 는 넣지 않았다. 우리 Kafka Streams 가 3.9.1 인데 에이전트가 3.7.0 까지만 가지고 있어
+  # 등록 자체가 안 되는 것을 기동 로그로 확인했다. Streams 도 내부적으로는 KafkaConsumer 를 쓰므로
+  # 연결은 아래 클라이언트 계측으로 될 수 있다. 배포 후 Entities(avg) 로 확인한다.
+  class_transformer:
+    com.newrelic.instrumentation.kafka-clients-spans:
+      enabled: true
+    # @KafkaListener 소비자 (archiver 2, alert 1, responder 1, detector 의 alerts-view 1)
+    com.newrelic.instrumentation.spring-kafka-2.2.0:
+      enabled: true
+
+  kafka:
+    spans:
+      distributed_trace:
+        # archiver 가 배치 소비라 필요하다. 한 번에 여러 건을 받아갈 때도 트레이스를 잇는다.
+        consume_many:
+          enabled: true
+
+production:
+  <<: *default_settings


### PR DESCRIPTION
Closes #229

## 문제

트레이스가 서비스 하나 안에서 끝난다. `Entities (avg)` 가 1 이고 서비스 맵에 노드가 하나만 뜬다. 서비스 사이가 HTTP 호출이 아니라 Kafka 발행-구독이라, 헤더로 트레이스 컨텍스트를 넘기지 않으면 이어지지 않는다.

## 한 것

`shared-resources/newrelic.yml` 로 에이전트의 Kafka 계측을 켠다. 기본값이 꺼짐인 이유는 Kafka 가 고처리량이라 ingest 부담을 우려해서다.

| 모듈 | 대상 |
|---|---|
| `kafka-clients-spans` | 프로듀서·컨슈머 스팬과 분산추적 헤더 |
| `spring-kafka-2.2.0` | `@KafkaListener` (archiver 2, alert 1, responder 1, detector 1) |
| `consume_many` | archiver 의 배치 소비 |

## 조용히 깨질 뻔한 것

**모듈 이름이 문서와 다르다.** 문서에는 `kafka-clients-spans-0.11.0.0` 처럼 판번호가 붙어 있는데, 에이전트 jar 안 `Implementation-Title` 은 `com.newrelic.instrumentation.kafka-clients-spans` 다. 문서대로 적었으면 오류 없이 무시됐다.

## 뺀 것

`kafka-streams-spans`. 우리 Kafka Streams 가 **3.9.1** 인데 에이전트가 **3.7.0** 까지만 가지고 있어 등록 자체가 안 된다(도커로 기동해 로그로 확인).

다만 Streams 도 내부적으로 `KafkaConsumer` 를 쓰고 그 계측은 정상 등록되므로 **연결은 될 수 있다.** 배포 후 판단한다.

## 검증

로컬에서 이미지를 굽고 에이전트를 실제로 띄워 확인했다.

```
registered weave package: com.newrelic.instrumentation.kafka-clients-spans-consumer-2.0.0
registered weave package: com.newrelic.instrumentation.spring-kafka-2.2.0
```

`./gradlew build` 통과. `/app/newrelic.yml` 이 에이전트 jar 옆에 놓이는 것과 `Loading configuration file "/app/./newrelic.yml"` 도 확인했다.

## 배포 후 확인

1. Traces 의 `Entities (avg)` 가 2 이상이 되는지 ← 이게 핵심
2. 서비스 맵 노드가 늘어나는지
3. **하루 ingest 를 볼 것.** 무료 티어 월 100GB 이고 넘으면 수집이 끊긴다. 늘면 `newrelic.yml` 을 되돌리면 된다

## 안 한 것

- Kafka 3.7 다운그레이드 — 관측 화면 때문에 인프라를 내리는 건 앞뒤가 바뀐다
- detector 만 micrometer 트레이싱 재활성화 — 한 JVM 에 계측 둘. 중복 스팬 관리 비용이 얻는 것보다 크다