### PR TITLE
feat: detector 가 레코드마다 발행 측 트레이스를 이어받는다

### DIFF
--- a/detector-service/build.gradle
+++ b/detector-service/build.gradle
@@ -11,6 +11,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter'
     implementation 'org.springframework.boot:spring-boot-starter-web'    // 데모용 이벤트 발행/조회 REST + Swagger 호스팅
     implementation 'org.springframework.kafka:spring-kafka'
+    // 레코드 단위로 발행 측 트레이스에 이어 붙이기 위한 API(#235). 에이전트가 없으면 no-op 이라 로컬은 영향 없다.
+    implementation 'com.newrelic.agent.java:newrelic-api:8.21.0'
     implementation 'io.micrometer:micrometer-registry-otlp'   // 메트릭 OTLP 전송 (판정 처리량/지연 관측 대상)
     implementation 'org.apache.kafka:kafka-streams'
     implementation 'com.fasterxml.jackson.core:jackson-databind'   // alerts JSON serde + Event.detail 파싱

--- a/detector-service/src/main/java/com/edrdog/detectorservice/kafkastreams/topology/CorrelationProcessor.java
+++ b/detector-service/src/main/java/com/edrdog/detectorservice/kafkastreams/topology/CorrelationProcessor.java
@@ -3,6 +3,7 @@ package com.edrdog.detectorservice.kafkastreams.topology;
 import com.edrdog.detectorservice.dto.Alert;
 import com.edrdog.schema.Event;
 import com.edrdog.detectorservice.rule.Rules;
+import com.edrdog.detectorservice.tracing.KafkaTraceLink;
 import io.micrometer.core.instrument.DistributionSummary;
 import io.micrometer.core.instrument.MeterRegistry;
 import org.apache.kafka.streams.KeyValue;
