### PR TITLE
fix: dev 반영 (서비스 메모리 상한 1Gi)

### DIFF
--- a/k8s/alert-service.yaml
+++ b/k8s/alert-service.yaml
@@ -65,10 +65,13 @@ spec:
           resources:
             requests:
               cpu: 100m
-              memory: 256Mi
+              memory: 384Mi
             limits:
               cpu: 500m
-              memory: 512Mi
+              # 512Mi 는 뉴렐릭 자바 에이전트를 붙이기 전 기준이었다. 붙이고 나서 실측이 collector 495Mi,
+              # api 472Mi, detector 468Mi 로 상한의 90%를 넘겼다. 늘어난 건 힙이 아니라 비힙
+              # (에이전트, 메타스페이스, 스레드)이라 -Xmx 로 눌러도 안 줄어든다.
+              memory: 1Gi
 ---
 apiVersion: v1
 kind: Service

--- a/k8s/api-service.yaml
+++ b/k8s/api-service.yaml
@@ -90,10 +90,13 @@ spec:
           resources:
             requests:
               cpu: 100m
-              memory: 256Mi
+              memory: 384Mi
             limits:
               cpu: 500m
-              memory: 512Mi
+              # 512Mi 는 뉴렐릭 자바 에이전트를 붙이기 전 기준이었다. 붙이고 나서 실측이 collector 495Mi,
+              # api 472Mi, detector 468Mi 로 상한의 90%를 넘겼다. 늘어난 건 힙이 아니라 비힙
+              # (에이전트, 메타스페이스, 스레드)이라 -Xmx 로 눌러도 안 줄어든다.
+              memory: 1Gi
           volumeMounts:
             - name: geoip
               mountPath: /etc/geoip

--- a/k8s/archiver-service.yaml
+++ b/k8s/archiver-service.yaml
@@ -66,10 +66,13 @@ spec:
           resources:
             requests:
               cpu: 100m
-              memory: 256Mi
+              memory: 384Mi
             limits:
               cpu: 500m
-              memory: 512Mi
+              # 512Mi 는 뉴렐릭 자바 에이전트를 붙이기 전 기준이었다. 붙이고 나서 실측이 collector 495Mi,
+              # api 472Mi, detector 468Mi 로 상한의 90%를 넘겼다. 늘어난 건 힙이 아니라 비힙
+              # (에이전트, 메타스페이스, 스레드)이라 -Xmx 로 눌러도 안 줄어든다.
+              memory: 1Gi
 ---
 apiVersion: v1
 kind: Service

--- a/k8s/collector-service.yaml
+++ b/k8s/collector-service.yaml
@@ -95,10 +95,13 @@ spec:
           resources:
             requests:
               cpu: 100m
-              memory: 256Mi
+              memory: 384Mi
             limits:
               cpu: 500m
-              memory: 512Mi
+              # 512Mi 는 뉴렐릭 자바 에이전트를 붙이기 전 기준이었다. 붙이고 나서 실측이 collector 495Mi,
+              # api 472Mi, detector 468Mi 로 상한의 90%를 넘겼다. 늘어난 건 힙이 아니라 비힙
+              # (에이전트, 메타스페이스, 스레드)이라 -Xmx 로 눌러도 안 줄어든다.
+              memory: 1Gi
           volumeMounts:
             - name: agent-tls
               mountPath: /etc/agent-tls

--- a/k8s/detector-service.yaml
+++ b/k8s/detector-service.yaml
@@ -65,10 +65,13 @@ spec:
           resources:
             requests:
               cpu: 100m
-              memory: 256Mi
+              memory: 384Mi
             limits:
               cpu: 500m
-              memory: 512Mi
+              # 512Mi 는 뉴렐릭 자바 에이전트를 붙이기 전 기준이었다. 붙이고 나서 실측이 collector 495Mi,
+              # api 472Mi, detector 468Mi 로 상한의 90%를 넘겼다. 늘어난 건 힙이 아니라 비힙
+              # (에이전트, 메타스페이스, 스레드)이라 -Xmx 로 눌러도 안 줄어든다.
+              memory: 1Gi
 ---
 apiVersion: v1
 kind: Service

--- a/k8s/responder-service.yaml
+++ b/k8s/responder-service.yaml
@@ -66,10 +66,13 @@ spec:
           resources:
             requests:
               cpu: 100m
-              memory: 256Mi
+              memory: 384Mi
             limits:
               cpu: 500m
-              memory: 512Mi
+              # 512Mi 는 뉴렐릭 자바 에이전트를 붙이기 전 기준이었다. 붙이고 나서 실측이 collector 495Mi,
+              # api 472Mi, detector 468Mi 로 상한의 90%를 넘겼다. 늘어난 건 힙이 아니라 비힙
+              # (에이전트, 메타스페이스, 스레드)이라 -Xmx 로 눌러도 안 줄어든다.
+              memory: 1Gi
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
에이전트를 붙인 뒤 실사용이 상한 512Mi 의 90%를 넘겼다. collector 는 여유가 17Mi 뿐이다. 상세는 #253.

매니페스트만 바뀌므로 이미지는 다시 안 굽고 파드만 교체된다.

## 배포 후

```bash
sudo kubectl -n edrdog top pod --sort-by=memory
```