### PR TITLE
fix: dev 반영 (alerts 컨슈머 트레이스 연결)

### DIFF
--- a/alert-service/build.gradle
+++ b/alert-service/build.gradle
@@ -1,6 +1,9 @@
 // Alert — alerts 를 별도 컨슈머 그룹(alert)으로 소비해 Slack 으로 알림 전송 (responder 와 독립)
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'   // RestClient (Slack webhook)
+    implementation project(':event-schema')                             // KafkaTraceLink (트레이스 연결). 스키마는 안 쓴다
     implementation 'org.springframework.kafka:spring-kafka'
     implementation 'com.fasterxml.jackson.core:jackson-databind'        // alerts JSON 역직렬화
+    // 리스너 시그니처를 바꾸면 기동은 멀쩡한데 레코드 수신에서만 터진다(#247). 브로커를 띄워 확인한다.
+    testImplementation 'org.springframework.kafka:spring-kafka-test'
 }

--- a/alert-service/src/main/java/com/edrdog/alertservice/AlertListener.java
+++ b/alert-service/src/main/java/com/edrdog/alertservice/AlertListener.java
@@ -3,13 +3,14 @@ package com.edrdog.alertservice;
 import com.edrdog.alertservice.dto.Alert;
 import com.edrdog.alertservice.slack.SlackNotifier;
 import com.edrdog.alertservice.webhook.AlertRouter;
+import com.edrdog.schema.KafkaTraceLink;
+import java.util.Optional;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
-
-import java.util.Optional;
 
 /**
  * alerts 토픽을 소비해 host 소유 유저(없으면 tenant 관리자 채널)의 Slack 으로 알림을 보내는 리스너.
@@ -31,8 +32,14 @@ public class AlertListener {
         this.cooldown = new Cooldown(cooldownMs);
     }
 
+    // 레코드로 받아야 헤더에서 트레이스를 이어받는다. 값만 받으면 detector 와 끊긴 트레이스가 된다.
     @KafkaListener(topics = "${edrdog.kafka.alerts-topic}", groupId = "${spring.kafka.consumer.group-id}")
-    public void onAlert(Alert alert) {
+    public void onAlert(ConsumerRecord<String, Alert> record) {
+        KafkaTraceLink.accept(record.headers());
+        handle(record.value());
+    }
+
+    public void handle(Alert alert) {
         if (alert == null || alert.host() == null || alert.ruleId() == null) {
             return;
         }

--- a/alert-service/src/test/java/com/edrdog/alertservice/AlertListenerKafkaTest.java
+++ b/alert-service/src/test/java/com/edrdog/alertservice/AlertListenerKafkaTest.java
@@ -1,0 +1,72 @@
+package com.edrdog.alertservice;
+
+import com.edrdog.alertservice.dto.Alert;
+import com.edrdog.alertservice.slack.SlackNotifier;
+import com.edrdog.alertservice.webhook.AlertRouter;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.kafka.support.serializer.JsonSerializer;
+import org.springframework.kafka.test.EmbeddedKafkaBroker;
+import org.springframework.kafka.test.context.EmbeddedKafka;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * alerts 토픽에 실제로 메시지를 흘려 리스너가 발송까지 가는지 본다.
+ *
+ * <p>리스너가 값(Alert) 대신 ConsumerRecord 를 받도록 바꿨다. 트레이스를 이어받으려면 헤더가 필요한데
+ * 값만 받으면 헤더에 손이 닿지 않기 때문이다. 이 변경은 기동에서는 아무 티가 안 나고 레코드가 올 때만
+ * 터지는 종류다(#247). 그래서 브로커를 띄우고 실제로 한 건 보낸다.
+ */
+@SpringBootTest(properties = {
+        "spring.kafka.consumer.auto-offset-reset=earliest",
+        "spring.kafka.listener.concurrency=1",
+        "management.tracing.enabled=false",
+})
+@EmbeddedKafka(partitions = 1, topics = "alerts")
+class AlertListenerKafkaTest {
+
+    private static final String WEBHOOK = "https://hooks/abc";
+
+    @Autowired
+    EmbeddedKafkaBroker broker;
+
+    @MockitoBean
+    AlertRouter router;
+
+    @MockitoBean
+    SlackNotifier slack;
+
+    @Test
+    void 발행한_alert_가_리스너를_거쳐_발송으로_넘어간다() {
+        when(router.route(any())).thenReturn(Optional.of(new AlertRouter.Route(WEBHOOK, "user:1")));
+
+        Alert alert = new Alert("t1", "host-1", "DOWNLOAD_AND_EXECUTE", "T1105",
+                Alert.SEV_CRITICAL, Alert.ACTION_KILL, System.currentTimeMillis(), List.of("evidence"));
+
+        try (var producer = new KafkaProducer<String, Alert>(
+                Map.of("bootstrap.servers", broker.getBrokersAsString()),
+                new StringSerializer(), new JsonSerializer<Alert>())) {
+            producer.send(new ProducerRecord<>("alerts", "host-1", alert));
+            producer.flush();
+        }
+
+        // 실패하면 리스너가 레코드를 못 받은 것이다. 파라미터 해석 실패가 여기서 잡힌다.
+        verify(slack, timeout(15_000))
+                .send(argThat(a -> "host-1".equals(a.host())), eq(WEBHOOK));
+    }
+}

