### PR TITLE
feat: APM 의 Kafka 탭을 켠다

### DIFF
--- a/shared-resources/newrelic.yml
+++ b/shared-resources/newrelic.yml
@@ -28,6 +28,13 @@ common: &default_settings
     # @KafkaListener 소비자 (archiver 2, alert 1, responder 1, detector 의 alerts-view 1)
     com.newrelic.instrumentation.spring-kafka-2.2.0:
       enabled: true
+    # APM 의 Kafka 탭을 채운다. 기본 모듈은 토픽 단위까지만 재므로 브로커 노드별 지표가 없어
+    # 탭이 "Kafka Node Metrics 를 켜라"는 안내만 띄운 채 비어 있었다. 둘은 배타적이라 같이 못 켠다.
+    # kafka-clients 3.9.1 을 쓰므로 3.9.0 판이 걸린다.
+    com.newrelic.instrumentation.kafka-clients-metrics-3.9.0:
+      enabled: false
+    com.newrelic.instrumentation.kafka-clients-node-metrics-3.9.0:
+      enabled: true
 
 production:
   <<: *default_settings


### PR DESCRIPTION
Closes #258

## 왜

각 서비스의 Kafka 탭이 `To view Kafka data, enable Kafka Node Metrics collection` 만 띄운 채 비어 있었다. 기본 모듈은 토픽 단위까지만 재고 탭이 요구하는 노드별 지표를 안 만든다.

## 뭘

```yaml
com.newrelic.instrumentation.kafka-clients-metrics-3.9.0:      enabled: false
com.newrelic.instrumentation.kafka-clients-node-metrics-3.9.0: enabled: true
```

판번호는 에이전트 JAR 매니페스트의 `Implementation-Title` 에서 확인했다. kafka-clients 3.9.1 을 쓰므로 3.9.0 판이 걸린다.

`shared-resources/` 가 바뀌므로 이미지 여섯 개를 다시 굽는다.

## 배포 후

기동 로그에 모듈이 걸렸는지 먼저 본다. 이름이 틀리면 오류 없이 무시된다(#232).

```bash
sudo kubectl -n edrdog logs -l app=collector-service --tail=200 | grep -i "weave package"
```

그다음 APM → 아무 서비스 → Kafka 탭에 Producer/Consumer 지표가 차는지 본다.

## 이 PR 이 안 하는 것

Kafka 를 서비스 맵 노드로 만들지 않는다. 뉴렐릭 맵은 프로듀서와 컨슈머를 직접 잇고 브로커를 중간에 그리지 않는다. 그건 도구가 안 하는 일이라 설정으로 못 바꾼다.