### PR TITLE
feat: dev 반영 (배포 마커 + 알림 조건 + CD 재빌드 버그)

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -35,7 +35,9 @@ jobs:
           # shared-resources/ 가 빠져 있어 관측 설정을 바꿔도 이미지가 안 구워졌다. 매니페스트만 다시
           # apply 되고 파드는 옛 이미지 그대로라, 바꾼 설정이 운영에 도달하지 않은 채 며칠 갈 수 있었다.
           # newrelic.yml 은 이미지 안 /app/newrelic.yml 로 들어가고 observability*.yml 은 jar 에 들어간다.
-          if echo "$FILES" | grep -qE '^(build\.gradle|settings\.gradle|gradlew|gradle/|shared-resources/|\.github/workflows/cd\.yml)'; then
+          # event-schema 는 라이브러리 모듈이라 이름이 *-service 가 아니다. 아래 필터에 안 걸려서
+          # 여기 없으면 이벤트 스키마나 KafkaTraceLink 를 고쳐도 아무 이미지도 안 구워진다.
+          if echo "$FILES" | grep -qE '^(build\.gradle|settings\.gradle|gradlew|gradle/|shared-resources/|event-schema/|\.github/workflows/cd\.yml)'; then
             echo "공통 파일이 바뀌어 전 모듈을 다시 굽는다" >&2
             echo "modules=$ALL" >> "$GITHUB_OUTPUT"; exit 0
           fi

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -299,3 +299,45 @@ jobs:
           exit 1
           fi
           REMOTE
