### PR TITLE
fix: punctuator 가 발행하는 알림에도 트레이스를 실는다

### DIFF
--- a/detector-service/src/main/java/com/edrdog/detectorservice/kafkastreams/topology/CorrelationProcessor.java
+++ b/detector-service/src/main/java/com/edrdog/detectorservice/kafkastreams/topology/CorrelationProcessor.java
@@ -189,6 +189,16 @@ public class CorrelationProcessor implements Processor<String, Event, String, Al
                 quiet.add(e.getKey());   // 순회 중 pendingHosts 를 건드리지 않으려고 먼저 모은다
             }
         }
+        if (quiet.isEmpty()) {
+            return;   // 대부분의 tick 은 여기서 끝난다. 아래 트랜잭션을 빈 채로 열지 않으려고 먼저 걸러낸다
+        }
+        // 여기서 나가는 알림은 벽시계가 트리거라 이어 붙일 부모가 없다. 그래도 트랜잭션이 있어야
+        // 프로듀서가 헤더를 실어 주고, 그래야 alert/responder/archiver 가 detector 에 이어진다.
+        // 시퀀스 룰은 대부분 이 경로로 나가므로 없으면 핵심 탐지가 통째로 트레이스 밖에 남는다.
+        KafkaTraceLink.traced(() -> flushAll(quiet));
+    }
+
+    private void flushAll(List<String> quiet) {
         // 조용해진 host 만 역직렬화한다. 아직 이벤트가 흐르는 host 는 store 를 읽지도 않는다.
         for (String host : quiet) {
             EventBuffer buffer = store.get(host);

--- a/event-schema/src/main/java/com/edrdog/schema/KafkaTraceLink.java
+++ b/event-schema/src/main/java/com/edrdog/schema/KafkaTraceLink.java
@@ -44,6 +44,24 @@ public final class KafkaTraceLink {
     }
 
     /**
+     * 이어 붙일 부모 없이 트랜잭션만 연다.
+     *
+     * <p>레코드가 아니라 벽시계가 부르는 쪽(detector 의 punctuator)에 쓴다. 거기서 발행하는 알림은
+     * 트리거가 특정 레코드가 아니라 "grace 가 지났다"라서 이어 붙일 부모가 없다. 그래도 트랜잭션이
+     * 있어야 프로듀서 계측이 헤더를 실어 주고, 그래야 alert/responder/archiver 가 detector 에 이어진다.
+     *
+     * <p>트랜잭션이 없으면 헤더가 통째로 안 실린다. 시퀀스 룰(R1·R2)은 대부분 이 경로로 발행되므로
+     * 이게 없으면 이 프로젝트의 핵심 탐지 경로가 트레이스 밖에 남는다.
+     *
+     * <p>⚠️ 부를 때마다 트랜잭션이 하나 생긴다. punctuate 처럼 자주 도는 자리에서는 실제로 할 일이
+     * 있을 때만 불러야 한다. 매 tick 감싸면 초당 두 개씩 빈 트랜잭션이 쌓인다.
+     */
+    @Trace(dispatcher = true)
+    public static void traced(Runnable body) {
+        body.run();
+    }
+
+    /**
      * 이미 열려 있는 트랜잭션을 발행 측 트레이스에 이어 붙이기만 한다.
      *
      * <p>배치가 작업 단위인 쪽(archiver 의 ClickHouse 적재)에 쓴다. 거기서는 레코드마다 트랜잭션을


### PR DESCRIPTION
Closes #264

## 왜

#261 로 컨슈머가 헤더를 읽게 고쳤는데도 맵에 선이 안 생겼다. 트레이스를 열어 보니 **alert 트레이스의 최상단이 alert 자신**이었다. 위로 아무것도 없다.

컨슈머가 못 읽은 게 아니라 메시지에 헤더가 없었다.

| 발행 경로 | 트랜잭션 | 헤더 |
|---|---|---|
| `processRecord` (점 룰, 늦게 온 트리거) | `KafkaTraceLink.linked` 안 | 실림 |
| `flushQuietHosts` (시퀀스 룰, 조용해진 host) | **밖** | 안 실림 |

시퀀스 룰(R1·R2)은 대부분 punctuator 로 나간다. **이 프로젝트의 핵심 탐지 경로가 통째로 트레이스 밖에 있었다.**

## 뭘

```java
if (quiet.isEmpty()) {
    return;                                  // 대부분의 tick 은 여기서 끝난다
}
KafkaTraceLink.traced(() -> flushAll(quiet));
```

벽시계가 트리거라 이어 붙일 부모가 없다. 그래서 부모 없이 트랜잭션만 여는 `traced` 를 새로 둔다.

빈 tick 까지 감싸면 초당 두 개씩 빈 트랜잭션이 쌓이므로 먼저 걸러낸다.

## 테스트

punctuator 경로는 기존 `DetectionTopologyTest` 가 덮는다. flush 를 막아 보니 **16개가 깨지는 것도 확인했다.** 통과만 보고 넘기지 않았다.

전체 테스트 통과.

## 배포 후

```bash
sudo kubectl -n edrdog exec deploy/kafka -- \
  /opt/kafka/bin/kafka-console-consumer.sh --bootstrap-server localhost:9092 \
  --topic alerts --max-messages 1 --property print.headers=true --timeout-ms 30000
```

알림을 하나 쏜 뒤 `newrelic` 헤더가 보여야 한다. 그다음 맵에 `detector → alert` 이 생기는지 본다.

## 안 한 것

`collector → detector → alert` 을 한 줄로 잇는 건 안 한다. 근거 이벤트의 트레이스를 state store 에 저장했다 되살려야 하는데 changelog 호환이 걸린다. 탐지 정확도가 아니라 화면 문제라 그 위험을 지금 지지 않는다.