### PR TITLE
fix: event-schema 가 바뀌면 전 모듈을 다시 굽는다

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -35,7 +35,9 @@ jobs:
           # shared-resources/ 가 빠져 있어 관측 설정을 바꿔도 이미지가 안 구워졌다. 매니페스트만 다시
           # apply 되고 파드는 옛 이미지 그대로라, 바꾼 설정이 운영에 도달하지 않은 채 며칠 갈 수 있었다.
           # newrelic.yml 은 이미지 안 /app/newrelic.yml 로 들어가고 observability*.yml 은 jar 에 들어간다.
-          if echo "$FILES" | grep -qE '^(build\.gradle|settings\.gradle|gradlew|gradle/|shared-resources/|\.github/workflows/cd\.yml)'; then
+          # event-schema 는 라이브러리 모듈이라 이름이 *-service 가 아니다. 아래 필터에 안 걸려서
+          # 여기 없으면 이벤트 스키마나 KafkaTraceLink 를 고쳐도 아무 이미지도 안 구워진다.
+          if echo "$FILES" | grep -qE '^(build\.gradle|settings\.gradle|gradlew|gradle/|shared-resources/|event-schema/|\.github/workflows/cd\.yml)'; then
             echo "공통 파일이 바뀌어 전 모듈을 다시 굽는다" >&2
             echo "modules=$ALL" >> "$GITHUB_OUTPUT"; exit 0
           fi


### PR DESCRIPTION
Closes #267

## 왜

`event-schema` 는 라이브러리 모듈이라 이름이 `*-service` 가 아니다. 재빌드 판정의 공통 파일 목록에도, 모듈 추출 필터에도 안 걸린다.

**`event-schema/**` 만 바꾸면 아무 이미지도 안 구워지고 매니페스트만 다시 apply 된다. 파드는 옛 이미지 그대로인데 CD 는 초록불이다.** #240(`shared-resources/` 누락)과 같은 유형이다.

#264 에서 안 터진 건 운이었다. `event-schema` 와 `detector-service` 를 같이 고쳐서 detector 가 자기 파일 때문에 구워졌다. event-schema 만 고쳤으면 조용히 넘어갔다.

`event-schema` 를 쓰는 모듈은 다섯이다(detector, archiver, collector, alert, responder).

## 뭘

공통 파일 목록에 `event-schema/` 추가. 한 줄이다.

이 파일의 기존 방침("판단이 안 서면 전부 굽는다. 느린 배포가 낡은 이미지 배포보다 낫다")을 그대로 따른다.