### PR TITLE
docs: 모듈 의존이 없다던 CD 주석을 사실대로 고친다

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -48,8 +48,12 @@ jobs:
           echo "modules=$MODULES" >> "$GITHUB_OUTPUT"
 
   # 빌드 + 테스트 후 boot jar 를 다음 잡으로 넘긴다 (바뀐 모듈만)
-  # settings.gradle 의 모듈끼리 의존이 하나도 없어서(project(...) 참조 0건) 모듈별로 잘라 돌려도
-  # 놓치는 깨짐이 없다. 공통 파일(build.gradle, gradle/**)이 바뀌면 shared 필터가 전 모듈을 태운다.
+  # 서비스끼리는 서로 의존하지 않아서 모듈별로 잘라 돌려도 놓치는 깨짐이 없다.
+  #
+  # ⚠️ 다만 여섯 서비스가 전부 event-schema 를 쓴다(project(':event-schema') 참조 7건).
+  #    그래서 event-schema 는 위 공통 파일 목록에 들어 있다. 거기서 빼면 스키마나 KafkaTraceLink 를
+  #    고쳐도 아무 이미지가 안 구워지고 CD 는 초록불로 끝난다(#267).
+  #    "모듈끼리 의존이 없다" 고 적혀 있던 자리다. 사실이 아니었다.
   build:
     needs: changes
     if: needs.changes.outputs.modules != '[]'


### PR DESCRIPTION
Refs #267

`cd.yml` 의 build 잡 주석이 이렇게 적혀 있었다.

> settings.gradle 의 모듈끼리 의존이 하나도 없어서(project(...) 참조 0건)

**사실이 아니다. 여섯 서비스가 전부 `event-schema` 를 쓴다.**

```
alert-service      implementation project(':event-schema')
api-service        implementation project(':event-schema')
collector-service  implementation project(':event-schema')
detector-service   implementation project(':event-schema') + protobuf project(':event-schema')
responder-service  implementation project(':event-schema')
archiver-service   implementation project(':event-schema')
```

## 왜 주석 하나가 중요한가

이 문장이 **모듈별로 잘라 빌드하는 근거**다. 이걸 믿고 #267 에서 넣은 `event-schema/` 공통 파일 가드를 지우면, 스키마나 `KafkaTraceLink` 를 고쳐도 아무 이미지가 안 구워진 채 CD 가 초록불로 끝난다.

잘못된 주석이 가드를 지울 명분이 되는 상태였다. 동작은 안 바뀌고 주석만 고친다.