### PR TITLE
feat: dev 반영 (archiver 트레이스 연결)

### DIFF
--- a/archiver-service/src/main/java/com/edrdog/archiverservice/EventListener.java
+++ b/archiver-service/src/main/java/com/edrdog/archiverservice/EventListener.java
@@ -2,8 +2,12 @@ package com.edrdog.archiverservice;
 
 import com.edrdog.archiverservice.clickhouse.ClickHouseWriter;
 import com.edrdog.schema.Event;
+import com.edrdog.schema.KafkaTraceLink;
 import java.util.List;
+import org.apache.kafka.common.header.Headers;
 import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.KafkaHeaders;
+import org.springframework.messaging.handler.annotation.Header;
 import org.springframework.stereotype.Component;
 
 /**
@@ -20,8 +24,19 @@ public class EventListener {
         this.writer = writer;
     }
 
+    /**
+     * @param headers 발행 측 트레이스를 이어받기 위한 레코드별 원본 헤더. 적재에는 쓰지 않는다.
+     *                이게 없으면 Kafka 를 건널 때 트레이스가 끊겨 서비스 맵에 collector 와 안 이어진다(#235).
+     */
     @KafkaListener(topics = "${edrdog.kafka.events-topic}", groupId = "${spring.kafka.consumer.group-id}")
-    public void onEvents(List<Event> events) {
+    public void onEvents(List<Event> events,
+                         @Header(KafkaHeaders.NATIVE_HEADERS) List<Headers> headers) {
+        // 배치가 작업 단위라 레코드마다 트랜잭션을 열지 않는다. 쪼개면 INSERT 를 묶어 파트 수를 줄인
+        // 설계가 깨진다. 트랜잭션은 부모를 하나만 가지므로 첫 레코드만 이어지는데, 서비스 맵은
+        // 일부만 이어져도 그려지므로 그걸로 충분하다.
+        if (!headers.isEmpty()) {
+            KafkaTraceLink.accept(headers.get(0));
+        }
         writer.insert(events);
     }
 }

--- a/detector-service/build.gradle
+++ b/detector-service/build.gradle
@@ -11,8 +11,6 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter'
     implementation 'org.springframework.boot:spring-boot-starter-web'    // 데모용 이벤트 발행/조회 REST + Swagger 호스팅
     implementation 'org.springframework.kafka:spring-kafka'
-    // 레코드 단위로 발행 측 트레이스에 이어 붙이기 위한 API(#235). 에이전트가 없으면 no-op 이라 로컬은 영향 없다.
-    implementation 'com.newrelic.agent.java:newrelic-api:8.21.0'
     implementation 'io.micrometer:micrometer-registry-otlp'   // 메트릭 OTLP 전송 (판정 처리량/지연 관측 대상)
     implementation 'org.apache.kafka:kafka-streams'
     implementation 'com.fasterxml.jackson.core:jackson-databind'   // alerts JSON serde + Event.detail 파싱

--- a/detector-service/src/main/java/com/edrdog/detectorservice/kafkastreams/topology/CorrelationProcessor.java
+++ b/detector-service/src/main/java/com/edrdog/detectorservice/kafkastreams/topology/CorrelationProcessor.java
@@ -3,7 +3,7 @@ package com.edrdog.detectorservice.kafkastreams.topology;
 import com.edrdog.detectorservice.dto.Alert;
 import com.edrdog.schema.Event;
 import com.edrdog.detectorservice.rule.Rules;
-import com.edrdog.detectorservice.tracing.KafkaTraceLink;
+import com.edrdog.schema.KafkaTraceLink;
 import io.micrometer.core.instrument.DistributionSummary;
 import io.micrometer.core.instrument.MeterRegistry;
 import org.apache.kafka.streams.KeyValue;

