### PR TITLE
fix: Kafka 메모리 상한을 기본 힙보다 크게 준다

### DIFF
--- a/k8s/kafka.yaml
+++ b/k8s/kafka.yaml
@@ -53,12 +53,13 @@ spec:
               port: 9092
             initialDelaySeconds: 15
             periodSeconds: 10
+          # 기본 힙이 -Xmx1G 라 상한이 1Gi 면 힙만으로 다 찬다. 비힙 몫까지 준다
           resources:
             requests:
               cpu: 250m
-              memory: 512Mi
-            limits:
               memory: 1Gi
+            limits:
+              memory: 2Gi
 ---
 # 클러스터 내부용 (INTERNAL 리스너)
 apiVersion: v1


### PR DESCRIPTION
Closes #255

## 왜

`apache/kafka:3.9.0` 의 기본 힙이 `-Xmx1G` 인데 컨테이너 상한도 `1Gi` 였다. 힙만으로 상한을 다 쓴다. 비힙(메타스페이스, 스레드, 다이렉트 버퍼)이 얹히면 힙이 차는 순간 OOMKilled 다.

실사용 `841Mi / 1Gi = 82%`. 안 죽은 건 힙이 아직 안 찼기 때문이다.

## 뭘

```yaml
requests: 512Mi → 1Gi
limits:   1Gi   → 2Gi
```

매니페스트만 바뀌므로 이미지는 다시 굽지 않는다. Kafka 파드가 한 번 재시작한다.

## 배포 후

```bash
sudo kubectl -n edrdog top pod --sort-by=memory
sudo kubectl -n edrdog get pod -l app=kafka
```

`AGE` 가 새것이고 `RESTARTS 0`, 상한 대비 절반 아래면 정상.

⚠️ Kafka 재시작 동안 수집·탐지가 잠깐 끊긴다.