### PR TITLE
feat: dev 반영 (archiver 레코드 단위 트레이스)

### DIFF
--- a/archiver-service/build.gradle
+++ b/archiver-service/build.gradle
@@ -5,4 +5,7 @@ dependencies {
     implementation 'org.springframework.kafka:spring-kafka'
     implementation 'com.fasterxml.jackson.core:jackson-databind'        // alerts JSON 역직렬화 + ClickHouse JSONEachRow 직렬화 (events 는 Protobuf)
     implementation 'io.micrometer:micrometer-registry-otlp'             // 메트릭 OTLP 전송 (ClickHouse 적재 지연/컨슈머 랙 관측 대상)
+    // 리스너가 실제 메시지를 받아 적재까지 가는지 보려면 브로커가 있어야 한다.
+    // 기동만 확인하고 배포했다가 적재가 통째로 멈춘 적이 있다(#247).
+    testImplementation 'org.springframework.kafka:spring-kafka-test'
 }

--- a/archiver-service/src/main/java/com/edrdog/archiverservice/EventListener.java
+++ b/archiver-service/src/main/java/com/edrdog/archiverservice/EventListener.java
@@ -2,7 +2,9 @@ package com.edrdog.archiverservice;
 
 import com.edrdog.archiverservice.clickhouse.ClickHouseWriter;
 import com.edrdog.schema.Event;
+import com.edrdog.schema.KafkaTraceLink;
 import java.util.List;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
 
@@ -11,10 +13,11 @@ import org.springframework.stereotype.Component;
  * detector 와 별도 그룹이라 같은 이벤트를 독립적으로 모두 받는다. 적재는 ClickHouseWriter 에 위임.
  * poll 로 받은 배치를 통째로 넘긴다.
  *
- * <p>트레이스를 이으려고 @Header(KafkaHeaders.NATIVE_HEADERS) List&lt;Headers&gt; 파라미터를 붙였다가
- * 적재가 통째로 멈췄다(#247). 배치 리스너에는 그 헤더가 채워지지 않아 메시지마다
- * "Missing header 'kafka_nativeHeaders'" 로 실패한다. 원본 헤더가 필요하면 파라미터를
- * List&lt;ConsumerRecord&lt;K,V&gt;&gt; 로 받아야 한다. 관측 때문에 적재를 멈출 수는 없어 되돌린다.
+ * <p>값이 아니라 레코드로 받는 이유는 헤더에 실린 발행 측 트레이스를 이어받기 위해서다. 이게 없으면
+ * Kafka 를 건널 때 트레이스가 끊겨, 서비스 맵에서 archiver 가 events 를 직접 받는다는 사실이 안 보인다.
+ *
+ * <p>{@code @Header(KafkaHeaders.NATIVE_HEADERS)} 로 헤더만 따로 받으려다 적재가 통째로 멈춘 적이
+ * 있다(#247). 배치 리스너에는 그 헤더가 채워지지 않는다. 레코드로 받아야 한다.
  */
 @Component
 public class EventListener {
@@ -26,7 +29,13 @@ public class EventListener {
     }
 
     @KafkaListener(topics = "${edrdog.kafka.events-topic}", groupId = "${spring.kafka.consumer.group-id}")
-    public void onEvents(List<Event> events) {
-        writer.insert(events);
+    public void onEvents(List<ConsumerRecord<String, Event>> records) {
+        // 배치가 작업 단위라 레코드마다 트랜잭션을 열지 않는다. 쪼개면 INSERT 를 한 번으로 묶어
+        // 파트 수를 줄인 설계가 깨진다. 트랜잭션은 부모를 하나만 가지므로 첫 레코드만 이어지는데,
+        // 서비스 맵은 일부만 이어져도 그려지므로 그걸로 충분하다.
+        if (!records.isEmpty()) {
+            KafkaTraceLink.accept(records.get(0).headers());
+        }
+        writer.insert(records.stream().map(ConsumerRecord::value).toList());
     }
 }

--- a/archiver-service/src/test/java/com/edrdog/archiverservice/EventListenerKafkaTest.java
+++ b/archiver-service/src/test/java/com/edrdog/archiverservice/EventListenerKafkaTest.java
@@ -1,0 +1,70 @@
+package com.edrdog.archiverservice;
+
+import com.edrdog.archiverservice.clickhouse.ClickHouseWriter;
+import com.edrdog.schema.Event;
+import com.edrdog.schema.EventSerializer;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.kafka.test.EmbeddedKafkaBroker;
+import org.springframework.kafka.test.context.EmbeddedKafka;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.verify;
+
+/**
+ * events 토픽에 실제로 메시지를 흘려 리스너가 적재까지 가는지 본다.
+ *
+ * <p>이 테스트가 없어서 사고가 났다(#247). 트레이스를 이으려고 리스너에 파라미터를 하나 붙였는데
+ * 배치 리스너에는 그 헤더가 채워지지 않아 메시지마다 실패했고, ClickHouse 적재가 통째로 멈췄다.
+ * 기동만 확인했기 때문에 로컬에서는 멀쩡해 보였다. 리스너 등록은 되고 레코드가 올 때 터지는 종류다.
+ *
+ * <p>그래서 여기서는 브로커를 띄우고 메시지를 실제로 보낸다. 적재 대상(ClickHouse)은 목으로 둔다.
+ * 확인하려는 건 저장 결과가 아니라 "리스너가 레코드를 받아 값을 꺼내 넘기는가"다.
+ */
+@SpringBootTest(properties = {
+        "spring.kafka.consumer.auto-offset-reset=earliest",
+        "spring.kafka.consumer.fetch-min-size=1",   // 한 건만 보내므로 하한을 낮춰야 바로 온다
+        "spring.kafka.listener.concurrency=1",
+        "management.tracing.enabled=false",
+        "management.otlp.metrics.export.enabled=false",
+})
+@EmbeddedKafka(partitions = 1, topics = "events")
+class EventListenerKafkaTest {
+
+    @Autowired
+    EmbeddedKafkaBroker broker;
+
+    @MockitoBean
+    ClickHouseWriter writer;
+
+    @Test
+    void 발행한_이벤트가_리스너를_거쳐_적재로_넘어간다() {
+        Event event = Event.newBuilder()
+                .setHost("host-1")
+                .setType("process")
+                .setTs(1700000000000L)
+                .setTenantId("99")
+                .build();
+
+        try (var producer = new KafkaProducer<String, Event>(
+                Map.of("bootstrap.servers", broker.getBrokersAsString()),
+                new StringSerializer(), new EventSerializer())) {
+            producer.send(new ProducerRecord<>("events", "host-1", event));
+            producer.flush();
+        }
+
+        // 실패하면 리스너가 레코드를 못 받은 것이다. 파라미터 해석 실패가 여기서 잡힌다.
+        verify(writer, timeout(15_000))
+                .insert(argThat((List<Event> batch) ->
+                        batch.stream().anyMatch(e -> "host-1".equals(e.getHost()))));
+    }
+}


### PR DESCRIPTION
archiver 가 레코드로 받아 발행 측 트레이스를 이어받는다. 상세는 #250.

#247 로 적재를 멈춘 적이 있어 이번에는 EmbeddedKafka 로 메시지를 실제로 흘리는 테스트를 먼저 만들었다. 테스트가 실패를 잡는 것도 확인했다.

## 배포 후

```bash
sudo kubectl -n edrdog logs deploy/archiver-service --tail=20 | grep -icE 'error|exception'
```

**0 이어야 한다.** 0 이 아니면 즉시 되돌린다.