--- a/event-schema/build.gradle
+++ b/event-schema/build.gradle
@@ -17,6 +17,9 @@ dependencies {
     api "com.google.protobuf:protobuf-java-util:${protobufVersion}"
     // Serde/Serializer 가 Kafka 인터페이스를, Jackson 모듈이 Jackson 인터페이스를 구현한다.
     // 쓰는 서비스에는 이미 둘 다 있어서 compileOnly 로 둔다.
+    // 발행 측 트레이스를 이어받는 KafkaTraceLink 가 쓴다. 쓰는 서비스도 런타임에 필요해서 api 다.
+    // 에이전트가 없으면 no-op 이라 로컬 실행과 테스트에는 영향이 없다.
+    api 'com.newrelic.agent.java:newrelic-api:8.21.0'
     compileOnly 'org.apache.kafka:kafka-clients'
     compileOnly 'com.fasterxml.jackson.core:jackson-databind'
     testImplementation 'org.apache.kafka:kafka-clients'

--- a/event-schema/src/main/java/com/edrdog/schema/KafkaTraceLink.java
+++ b/event-schema/src/main/java/com/edrdog/schema/KafkaTraceLink.java
@@ -1,4 +1,4 @@
-package com.edrdog.detectorservice.tracing;
+package com.edrdog.schema;
 
 import com.newrelic.api.agent.HeaderType;
 import com.newrelic.api.agent.NewRelic;
@@ -22,20 +22,39 @@ import java.util.stream.StreamSupport;
  * 켜져 있으면 폴 단위 트랜잭션이 이미 열려 있어서, 아래 {@code @Trace(dispatcher = true)} 가
  * 새 트랜잭션이 아니라 기존 트랜잭션의 구간이 되어 버린다.
  *
- * <p>판정 로직에서 이 클래스만 부르게 격리해 두었다. 관측 백엔드를 옮기면 여기만 걷어내면 된다.
- * 에이전트가 없으면 API 가 알아서 아무 일도 안 하므로 로컬 실행에도 영향이 없다.
+ * <p>벤더 API 를 이 클래스에만 두었다. 관측 백엔드를 옮기면 여기만 걷어내면 된다.
+ * 에이전트가 없으면 API 가 알아서 아무 일도 안 하므로 로컬 실행과 테스트에 영향이 없다.
+ *
+ * <p>events 토픽을 쓰는 쪽이 다 같이 필요해서 event-schema 에 둔다. 헤더 규약을 정의한
+ * {@link EventHeaders} 옆자리다.
  */
 public final class KafkaTraceLink {
 
     private KafkaTraceLink() {
     }
 
-    /** 레코드 하나를 별도 트랜잭션으로 열고, 헤더에 실린 발행 측 트레이스에 이어 붙인다. */
+    /**
+     * 레코드 하나를 별도 트랜잭션으로 열고, 헤더에 실린 발행 측 트레이스에 이어 붙인다.
+     * 레코드마다 처리가 일어나는 쪽(detector 의 판정)에 쓴다.
+     */
     @Trace(dispatcher = true)
     public static void linked(Iterable<Header> kafkaHeaders, Runnable body) {
+        accept(kafkaHeaders);
+        body.run();
+    }
+
+    /**
+     * 이미 열려 있는 트랜잭션을 발행 측 트레이스에 이어 붙이기만 한다.
+     *
+     * <p>배치가 작업 단위인 쪽(archiver 의 ClickHouse 적재)에 쓴다. 거기서는 레코드마다 트랜잭션을
+     * 열 이유가 없다. 실제 작업이 배치당 한 번이고, 쪼개면 INSERT 를 묶어 파트 수를 줄인 설계가 깨진다.
+     *
+     * <p>트랜잭션은 부모를 하나만 가질 수 있으므로 배치의 첫 레코드만 이어진다. 서비스 맵은 트레이스가
+     * 전부 이어져야 그려지는 게 아니라 일부만 이어져도 되므로 이걸로 충분하다.
+     */
+    public static void accept(Iterable<Header> kafkaHeaders) {
         NewRelic.getAgent().getTransaction()
                 .acceptDistributedTraceHeaders(TransportType.Kafka, new KafkaHeaders(kafkaHeaders));
-        body.run();
     }
 
     /** 뉴렐릭이 읽을 수 있게 Kafka 헤더를 감싼다. 읽기 전용이라 쓰기 메서드는 비워 둔다. */


### PR DESCRIPTION
archiver 도 발행 측 트레이스를 이어받게 한다. 상세는 #245.

배치를 쪼개지 않고 첫 레코드 헤더만 수락한다. ClickHouse 파트 설계는 그대로 둔다.

## 배포 후

```bash
sudo kubectl -n edrdog get pods | grep archiver   # AGE 몇 분 이내
```

그다음 Traces 에서 `SpringKafka/...EventListener` 의 `Entities` 확인. 2 이상이면 서비스 맵에 `collector → archiver` 가 추가된다.