@@ -94,6 +95,13 @@ public class CorrelationProcessor implements Processor<String, Event, String, Al
 
     @Override
     public void process(Record<String, Event> record) {
+        // Kafka 를 건너도 트레이스가 이어지게 레코드마다 트랜잭션을 연다(#235).
+        // Streams 는 폴 단위로 트랜잭션을 열어 배치에 부모를 하나만 달 수 있어서, 여기서 직접 열지 않으면
+        // 배치의 나머지 레코드가 전부 출처를 잃는다. 판정 로직은 그대로 두고 감싸기만 한다.
+        KafkaTraceLink.linked(record.headers(), () -> processRecord(record));
+    }
+
+    private void processRecord(Record<String, Event> record) {
         Event current = record.value();
         if (current == null || record.key() == null) {
             return;

--- a/detector-service/src/main/java/com/edrdog/detectorservice/tracing/KafkaTraceLink.java
+++ b/detector-service/src/main/java/com/edrdog/detectorservice/tracing/KafkaTraceLink.java
@@ -1,0 +1,83 @@
+package com.edrdog.detectorservice.tracing;
+
+import com.newrelic.api.agent.HeaderType;
+import com.newrelic.api.agent.NewRelic;
+import com.newrelic.api.agent.Trace;
+import com.newrelic.api.agent.TransportType;
+import org.apache.kafka.common.header.Header;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.StreamSupport;
+
+/**
+ * Kafka 레코드 하나를 발행 측 트레이스에 이어 붙인다.
+ *
+ * <p>여기가 없으면 Kafka 를 건널 때 트레이스가 끊긴다. 프로듀서는 헤더에 컨텍스트를 싣지만
+ * (실측 확인), Kafka Streams 는 폴 단위로 트랜잭션을 열어 배치에 부모를 하나만 달 수 있다.
+ * 배치가 500건이면 499건이 출처를 잃는다. 그래서 레코드마다 트랜잭션을 직접 연다(#235).
+ *
+ * <p><b>전제</b>: {@code newrelic.yml} 에서 {@code kafka-streams-spans} 가 꺼져 있어야 한다.
+ * 켜져 있으면 폴 단위 트랜잭션이 이미 열려 있어서, 아래 {@code @Trace(dispatcher = true)} 가
+ * 새 트랜잭션이 아니라 기존 트랜잭션의 구간이 되어 버린다.
+ *
+ * <p>판정 로직에서 이 클래스만 부르게 격리해 두었다. 관측 백엔드를 옮기면 여기만 걷어내면 된다.
+ * 에이전트가 없으면 API 가 알아서 아무 일도 안 하므로 로컬 실행에도 영향이 없다.
+ */
+public final class KafkaTraceLink {
+
+    private KafkaTraceLink() {
+    }
+
+    /** 레코드 하나를 별도 트랜잭션으로 열고, 헤더에 실린 발행 측 트레이스에 이어 붙인다. */
+    @Trace(dispatcher = true)
+    public static void linked(Iterable<Header> kafkaHeaders, Runnable body) {
+        NewRelic.getAgent().getTransaction()
+                .acceptDistributedTraceHeaders(TransportType.Kafka, new KafkaHeaders(kafkaHeaders));
+        body.run();
+    }
+
+    /** 뉴렐릭이 읽을 수 있게 Kafka 헤더를 감싼다. 읽기 전용이라 쓰기 메서드는 비워 둔다. */
+    private record KafkaHeaders(Iterable<Header> delegate) implements com.newrelic.api.agent.Headers {
+
+        @Override
+        public HeaderType getHeaderType() {
+            return HeaderType.MESSAGE;
+        }
+
+        @Override
+        public String getHeader(String name) {
+            for (Header h : delegate) {
+                if (h.key().equals(name) && h.value() != null) {
+                    return new String(h.value(), StandardCharsets.UTF_8);
+                }
+            }
+            return null;
+        }
+
+        @Override
+        public Collection<String> getHeaders(String name) {
+            String v = getHeader(name);
+            return v == null ? List.of() : List.of(v);
+        }
+
+        @Override
+        public Collection<String> getHeaderNames() {
+            return StreamSupport.stream(delegate.spliterator(), false).map(Header::key).toList();
+        }
+
+        @Override
+        public void setHeader(String name, String value) {
+        }
+
+        @Override
+        public void addHeader(String name, String value) {
+        }
+
+        @Override
+        public boolean containsHeader(String name) {
+            return getHeader(name) != null;
+        }
+    }
+}

--- a/shared-resources/newrelic.yml
+++ b/shared-resources/newrelic.yml
@@ -22,9 +22,9 @@ common: &default_settings
     # 프로듀서가 트레이스 컨텍스트를 메시지 헤더에 넣는다. 이게 꺼져 있으면 컨슈머가 읽을 게 없다.
     com.newrelic.instrumentation.kafka-clients-spans-0.11.0.0:
       enabled: true
-    # detector 의 판정 토폴로지. Streams 는 spring-kafka 계측이 적용되지 않아 별도로 필요하다.
-    com.newrelic.instrumentation.kafka-streams-spans-3.7.0:
-      enabled: true
+    # kafka-streams-spans 는 꺼 둔다. 켜면 폴 단위로 트랜잭션이 열려서, detector 가 레코드마다
+    # 여는 트랜잭션(KafkaTraceLink)이 새 트랜잭션이 아니라 그 안의 구간이 되어 버린다.
+    # 그러면 배치에 부모를 하나만 달 수 있어 나머지 레코드가 출처를 잃는다(#235).
     # @KafkaListener 소비자 (archiver 2, alert 1, responder 1, detector 의 alerts-view 1)
     com.newrelic.instrumentation.spring-kafka-2.2.0:
       enabled: true


### PR DESCRIPTION
Closes #235

## 문제

Kafka 를 건널 때 트레이스가 끊긴다. 프로듀서는 헤더에 컨텍스트를 **정상적으로 싣는다**(운영 메시지를 직접 떠서 확인).

```
schema-version:1, event-type:network, tenant-id:99,
newrelic:{"d":{"tr":"49457d6157ed252f4e67ce8aefc50b4a","sa":true,...}}
```

받는 쪽이 문제다. Kafka Streams 는 **폴 단위로 트랜잭션을 열고** 트랜잭션은 부모를 하나만 가질 수 있다. 배치가 500건이면 499건이 출처를 잃는다. 설정으로 풀 수 있는 문제가 아니다.

## 한 것

레코드마다 트랜잭션을 열고 헤더의 컨텍스트를 수락한다.

```java
public void process(Record<String, Event> record) {
    KafkaTraceLink.linked(record.headers(), () -> processRecord(record));
}
```

판정 로직은 손대지 않았다. 기존 본문을 `processRecord` 로 옮기고 감싸기만 했다.

**벤더 API 를 `KafkaTraceLink` 한 곳에 격리했다.** 관측 백엔드를 옮기면 이 클래스만 걷어내면 된다.

## kafka-streams-spans 를 끈 이유

켜 두면 폴 단위 트랜잭션이 먼저 열려서, 위 `@Trace(dispatcher = true)` 가 새 트랜잭션이 아니라 그 안의 구간이 된다. 같은 한계에 다시 걸린다.

## 검증

- `./gradlew build` 통과 (기존 detector 테스트 포함). 에이전트가 없으면 API 가 no-op 이라 영향 없음
- jar 에 `newrelic-api-8.21.0` 과 `KafkaTraceLink` 포함 확인
- `@Trace(dispatcher)` 가 `RuntimeVisibleAnnotations` 로 남은 것 확인
- 이미지 기동 시 `kafka-streams-spans` 가 등록되지 않는 것 확인

레코드가 흘러야 클래스가 로드되므로 계측 자체는 배포 후 확인한다.

## 배포 후

`Traces` 의 `Entities (avg)` 가 2 이상이 되는지. 되면 서비스 맵이 그려진다.

**ingest 를 같이 봐야 한다.** 레코드마다 트랜잭션이 생기므로 늘어난다. 무료 티어 월 100GB.