### PR TITLE
fix: Kafka 계측 모듈 이름에 판번호를 채운다

### DIFF
--- a/shared-resources/newrelic.yml
+++ b/shared-resources/newrelic.yml
@@ -4,17 +4,21 @@
 # 환경변수가 이 파일보다 우선하고, 시크릿을 깃에 넣지 않는다는 원칙과도 맞다.
 common: &default_settings
   # Kafka 구간에서 트레이스가 끊겨 서비스 맵에 노드가 하나만 뜬다(이슈 #229).
-  # 프로듀서가 메시지 헤더에 트레이스 컨텍스트를 싣고 컨슈머가 이어받아야 이어진다.
-  # 아래 둘 다 에이전트 기본값이 꺼짐이다(Kafka 가 고처리량이라 뉴렐릭이 꺼 뒀다).
+  # 서비스 사이가 HTTP 호출이 아니라 발행-구독이라, 프로듀서가 메시지 헤더에 트레이스 컨텍스트를 싣고
+  # 컨슈머가 이어받아야 collector -> detector -> archiver 가 한 트레이스로 이어진다.
   #
-  # 모듈 이름은 문서가 아니라 에이전트 jar 안 Implementation-Title 을 확인해 적었다.
-  # 문서에는 kafka-clients-spans-0.11.0.0 처럼 판번호가 붙어 있는데 실제 이름에는 없다. 틀리면 조용히 무시된다.
+  # ⚠️ 이름에 판번호까지 정확히 적어야 한다. JAR 매니페스트는 72바이트에서 줄이 접히는데,
+  #    접힌 뒷부분을 놓치고 판번호 없이 적었다가 아무것도 안 켜진 채로 한 번 배포했다(#232).
+  #    켜졌는지는 기동 로그의 "registered weave package" 로 확인한다. 이름이 틀리면 오류 없이 무시된다.
   #
-  # kafka-streams-spans 는 넣지 않았다. 우리 Kafka Streams 가 3.9.1 인데 에이전트가 3.7.0 까지만 가지고 있어
-  # 등록 자체가 안 되는 것을 기동 로그로 확인했다. Streams 도 내부적으로는 KafkaConsumer 를 쓰므로
-  # 연결은 아래 클라이언트 계측으로 될 수 있다. 배포 후 Entities(avg) 로 확인한다.
+  # 컨슈머 쪽(kafka-clients-spans-consumer-2.0.0)은 기본값이 켜짐이라 여기 없다.
+  # 아래 셋은 기본값이 꺼짐이다. Kafka 가 고처리량이라 뉴렐릭이 ingest 부담을 우려해 꺼 뒀다.
   class_transformer:
-    com.newrelic.instrumentation.kafka-clients-spans:
+    # 프로듀서가 트레이스 컨텍스트를 메시지 헤더에 넣는다. 이게 꺼져 있으면 컨슈머가 읽을 게 없다.
+    com.newrelic.instrumentation.kafka-clients-spans-0.11.0.0:
+      enabled: true
+    # detector 의 판정 토폴로지. Streams 는 spring-kafka 계측이 적용되지 않아 별도로 필요하다.
+    com.newrelic.instrumentation.kafka-streams-spans-3.7.0:
       enabled: true
     # @KafkaListener 소비자 (archiver 2, alert 1, responder 1, detector 의 alerts-view 1)
     com.newrelic.instrumentation.spring-kafka-2.2.0:


### PR DESCRIPTION
Closes #232

#229 로 켠 Kafka 분산추적이 실제로는 아무것도 안 켜져 있었다.

## 원인

모듈 이름에서 판번호가 빠졌다. JAR 매니페스트가 72바이트에서 줄이 접히는데 접힌 뒷부분을 놓치고 읽었다.

```
Implementation-Title: com.newrelic.instrumentation.kafka-clients-spans
 -0.11.0.0        ← 놓친 줄
```

문서에 판번호가 붙어 있는 걸 보고 "실제와 다르다"고 판단해 무시했는데, 문서가 맞았다.

## 결과였던 상태

| 모듈 | 의도 | 실제 |
|---|---|---|
| 프로듀서 (`kafka-clients-spans-0.11.0.0`) | 헤더 주입 | **꺼짐** (이름 불일치) |
| 컨슈머 (`kafka-clients-spans-consumer-2.0.0`) | 헤더 수신 | 켜짐 (기본값이라 우연히) |
| Streams (`kafka-streams-spans-3.7.0`) | Streams 구간 | **꺼짐** (이름 불일치) |
| `spring-kafka-2.2.0` | @KafkaListener | 켜짐 |

**헤더를 넣는 쪽이 꺼져 있었다.** 읽는 쪽만 켜져 있으니 이어질 수가 없었다. 그러면서 `spring-kafka` 때문에 스팬은 트레이스당 34 → 131 로 늘어, 비용만 내고 효과는 0 이었다.

`kafka-streams-spans` 를 "Kafka 3.9.1 미지원"이라 판단한 것도 같은 착오다. 3.9.1 에서 정상 등록된다.

## 검증 (배포 전 로컬)

이미지를 굽고 에이전트를 실제로 띄워 확인했다.

```
registered weave package: com.newrelic.instrumentation.kafka-clients-spans-0.11.0.0
registered weave package: com.newrelic.instrumentation.kafka-clients-spans-consumer-2.0.0
registered weave package: com.newrelic.instrumentation.kafka-streams-spans-3.7.0
registered weave package: com.newrelic.instrumentation.spring-kafka-2.2.0
```

Streams 는 처리 루프까지 위빙하는 것을 확인했다.

```
Instrumented org.apache.kafka.streams.processor.internals.StreamThread.runOnceWithoutProcessingThreads()V
  [com.newrelic.instrumentation.kafka-streams-spans-3.7.0]
```

## 재발 방지

이름이 틀리면 에이전트가 오류 없이 무시한다. 이 파일을 고칠 때는 로컬에서 에이전트를 띄워 `registered weave package` 로 확인한다는 주석을 파일에 남겼다.

## 배포 후 확인

`Traces` 의 `Entities (avg)` 가 2 이상이 되는지. 이번에도 1이면 진짜 안 되는 것이다.