### PR TITLE
chore: dev 반영 (Kafka 스팬 계측 정리)

### DIFF
--- a/collector-service/build.gradle
+++ b/collector-service/build.gradle
@@ -10,4 +10,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'    // 등록 노드(node_key 해시 → tenant/host) 저장
     runtimeOnly 'com.mysql:mysql-connector-j'                           // 등록 노드 저장용 MySQL 드라이버
     testImplementation 'com.h2database:h2'                              // 수집 흐름 통합 테스트용 임베디드 DB
+    // Kafka 헤더에 traceparent 가 실제로 실리는지 보려면 브로커가 있어야 한다(이슈 #235).
+    // 설정만 보고 "되겠지" 했다가 배포를 두 번 헛돌렸다(#229, #232).
+    testImplementation 'org.springframework.kafka:spring-kafka-test'
 }

--- a/collector-service/src/test/java/com/edrdog/collectorservice/tracing/KafkaTraceHeaderPropagationTest.java
+++ b/collector-service/src/test/java/com/edrdog/collectorservice/tracing/KafkaTraceHeaderPropagationTest.java
@@ -1,0 +1,90 @@
+package com.edrdog.collectorservice.tracing;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.header.Header;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.test.EmbeddedKafkaBroker;
+import org.springframework.kafka.test.context.EmbeddedKafka;
+import org.springframework.kafka.test.utils.KafkaTestUtils;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * KafkaTemplate 이 발행할 때 트레이스 컨텍스트를 메시지 헤더에 싣는지 본다.
+ *
+ * <p>서비스 사이가 HTTP 호출이 아니라 발행-구독이라, 헤더에 실리지 않으면 컨슈머는 부모가 없다고 보고
+ * 새 traceId 를 발급한다. 그래서 Kafka 를 건널 때마다 트레이스가 끊기고 서비스 맵에 노드가 하나만 뜬다.
+ *
+ * <p><b>지금은 실패한다.</b> 아래 전제가 전부 갖춰졌는데도 헤더가 비어 있는 것을 확인했다(#235).
+ * 운영에서 kafka-console-consumer 로 본 것과 같은 현상을 여기서 몇 초 만에 재현한다.
+ *
+ * <pre>
+ *   Tracer               OtelTracer 존재
+ *   Propagator           OtelPropagator 존재
+ *   ObservationRegistry  활성 (noop 아님)
+ *   발행 시점 활성 스팬    있음
+ *   observation-enabled  true
+ *   → traceparent 헤더    없음
+ * </pre>
+ *
+ * <p>다음에 이어갈 때는 배포하지 말고 여기서 시작한다. 설정만 보고 되겠거니 하다가 배포를 두 번
+ * 헛돌렸다(#229, #232). Spring Kafka 가 observation 을 KafkaTemplate 에 어떻게 적용하는지부터 본다.
+ */
+@Disabled("미해결: 전제가 다 갖춰져도 traceparent 가 안 실린다. 조사 재개용 재현 하네스다 (#235)")
+@SpringBootTest(properties = {
+        "management.tracing.enabled=true",
+        "management.tracing.sampling.probability=1.0",
+        "spring.kafka.template.observation-enabled=true",
+        "management.otlp.metrics.export.enabled=false",
+        "spring.datasource.url=jdbc:h2:mem:trace;DB_CLOSE_DELAY=-1",
+        "spring.jpa.hibernate.ddl-auto=create-drop",
+})
+@EmbeddedKafka(partitions = 1, topics = KafkaTraceHeaderPropagationTest.TOPIC)
+class KafkaTraceHeaderPropagationTest {
+
+    static final String TOPIC = "trace-propagation-probe";
+
+    @Autowired
+    KafkaTemplate<String, byte[]> template;
+
+    @Autowired
+    EmbeddedKafkaBroker broker;
+
+    @Autowired
+    io.micrometer.tracing.Tracer tracer;
+
+    @Test
+    void 발행한_메시지_헤더에_traceparent_가_실린다() {
+        // 운영에서는 HTTP 요청 스팬 안에서 발행이 일어난다. 조건을 같게 맞춘다.
+        var scoped = tracer.startScopedSpan("probe");
+        try {
+            template.send(TOPIC, "host-1", new byte[]{1, 2, 3});
+        } finally {
+            scoped.end();
+        }
+
+        var consumer = new org.apache.kafka.clients.consumer.KafkaConsumer<String, byte[]>(Map.of(
+                "bootstrap.servers", broker.getBrokersAsString(),
+                "group.id", "probe",
+                "auto.offset.reset", "earliest",
+                "key.deserializer", org.apache.kafka.common.serialization.StringDeserializer.class,
+                "value.deserializer", org.apache.kafka.common.serialization.ByteArrayDeserializer.class));
+        consumer.subscribe(List.of(TOPIC));
+
+        ConsumerRecord<String, byte[]> record = KafkaTestUtils.getSingleRecord(consumer, TOPIC);
+        consumer.close();
+
+        var keys = Arrays.stream(record.headers().toArray()).map(Header::key).toList();
+        assertThat(keys)
+                .as("헤더 목록: %s — traceparent 가 없으면 Kafka 를 건널 때 트레이스가 끊긴다", keys)
+                .contains("traceparent");
+    }
+}

--- a/shared-resources/newrelic.yml
+++ b/shared-resources/newrelic.yml
@@ -3,33 +3,20 @@
 # 라이선스 키와 앱 이름은 여기 두지 않는다. 매니페스트의 NEW_RELIC_LICENSE_KEY / NEW_RELIC_APP_NAME
 # 환경변수가 이 파일보다 우선하고, 시크릿을 깃에 넣지 않는다는 원칙과도 맞다.
 common: &default_settings
-  # Kafka 구간에서 트레이스가 끊겨 서비스 맵에 노드가 하나만 뜬다(이슈 #229).
-  # 서비스 사이가 HTTP 호출이 아니라 발행-구독이라, 프로듀서가 메시지 헤더에 트레이스 컨텍스트를 싣고
-  # 컨슈머가 이어받아야 collector -> detector -> archiver 가 한 트레이스로 이어진다.
+  # @KafkaListener 소비를 트랜잭션으로 잡는다. 이게 없으면 archiver/alert/responder 는
+  # 액추에이터 프로브 트래픽만 APM 에 보이고 정작 메시지 처리는 안 보인다. 기본값은 꺼짐이다.
   #
   # ⚠️ 이름에 판번호까지 정확히 적어야 한다. JAR 매니페스트는 72바이트에서 줄이 접히는데,
-  #    접힌 뒷부분을 놓치고 판번호 없이 적었다가 아무것도 안 켜진 채로 한 번 배포했다(#232).
-  #    켜졌는지는 기동 로그의 "registered weave package" 로 확인한다. 이름이 틀리면 오류 없이 무시된다.
+  #    접힌 뒷부분을 놓치고 적었다가 아무것도 안 켜진 채로 배포했다(#232).
+  #    켜졌는지는 기동 로그의 "registered weave package" 로 확인한다. 틀리면 오류 없이 무시된다.
   #
-  # 컨슈머 쪽(kafka-clients-spans-consumer-2.0.0)은 기본값이 켜짐이라 여기 없다.
-  # 아래 셋은 기본값이 꺼짐이다. Kafka 가 고처리량이라 뉴렐릭이 ingest 부담을 우려해 꺼 뒀다.
+  # kafka-clients-spans / kafka-streams-spans 는 뺐다. 켜도 프로듀서가 메시지 헤더에
+  # traceparent 를 싣지 않아 트레이스가 안 이어진다(kafka-console-consumer 로 헤더를 직접 확인).
+  # 스팬만 늘고 얻는 게 없었다. 미해결로 #235 에 남겼다.
   class_transformer:
-    # 프로듀서가 트레이스 컨텍스트를 메시지 헤더에 넣는다. 이게 꺼져 있으면 컨슈머가 읽을 게 없다.
-    com.newrelic.instrumentation.kafka-clients-spans-0.11.0.0:
-      enabled: true
-    # detector 의 판정 토폴로지. Streams 는 spring-kafka 계측이 적용되지 않아 별도로 필요하다.
-    com.newrelic.instrumentation.kafka-streams-spans-3.7.0:
-      enabled: true
     # @KafkaListener 소비자 (archiver 2, alert 1, responder 1, detector 의 alerts-view 1)
     com.newrelic.instrumentation.spring-kafka-2.2.0:
       enabled: true
-
-  kafka:
-    spans:
-      distributed_trace:
-        # archiver 가 배치 소비라 필요하다. 한 번에 여러 건을 받아갈 때도 트레이스를 잇는다.
-        consume_many:
-          enabled: true
 
 production:
   <<: *default_settings


### PR DESCRIPTION
`dev` 를 `main` 에 반영한다. 머지 시 CD 가 배포한다.

효과 없는 Kafka 스팬 계측(`kafka-clients-spans`, `kafka-streams-spans`)을 걷어낸다. 프로듀서가 메시지 헤더에 트레이스 컨텍스트를 싣지 않아 트레이스가 안 이어지는 것을 헤더를 직접 떠서 확인했다. 스팬만 늘고 얻는 게 없었다.

`spring-kafka-2.2.0` 은 남긴다. `@KafkaListener` 소비가 APM 트랜잭션으로 잡히는 실제 효과가 있다.

재현 테스트를 `@Disabled` 로 남겼다. 상세는 #236, 미해결 기록은 #235.

## 배포 후

파드 6개가 정상인지만 보면 된다. 관측 동작 자체는 안 바뀐다(스팬 수만 줄어든다).