### PR TITLE
fix: 알림 스크립트가 찍는 정책 링크가 404 였다

### DIFF
--- a/scripts/newrelic-alerts.sh
+++ b/scripts/newrelic-alerts.sh
@@ -87,5 +87,8 @@ while IFS='|' read -r NAME DESC NRQL DURATION; do
 done <<< "$CONDITIONS"
 
 echo
-echo "정책: https://one.newrelic.com/alerts/policies/detail/$POLICY_ID?account=$ACCOUNT"
+# 정책 상세는 엔티티 리다이렉트로만 열린다. GUID 는 "계정|AIOPS|POLICY|id" 를 base64 한 것이고
+# 패딩(=)은 URL 에 안 들어간다. /alerts/policies/detail/<id> 같은 경로는 404 다.
+GUID=$(printf '%s' "$ACCOUNT|AIOPS|POLICY|$POLICY_ID" | base64 | tr -d '=\n')
+echo "정책: https://one.newrelic.com/redirect/entity/$GUID?account=$ACCOUNT"
 echo "⚠️ 알림 채널(Slack·메일)은 아직 없다. Alerts → Destinations 에서 붙여야 실제로 도착한다."


### PR DESCRIPTION
Refs #271

스크립트 마지막에 출력하던 `/alerts/policies/detail/<id>` 는 존재하지 않는 경로다. 열면 `404 - Nerdlet "policies.detail" not found` 가 뜬다.

정책 상세는 엔티티 리다이렉트로만 열린다.

```
https://one.newrelic.com/redirect/entity/<GUID>?account=<계정>
GUID = base64("<계정>|AIOPS|POLICY|<정책id>")  # 패딩(=) 제거
```

UI 에서 정책을 눌러 실제 URL 을 받아 대조했다. 생성한 값이 정확히 일치한다.

동작에는 영향이 없고 출력 링크만 고친다.