+
+      # 배포 시각을 뉴렐릭 차트에 세로선으로 찍는다. 이게 없으면 "이 지연이 어느 배포부터인가"를
+      # 눈으로 못 본다. 하루에 배포를 여러 번 하면 그 경계가 곧 원인 후보다.
+      #
+      # 마커 실패로 배포를 죽이지 않는다. 배포는 이미 끝났고 마커는 부가 정보다.
+      # NEW_RELIC_API_KEY(User key)가 없으면 조용히 건너뛴다. 라이선스 키로는 안 된다.
+      - name: 뉴렐릭 배포 마커
+        if: success()
+        continue-on-error: true
+        env:
+          NR_API_KEY: ${{ secrets.NEW_RELIC_API_KEY }}
+          BUILT_JSON: ${{ needs.changes.outputs.modules }}
+          SHA: ${{ github.sha }}
+          ACTOR: ${{ github.actor }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          # 이 잡에는 checkout 이 없다. 커밋 제목은 이벤트에서 받는다.
+          SUBJECT: ${{ github.event.head_commit.message }}
+        run: |
+          if [ -z "${NR_API_KEY:-}" ]; then
+            echo "NEW_RELIC_API_KEY 가 없어 배포 마커를 건너뛴다" >&2
+            exit 0
+          fi
+          SUBJECT=$(printf '%s' "${SUBJECT:-}" | head -1 | tr -d '"\\')
+          # 매니페스트만 바뀌어 아무것도 안 구운 배포도 롤아웃은 일어난다. 그때는 여섯 개 다 찍는다.
+          MODULES=$(jq -r 'if length == 0 then
+              ["detector-service","responder-service","archiver-service","api-service","alert-service","collector-service"][]
+            else .[] end' <<<"$BUILT_JSON")
+          for m in $MODULES; do
+            APP=${m%-service}                       # 뉴렐릭 앱 이름은 NEW_RELIC_APP_NAME 과 같다(접미사 없음)
+            GUID=$(curl -sS https://api.newrelic.com/graphql \
+              -H "Api-Key: $NR_API_KEY" -H 'Content-Type: application/json' \
+              -d "{\"query\":\"{actor{entitySearch(query:\\\"domain='APM' AND type='APPLICATION' AND name='$APP'\\\"){results{entities{guid}}}}}\"}" \
+              | jq -r '.data.actor.entitySearch.results.entities[0].guid // empty')
+            if [ -z "$GUID" ]; then
+              echo "  $APP: 엔티티를 못 찾아 건너뜀" >&2; continue
+            fi
+            OK=$(curl -sS https://api.newrelic.com/graphql \
+              -H "Api-Key: $NR_API_KEY" -H 'Content-Type: application/json' \
+              -d "{\"query\":\"mutation{changeTrackingCreateDeployment(deployment:{entityGuid:\\\"$GUID\\\",version:\\\"${SHA:0:7}\\\",commit:\\\"$SHA\\\",user:\\\"$ACTOR\\\",deepLink:\\\"$RUN_URL\\\",description:\\\"$SUBJECT\\\"}){deploymentId}}\"}" \
+              | jq -r '.data.changeTrackingCreateDeployment.deploymentId // empty')
+            [ -n "$OK" ] && echo "  $APP: 마커 기록됨" >&2 || echo "  $APP: 마커 실패" >&2
+          done

--- a/scripts/newrelic-alerts.sh
+++ b/scripts/newrelic-alerts.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# 뉴렐릭 알림 조건을 만든다(멱등: 같은 이름이 있으면 건너뛴다).
+#
+# 왜 필요한가: #247 때 archiver 가 메시지마다 실패해 ClickHouse 적재가 통째로 멈췄는데,
+# 로그를 뒤질 때까지 아무도 몰랐다. 계측만 있고 알림이 없으면 사람이 화면을 볼 때만 안다.
+#
+# 조건은 전부 "파이프라인 한 단이 멈췄다"를 본다. 지연이나 에러율이 아니라 정지를 본다.
+# 이 시스템에서 가장 나쁜 상태가 조용히 멈춰 있는 것이기 때문이다.
+#
+# 실행:
+#   NEW_RELIC_API_KEY=<User key> NEW_RELIC_ACCOUNT_ID=8385315 ./scripts/newrelic-alerts.sh
+#
+# ⚠️ 라이선스 키가 아니라 User key 다. 프로필 → API keys → Create a key → Key type: User.
+set -euo pipefail
+
+: "${NEW_RELIC_API_KEY:?User key 가 필요하다 (라이선스 키 아님)}"
+ACCOUNT="${NEW_RELIC_ACCOUNT_ID:-8385315}"
+POLICY_NAME="EDRdog 파이프라인 정지"
+API=https://api.newrelic.com/graphql
+
+nerdgraph() {
+  curl -sS "$API" -H "Api-Key: $NEW_RELIC_API_KEY" -H 'Content-Type: application/json' \
+    --data-binary @- <<< "$(jq -Rs '{query: .}' <<< "$1")"
+}
+
+# --- 정책 (없으면 만든다)
+POLICY_ID=$(nerdgraph "{actor{account(id:$ACCOUNT){alerts{policiesSearch(searchCriteria:{name:\"$POLICY_NAME\"}){policies{id}}}}}}" \
+  | jq -r '.data.actor.account.alerts.policiesSearch.policies[0].id // empty')
+
+if [ -z "$POLICY_ID" ]; then
+  POLICY_ID=$(nerdgraph "mutation{alertsPolicyCreate(accountId:$ACCOUNT,policy:{name:\"$POLICY_NAME\",incidentPreference:PER_CONDITION}){id}}" \
+    | jq -r '.data.alertsPolicyCreate.id // empty')
+  [ -n "$POLICY_ID" ] || { echo "정책 생성 실패" >&2; exit 1; }
+  echo "정책 생성: $POLICY_ID"
+else
+  echo "정책 재사용: $POLICY_ID"
+fi
+
+# --- 조건
+# 이름|설명|NRQL|threshold_duration(초)
+#
+# 전부 "5분 동안 0건" 이다. 값이 없는 것과 0인 것을 구분해야 해서 sinceValue 로 빈 구간도 위반으로 본다.
+CONDITIONS=$(cat <<'EOF'
+archiver ClickHouse 적재 중단|events 를 받아도 ClickHouse 로 안 넣고 있다. #247 이 이 상태였다.|SELECT count(*) FROM Span WHERE entity.name = 'archiver' AND name = 'External/clickhouse/JavaHttpClient/send'|300
+detector 판정 중단|이벤트가 들어와도 판정이 안 돌고 있다. 탐지가 통째로 멈춘 상태다.|SELECT count(*) FROM Span WHERE entity.name = 'detector' AND nr.entryPoint IS TRUE AND name LIKE 'Custom/%KafkaTraceLink%'|300
+collector 수집 중단|엔드포인트에서 이벤트가 안 들어오고 있다. 파이프라인 최상단이 끊겼다.|SELECT count(*) FROM Span WHERE entity.name = 'collector' AND name = 'MessageBroker/Kafka/Topic/Produce/Named/events'|300
+서비스 5xx 발생|4xx 는 뺀다. 목적지 미등록 404 가 정상 흐름이라 같이 세면 상시 발화한다.|SELECT count(*) FROM Transaction WHERE http.statusCode >= 500|300
+EOF
+)
+
+while IFS='|' read -r NAME DESC NRQL DURATION; do
+  [ -n "$NAME" ] || continue
+  EXISTS=$(nerdgraph "{actor{account(id:$ACCOUNT){alerts{nrqlConditionsSearch(searchCriteria:{name:\"$NAME\"}){nrqlConditions{id}}}}}}" \
+    | jq -r '.data.actor.account.alerts.nrqlConditionsSearch.nrqlConditions[0].id // empty')
+  if [ -n "$EXISTS" ]; then
+    echo "  건너뜀(이미 있음): $NAME"
+    continue
+  fi
+
+  # 5xx 는 "1건이라도 나오면" 이고, 나머지는 "0건이 이어지면" 이다. 방향이 반대다.
+  if [[ "$NAME" == *5xx* ]]; then
+    OP=ABOVE; THRESHOLD=0; GAP=FILL_LAST_VALUE
+  else
+    OP=BELOW; THRESHOLD=1; GAP=STATIC   # 데이터가 아예 없는 구간도 0 으로 채워야 정지를 잡는다
+  fi
+
+  ID=$(nerdgraph "mutation{alertsNrqlConditionStaticCreate(accountId:$ACCOUNT,policyId:\"$POLICY_ID\",condition:{
+      name:\"$NAME\",
+      description:\"$DESC\",
+      enabled:true,
+      nrql:{query:\"$NRQL\"},
+      signal:{aggregationWindow:60,aggregationMethod:EVENT_FLOW,aggregationDelay:120,fillOption:$GAP,fillValue:0},
+      terms:[{operator:$OP,threshold:$THRESHOLD,thresholdDuration:$DURATION,thresholdOccurrences:ALL,priority:CRITICAL}],
+      violationTimeLimitSeconds:86400
+    }){id}}" | jq -r '.data.alertsNrqlConditionStaticCreate.id // empty')
+
+  [ -n "$ID" ] && echo "  생성: $NAME ($ID)" || echo "  실패: $NAME" >&2
+done <<< "$CONDITIONS"
+
+echo
+echo "정책: https://one.newrelic.com/alerts/policies/detail/$POLICY_ID?account=$ACCOUNT"
+echo "⚠️ 알림 채널(Slack·메일)은 아직 없다. Alerts → Destinations 에서 붙여야 실제로 도착한다."


### PR DESCRIPTION
- CD 가 event-schema 변경에 아무 이미지도 안 굽던 버그 (#267)
- 배포 시각을 뉴렐릭 마커로 기록 (#269)
- 파이프라인 정지 알림 조건 스크립트 (#271)

배포 마커는 NEW_RELIC_API_KEY(User key) 시크릿이 있어야 동작하고, 없으면 조용히 건너뛴다.