### PR TITLE
fix: dev 반영 (Kafka 메모리 상한 2Gi)

### DIFF
--- a/k8s/kafka.yaml
+++ b/k8s/kafka.yaml
@@ -53,12 +53,13 @@ spec:
               port: 9092
             initialDelaySeconds: 15
             periodSeconds: 10
+          # 기본 힙이 -Xmx1G 라 상한이 1Gi 면 힙만으로 다 찬다. 비힙 몫까지 준다
           resources:
             requests:
               cpu: 250m
-              memory: 512Mi
-            limits:
               memory: 1Gi
+            limits:
+              memory: 2Gi
 ---
 # 클러스터 내부용 (INTERNAL 리스너)
 apiVersion: v1


### PR DESCRIPTION
Kafka 기본 힙이 -Xmx1G 인데 컨테이너 상한도 1Gi 라 힙만으로 다 찼다. requests 1Gi / limits 2Gi 로 올린다.

Closes #255