### PR TITLE
fix: 서비스 메모리 상한을 1Gi 로 올린다

### DIFF
--- a/k8s/alert-service.yaml
+++ b/k8s/alert-service.yaml
@@ -65,10 +65,13 @@ spec:
           resources:
             requests:
               cpu: 100m
-              memory: 256Mi
+              memory: 384Mi
             limits:
               cpu: 500m
-              memory: 512Mi
+              # 512Mi 는 뉴렐릭 자바 에이전트를 붙이기 전 기준이었다. 붙이고 나서 실측이 collector 495Mi,
+              # api 472Mi, detector 468Mi 로 상한의 90%를 넘겼다. 늘어난 건 힙이 아니라 비힙
+              # (에이전트, 메타스페이스, 스레드)이라 -Xmx 로 눌러도 안 줄어든다.
+              memory: 1Gi
 ---
 apiVersion: v1
 kind: Service

--- a/k8s/api-service.yaml
+++ b/k8s/api-service.yaml
@@ -90,10 +90,13 @@ spec:
           resources:
             requests:
               cpu: 100m
-              memory: 256Mi
+              memory: 384Mi
             limits:
               cpu: 500m
-              memory: 512Mi
+              # 512Mi 는 뉴렐릭 자바 에이전트를 붙이기 전 기준이었다. 붙이고 나서 실측이 collector 495Mi,
+              # api 472Mi, detector 468Mi 로 상한의 90%를 넘겼다. 늘어난 건 힙이 아니라 비힙
+              # (에이전트, 메타스페이스, 스레드)이라 -Xmx 로 눌러도 안 줄어든다.
+              memory: 1Gi
           volumeMounts:
             - name: geoip
               mountPath: /etc/geoip

--- a/k8s/archiver-service.yaml
+++ b/k8s/archiver-service.yaml
@@ -66,10 +66,13 @@ spec:
           resources:
             requests:
               cpu: 100m
-              memory: 256Mi
+              memory: 384Mi
             limits:
               cpu: 500m
-              memory: 512Mi
+              # 512Mi 는 뉴렐릭 자바 에이전트를 붙이기 전 기준이었다. 붙이고 나서 실측이 collector 495Mi,
+              # api 472Mi, detector 468Mi 로 상한의 90%를 넘겼다. 늘어난 건 힙이 아니라 비힙
+              # (에이전트, 메타스페이스, 스레드)이라 -Xmx 로 눌러도 안 줄어든다.
+              memory: 1Gi
 ---
 apiVersion: v1
 kind: Service

--- a/k8s/collector-service.yaml
+++ b/k8s/collector-service.yaml
@@ -95,10 +95,13 @@ spec:
           resources:
             requests:
               cpu: 100m
-              memory: 256Mi
+              memory: 384Mi
             limits:
               cpu: 500m
-              memory: 512Mi
+              # 512Mi 는 뉴렐릭 자바 에이전트를 붙이기 전 기준이었다. 붙이고 나서 실측이 collector 495Mi,
+              # api 472Mi, detector 468Mi 로 상한의 90%를 넘겼다. 늘어난 건 힙이 아니라 비힙
+              # (에이전트, 메타스페이스, 스레드)이라 -Xmx 로 눌러도 안 줄어든다.
+              memory: 1Gi
           volumeMounts:
             - name: agent-tls
               mountPath: /etc/agent-tls

--- a/k8s/detector-service.yaml
+++ b/k8s/detector-service.yaml
@@ -65,10 +65,13 @@ spec:
           resources:
             requests:
               cpu: 100m
-              memory: 256Mi
+              memory: 384Mi
             limits:
               cpu: 500m
-              memory: 512Mi
+              # 512Mi 는 뉴렐릭 자바 에이전트를 붙이기 전 기준이었다. 붙이고 나서 실측이 collector 495Mi,
+              # api 472Mi, detector 468Mi 로 상한의 90%를 넘겼다. 늘어난 건 힙이 아니라 비힙
+              # (에이전트, 메타스페이스, 스레드)이라 -Xmx 로 눌러도 안 줄어든다.
+              memory: 1Gi
 ---
 apiVersion: v1
 kind: Service

--- a/k8s/responder-service.yaml
+++ b/k8s/responder-service.yaml
@@ -66,10 +66,13 @@ spec:
           resources:
             requests:
               cpu: 100m
-              memory: 256Mi
+              memory: 384Mi
             limits:
               cpu: 500m
-              memory: 512Mi
+              # 512Mi 는 뉴렐릭 자바 에이전트를 붙이기 전 기준이었다. 붙이고 나서 실측이 collector 495Mi,
+              # api 472Mi, detector 468Mi 로 상한의 90%를 넘겼다. 늘어난 건 힙이 아니라 비힙
+              # (에이전트, 메타스페이스, 스레드)이라 -Xmx 로 눌러도 안 줄어든다.
+              memory: 1Gi
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
Closes #252

에이전트를 붙인 뒤(#223) 실사용이 상한에 거의 닿았다.

| 서비스 | 사용 | 상한 대비 |
|---|---|---|
| collector | 495Mi | **97%** |
| api | 472Mi | **92%** |
| detector | 468Mi | **91%** |

collector 는 여유가 **17Mi** 다. 아직 OOM 은 안 났지만 시간 문제다.

늘어난 것은 힙이 아니라 **비힙**(에이전트, 메타스페이스, 스레드)이라 `-Xmx` 로 눌러도 안 줄어든다.

## 노드 여유

```
memory  requests 3788Mi (15%)   limits 8746Mi (36%)
사용     11656Mi (48%)                                  # 총 24Gi 급
```

여섯 개를 1Gi 로 올려도 limits 합이 11.7Gi(47%) 다.

## 변경

- limits 512Mi → **1Gi** (6개 전부)
- requests 256Mi → **384Mi** (실사용이 이미 그 위라 스케줄러가 남은 자리를 잘못 계산한다)

## 배포 후

```bash
sudo kubectl -n edrdog top pod --sort-by=memory
```

상한 대비 비율이 절반 아래로 떨어져야 한다. 며칠 지켜보고 1Gi 도 빠듯하면 에이전트 부담을 줄이는 쪽(샘플링, 계측 축소)을 본다.