### PR TITLE
fix: shared-resources 변경에도 이미지를 다시 굽는다

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -32,7 +32,10 @@ jobs:
           FILES=$(git diff --name-only "$BEFORE" "$GITHUB_SHA")
           echo "바뀐 파일:" >&2; echo "$FILES" | sed 's/^/  /' >&2
           # 공통 파일은 어느 모듈이 영향받을지 알 수 없으므로 전부 굽는다.
-          if echo "$FILES" | grep -qE '^(build\.gradle|settings\.gradle|gradlew|gradle/|\.github/workflows/cd\.yml)'; then
+          # shared-resources/ 가 빠져 있어 관측 설정을 바꿔도 이미지가 안 구워졌다. 매니페스트만 다시
+          # apply 되고 파드는 옛 이미지 그대로라, 바꾼 설정이 운영에 도달하지 않은 채 며칠 갈 수 있었다.
+          # newrelic.yml 은 이미지 안 /app/newrelic.yml 로 들어가고 observability*.yml 은 jar 에 들어간다.
+          if echo "$FILES" | grep -qE '^(build\.gradle|settings\.gradle|gradlew|gradle/|shared-resources/|\.github/workflows/cd\.yml)'; then
             echo "공통 파일이 바뀌어 전 모듈을 다시 굽는다" >&2
             echo "modules=$ALL" >> "$GITHUB_OUTPUT"; exit 0
           fi


### PR DESCRIPTION
Closes #240

CD 변경 감지에 `shared-resources/` 가 빠져 있어 공통 설정을 바꿔도 이미지가 재빌드되지 않았다. 매니페스트만 다시 apply 되고 파드는 옛 이미지 그대로다.

`shared-resources/newrelic.yml` 은 이미지 안 `/app/newrelic.yml` 이고 `observability*.yml` 은 jar 안이라, 둘 다 재빌드 없이는 반영이 없다.

## 실제 피해

| 배포 | 반영 |
|---|---|
| #231 첫 Kafka 계측 | 됨 (build.gradle 동시 변경) |
| #234 모듈 이름 수정 | **안 됨** |
| #237 계측 제거 | collector 만 |
| #239 되살림 | **안 됨** |

**모듈 이름을 고친 것이 운영에 간 적이 없다.** 그런데 "이름을 고쳤는데도 안 된다"고 판단해 #235 조사 방향을 두 번 틀었다. 헤더가 비어 있던 것도 이름이 틀린 옛 이미지를 본 결과다.

## 확인

```
shared-resources/newrelic.yml       -> 전 모듈 재빌드
shared-resources/observability.yml  -> 전 모듈 재빌드
detector-service/src/x.java         -> 해당 모듈만
README.md                           -> 재빌드 없음
```

## 배포 후

파드 `AGE` 를 확인한다. 몇 분 이내여야 이미지가 실제로 바뀐 것이다.