--- a/alert-service/src/test/java/com/edrdog/alertservice/AlertListenerTest.java
+++ b/alert-service/src/test/java/com/edrdog/alertservice/AlertListenerTest.java
@@ -50,7 +50,7 @@ class AlertListenerTest {
         routed();
         when(slack.send(any(), anyString())).thenReturn(true);
 
-        listener.onAlert(alert(1_000));
+        listener.handle(alert(1_000));
 
         verify(slack).send(any(), anyString());
     }
@@ -60,7 +60,7 @@ class AlertListenerTest {
     void noRoute_skips() {
         when(router.route(any())).thenReturn(Optional.empty());
 
-        listener.onAlert(alert(1_000));
+        listener.handle(alert(1_000));
 
         verify(slack, never()).send(any(), anyString());
     }
@@ -71,8 +71,8 @@ class AlertListenerTest {
         routed();
         when(slack.send(any(), anyString())).thenReturn(true);
 
-        listener.onAlert(alert(1_000));
-        listener.onAlert(alert(2_000));
+        listener.handle(alert(1_000));
+        listener.handle(alert(2_000));
 
         verify(slack, times(1)).send(any(), anyString());
     }
@@ -83,8 +83,8 @@ class AlertListenerTest {
         routed();
         when(slack.send(any(), anyString())).thenReturn(false);
 
-        listener.onAlert(alert(1_000));
-        listener.onAlert(alert(2_000));
+        listener.handle(alert(1_000));
+        listener.handle(alert(2_000));
 
         verify(slack, times(2)).send(any(), anyString());
     }

--- a/archiver-service/src/main/java/com/edrdog/archiverservice/alert/AlertIngestListener.java
+++ b/archiver-service/src/main/java/com/edrdog/archiverservice/alert/AlertIngestListener.java
@@ -1,7 +1,9 @@
 package com.edrdog.archiverservice.alert;
 
 import com.edrdog.archiverservice.alert.dto.Alert;
+import com.edrdog.schema.KafkaTraceLink;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.kafka.annotation.KafkaListener;
@@ -25,8 +27,14 @@ public class AlertIngestListener {
         this.mapper = mapper;
     }
 
+    // 레코드로 받아야 헤더에서 트레이스를 이어받는다. 값만 받으면 detector 와 끊긴 트레이스가 된다.
     @KafkaListener(topics = "${edrdog.kafka.alerts-topic}", containerFactory = "alertListenerContainerFactory")
-    public void onAlert(String message) {
+    public void onAlert(ConsumerRecord<String, String> record) {
+        KafkaTraceLink.accept(record.headers());
+        handle(record.value());
+    }
+
+    public void handle(String message) {
         Alert alert = parse(message);
         if (alert == null || alert.tenantId() == null || alert.tenantId().isBlank()
                 || alert.host() == null || alert.ruleId() == null) {

--- a/archiver-service/src/test/java/com/edrdog/archiverservice/alert/AlertIngestListenerKafkaTest.java
+++ b/archiver-service/src/test/java/com/edrdog/archiverservice/alert/AlertIngestListenerKafkaTest.java
@@ -1,0 +1,65 @@
+package com.edrdog.archiverservice.alert;
+
+import com.edrdog.archiverservice.clickhouse.ClickHouseWriter;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.kafka.test.EmbeddedKafkaBroker;
+import org.springframework.kafka.test.context.EmbeddedKafka;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.verify;
+
+/**
+ * alerts 토픽에 실제로 메시지를 흘려 리스너가 적재까지 가는지 본다.
+ *
+ * <p>리스너가 값(String) 대신 ConsumerRecord 를 받도록 바꿨다. 트레이스를 이어받으려면 헤더가 필요한데
+ * 값만 받으면 헤더에 손이 닿지 않기 때문이다. 이 변경은 기동에서는 아무 티가 안 나고 레코드가 올 때만
+ * 터지는 종류다(#247). 그래서 브로커를 띄우고 실제로 한 건 보낸다.
+ */
+@SpringBootTest(properties = {
+        "spring.kafka.consumer.auto-offset-reset=earliest",
+        "spring.kafka.consumer.fetch-min-size=1",
+        "spring.kafka.listener.concurrency=1",
+        "management.tracing.enabled=false",
+        "management.otlp.metrics.export.enabled=false",
+})
+@EmbeddedKafka(partitions = 1, topics = {"events", "alerts"})
+class AlertIngestListenerKafkaTest {
+
+    @Autowired
+    EmbeddedKafkaBroker broker;
+
+    @MockitoBean
+    AlertClickHouseWriter alertWriter;
+
+    @MockitoBean
+    ClickHouseWriter eventWriter;   // events 리스너도 같이 뜨므로 실제 적재를 막는다
+
+    @Test
+    void 발행한_alert_가_리스너를_거쳐_적재로_넘어간다() {
+        String json = """
+                {"tenantId":"1","host":"host-1","ruleId":"DOWNLOAD_AND_EXECUTE","mitre":"T1105",
+                 "severity":"CRITICAL","action":"kill","ts":1700000000000,"matched":["evidence"]}
+                """;
+
+        try (var producer = new KafkaProducer<String, String>(
+                Map.of("bootstrap.servers", broker.getBrokersAsString()),
+                new StringSerializer(), new StringSerializer())) {
+            producer.send(new ProducerRecord<>("alerts", "host-1", json));
+            producer.flush();
+        }
+
+        // 실패하면 리스너가 레코드를 못 받은 것이다. 파라미터 해석 실패가 여기서 잡힌다.
+        verify(alertWriter, timeout(15_000))
+                .insert(any(), argThat(a -> "host-1".equals(a.host())));
+    }
+}

--- a/archiver-service/src/test/java/com/edrdog/archiverservice/alert/AlertIngestListenerTest.java
+++ b/archiver-service/src/test/java/com/edrdog/archiverservice/alert/AlertIngestListenerTest.java
@@ -24,38 +24,38 @@ class AlertIngestListenerTest {
 
     @Test
     void tenantId_없으면_버린다() throws Exception {
-        listener.onAlert(json(alert(null, "host-1", "RULE_A")));
+        listener.handle(json(alert(null, "host-1", "RULE_A")));
         verify(writer, never()).insert(any(), any());
     }
 
     @Test
     void tenantId_가_빈문자열이면_버린다() throws Exception {
-        listener.onAlert(json(alert("", "host-1", "RULE_A")));
+        listener.handle(json(alert("", "host-1", "RULE_A")));
         verify(writer, never()).insert(any(), any());
     }
 
     @Test
     void host_없으면_버린다() throws Exception {
-        listener.onAlert(json(alert("t1", null, "RULE_A")));
+        listener.handle(json(alert("t1", null, "RULE_A")));
         verify(writer, never()).insert(any(), any());
     }
 
     @Test
     void ruleId_없으면_버린다() throws Exception {
-        listener.onAlert(json(alert("t1", "host-1", null)));
+        listener.handle(json(alert("t1", "host-1", null)));
         verify(writer, never()).insert(any(), any());
     }
 
     @Test
     void 파싱_실패한_메시지는_버린다() {
-        listener.onAlert("{이건 JSON 이 아니다");
+        listener.handle("{이건 JSON 이 아니다");
         verify(writer, never()).insert(any(), any());
     }
 
     @Test
     void 필수값이_다있으면_결정적_id로_적재한다() throws Exception {
         Alert alert = alert("t1", "host-1", "RULE_A");
-        listener.onAlert(json(alert));
+        listener.handle(json(alert));
         String expectedId = AlertId.of("t1", "host-1", "RULE_A", 1000L);
         verify(writer).insert(eq(expectedId), eq(alert));
     }

--- a/responder-service/build.gradle
+++ b/responder-service/build.gradle
@@ -1,6 +1,9 @@
 // Responder: alerts 소비 → 권장 조치 dry-run 표시 + 반자동 실제 조치(에이전트 명령 큐) (group: responder)
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'  // 실행 트리거 API + 에이전트 명령 채널
+    implementation project(':event-schema')                            // KafkaTraceLink (트레이스 연결). 스키마는 안 쓴다
     implementation 'org.springframework.kafka:spring-kafka'
     implementation 'com.fasterxml.jackson.core:jackson-databind'   // alerts JSON 역직렬화
+    // 리스너 시그니처를 바꾸면 기동은 멀쩡한데 레코드 수신에서만 터진다(#247). 브로커를 띄워 확인한다.
+    testImplementation 'org.springframework.kafka:spring-kafka-test'
 }

--- a/responder-service/src/main/java/com/edrdog/responderservice/AlertListener.java
+++ b/responder-service/src/main/java/com/edrdog/responderservice/AlertListener.java
@@ -2,6 +2,8 @@ package com.edrdog.responderservice;
 
 import com.edrdog.responderservice.dto.Alert;
 import com.edrdog.responderservice.response.ResponsePlanner;
+import com.edrdog.schema.KafkaTraceLink;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
@@ -23,8 +25,14 @@ public class AlertListener {
         this.planner = new ResponsePlanner(cooldownMs);
     }
 
+    // 레코드로 받아야 헤더에서 트레이스를 이어받는다. 값만 받으면 detector 와 끊긴 트레이스가 된다.
     @KafkaListener(topics = "${edrdog.kafka.alerts-topic}", groupId = "${spring.kafka.consumer.group-id}")
-    public void onAlert(Alert alert) {
+    public void onAlert(ConsumerRecord<String, Alert> record) {
+        KafkaTraceLink.accept(record.headers());
+        handle(record.value());
+    }
+
+    public void handle(Alert alert) {
         planner.plan(alert).ifPresent(log::info);
     }
 }

--- a/responder-service/src/test/java/com/edrdog/responderservice/AlertListenerKafkaTest.java
+++ b/responder-service/src/test/java/com/edrdog/responderservice/AlertListenerKafkaTest.java
@@ -1,0 +1,63 @@
+package com.edrdog.responderservice;
+
+import com.edrdog.responderservice.dto.Alert;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.kafka.support.serializer.JsonSerializer;
+import org.springframework.kafka.test.EmbeddedKafkaBroker;
+import org.springframework.kafka.test.context.EmbeddedKafka;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.verify;
+
+/**
+ * alerts 토픽에 실제로 메시지를 흘려 리스너가 값을 꺼내 판정으로 넘기는지 본다.
+ *
+ * <p>리스너가 값(Alert) 대신 ConsumerRecord 를 받도록 바꿨다. 트레이스를 이어받으려면 헤더가 필요한데
+ * 값만 받으면 헤더에 손이 닿지 않기 때문이다. 이 변경은 기동에서는 아무 티가 안 나고 레코드가 올 때만
+ * 터지는 종류다(#247). 그래서 브로커를 띄우고 실제로 한 건 보낸다.
+ *
+ * <p>dry-run 이라 바깥으로 나가는 부수효과가 로그뿐이다. 그래서 목 대신 스파이를 걸어
+ * 값을 꺼내 넘기는 지점을 직접 확인한다.
+ */
+@SpringBootTest(properties = {
+        "spring.kafka.consumer.auto-offset-reset=earliest",
+        "spring.kafka.listener.concurrency=1",
+        "management.tracing.enabled=false",
+})
+@EmbeddedKafka(partitions = 1, topics = "alerts")
+class AlertListenerKafkaTest {
+
+    @Autowired
+    EmbeddedKafkaBroker broker;
+
+    @MockitoSpyBean
+    AlertListener listener;
+
+    @Test
+    void 발행한_alert_가_리스너를_거쳐_판정으로_넘어간다() {
+        Alert alert = new Alert("host-1", "DOWNLOAD_AND_EXECUTE", "T1105",
+                "CRITICAL", Alert.ACTION_KILL, System.currentTimeMillis(),
+                List.of("evidence"), "update32.exe");
+
+        try (var producer = new KafkaProducer<String, Alert>(
+                Map.of("bootstrap.servers", broker.getBrokersAsString()),
+                new StringSerializer(), new JsonSerializer<Alert>())) {
+            producer.send(new ProducerRecord<>("alerts", "host-1", alert));
+            producer.flush();
+        }
+
+        // 실패하면 리스너가 레코드를 못 받은 것이다. 파라미터 해석 실패가 여기서 잡힌다.
+        verify(listener, timeout(15_000))
+                .handle(argThat((Alert a) -> a != null && "host-1".equals(a.host())));
+    }
+}


### PR DESCRIPTION
alerts 리스너 세 곳이 ConsumerRecord 를 받아 헤더에서 트레이스를 이어받는다. 브로커를 띄우는 테스트 3종 포함.

Closes #261