### PR TITLE
fix: dev 반영 (agent_nodes 중복 enroll)

### DIFF
--- a/collector-service/src/main/java/com/edrdog/collectorservice/agent/AgentService.java
+++ b/collector-service/src/main/java/com/edrdog/collectorservice/agent/AgentService.java
@@ -12,6 +12,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Instant;
+import java.util.Comparator;
+import java.util.List;
 import java.util.Optional;
 
 /** 수집 API 의 서버 로직. enroll secret/node_key 인증과 tenant 태깅·검증·발행을 담당한다. */
@@ -48,14 +50,21 @@ public class AgentService {
         String host = (hostIdentifier == null || hostIdentifier.isBlank()) ? "unknown" : hostIdentifier;
         Instant now = Instant.now();
         String nodeKey = Tokens.newToken();
-        AgentNode previous = nodes.findByTenantIdAndHostIdentifier(tenantId, host).orElse(null);
-        if (previous == null) {
-            nodes.save(AgentNode.enroll(Tokens.hash(nodeKey), tenantId, host, platform, now));
-        } else {
-            nodes.delete(previous);   // 해시가 PK 라 토큰을 새로 발급하면 행을 갈아끼워야 한다
-            nodes.flush();
-            nodes.save(AgentNode.reenroll(Tokens.hash(nodeKey), previous, platform, now));
+        List<AgentNode> found = nodes.findAllByTenantIdAndHostIdentifier(tenantId, host);
+        if (found.size() > 1) {
+            // 유니크 제약이 붙기 전에 생긴 중복. 이 경로가 유일한 자동 청소 기회다.
+            log.warn("중복 노드 {}건 정리 tenant={} host={}", found.size(), tenantId, host);
         }
+        // 최초 등록 시각은 가장 오래된 행에서 물려받는다
+        AgentNode previous = found.stream().min(Comparator.comparing(AgentNode::getEnrolledAt)).orElse(null);
+        if (previous != null) {
+            nodes.deleteAll(found);   // 해시가 PK 라 토큰을 새로 발급하면 행을 갈아끼워야 한다
+            // flush 가 없으면 Hibernate 가 INSERT 를 DELETE 보다 앞세워 유니크 제약에 걸린다
+            nodes.flush();
+        }
+        nodes.save(previous == null
+                ? AgentNode.enroll(Tokens.hash(nodeKey), tenantId, host, platform, now)
+                : AgentNode.reenroll(Tokens.hash(nodeKey), previous, platform, now));
         return Optional.of(nodeKey);
     }
 

--- a/collector-service/src/main/java/com/edrdog/collectorservice/agent/domain/AgentNode.java
+++ b/collector-service/src/main/java/com/edrdog/collectorservice/agent/domain/AgentNode.java
@@ -4,6 +4,7 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 
 import java.time.Instant;
 
@@ -12,7 +13,11 @@ import java.time.Instant;
  * PK 는 발급 토큰의 SHA-256 해시다. 평문은 저장하지 않아 DB 가 새도 엔드포인트를 위장할 수 없다.
  */
 @Entity
-@Table(name = "agent_nodes")
+// 제약이 없으면 enroll 요청 둘이 동시에 들어올 때 양쪽 다 신규로 보고 각자 INSERT 한다(#194).
+@Table(name = "agent_nodes",
+        uniqueConstraints = @UniqueConstraint(
+                name = "uk_agent_nodes_tenant_host",
+                columnNames = {"tenant_id", "host_identifier"}))
 public class AgentNode {
 
     @Id

--- a/collector-service/src/main/java/com/edrdog/collectorservice/agent/repository/AgentNodeRepository.java
+++ b/collector-service/src/main/java/com/edrdog/collectorservice/agent/repository/AgentNodeRepository.java
@@ -4,12 +4,15 @@ import com.edrdog.collectorservice.agent.domain.AgentNode;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
-import java.util.Optional;
 
 public interface AgentNodeRepository extends JpaRepository<AgentNode, String> {
 
-    /** 같은 tenant 의 같은 host 재-enroll 시 노드를 재사용(무한 증식 방지). */
-    Optional<AgentNode> findByTenantIdAndHostIdentifier(Long tenantId, String hostIdentifier);
+    /**
+     * 같은 tenant 의 같은 host 재-enroll 시 노드를 재사용(무한 증식 방지).
+     * 단건이 아니라 목록으로 받는다. 유니크 제약이 붙기 전에 생긴 중복 행이 있어도 조회부터 터지면
+     * 재-enroll 로 정리할 기회조차 없어 그 호스트는 영영 등록하지 못한다.
+     */
+    List<AgentNode> findAllByTenantIdAndHostIdentifier(Long tenantId, String hostIdentifier);
 
     /** tenant 의 등록 노드 전체(api-service 호스트 목록 화면이 events 와 병합하는 데 쓴다). */
     List<AgentNode> findByTenantId(Long tenantId);

--- a/collector-service/src/test/java/com/edrdog/collectorservice/agent/AgentEnrollDuplicateTest.java
+++ b/collector-service/src/test/java/com/edrdog/collectorservice/agent/AgentEnrollDuplicateTest.java
@@ -4,12 +4,17 @@ import com.edrdog.collectorservice.agent.domain.AgentNode;
 import com.edrdog.collectorservice.agent.repository.AgentNodeRepository;
 import com.edrdog.collectorservice.responder.ResponderClient;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -18,27 +23,38 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-/** 같은 (tenant, host) 행이 둘이 되면 enroll 이 영구히 막히던 문제(#194) 검증. */
+/**
+ * 같은 (tenant, host) 행이 둘이 되면 enroll 이 영구히 막히던 문제(#194)를 막는 두 장치를 검증한다.
+ * 유니크 제약은 중복 생성을 막고, 리스트 조회는 제약이 붙기 전에 생긴 중복을 스스로 치운다.
+ */
 @SpringBootTest
 @AutoConfigureMockMvc
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.ANY)
+// 순서를 고정한다. 중복 테스트가 제약을 떨어뜨렸다 손으로 되돌리므로, 그 뒤에 제약을 검증하면
+// 매핑이 아니라 테스트가 만든 제약을 보게 된다.
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 class AgentEnrollDuplicateTest {
 
     private static final String SECRET = "tenant-9-secret";
     private static final long TENANT = 9L;
     private static final String HOST = "gimdonghyeon-ui-MacBookPro.local";
+    private static final String CONSTRAINT = "uk_agent_nodes_tenant_host";
 
     @Autowired
     private MockMvc mvc;
 
     @Autowired
     private AgentNodeRepository nodes;
+
+    @Autowired
+    private JdbcTemplate jdbc;
 
     @MockitoBean
     private EventsProducer producer;
@@ -55,13 +71,25 @@ class AgentEnrollDuplicateTest {
         nodes.flush();
     }
 
+    @Test
+    @Order(1)
+    void 같은_tenant_host_행은_둘이_될_수_없다() {
+        nodes.saveAndFlush(AgentNode.enroll("hash-a", TENANT, HOST, "darwin", Instant.parse("2026-08-02T09:30:09Z")));
+
+        assertThrows(DataIntegrityViolationException.class, () -> nodes.saveAndFlush(
+                AgentNode.enroll("hash-b", TENANT, HOST, "darwin", Instant.parse("2026-08-02T09:30:10Z"))));
+    }
+
     /**
-     * 중복 행이 남아 있어도 enroll 이 터지지 않고 행을 하나로 정리해야 한다.
+     * 제약이 붙기 전에 생긴 중복이 남아 있어도 enroll 이 터지지 않고 행을 하나로 정리해야 한다.
      * 조회가 터지면 재-enroll 로 정리될 기회조차 없어 그 호스트는 사람이 DB 를 고칠 때까지 등록을 못 한다.
      */
     @Test
+    @Order(2)
     void 이미_중복이_있어도_enroll_이_정리하고_등록한다() throws Exception {
         Instant first = Instant.parse("2026-08-02T09:30:09Z");
+        // 제약이 있으면 이 상황 자체를 만들 수 없다. 제약이 붙기 전에 생긴 데이터를 재현한다.
+        jdbc.execute("ALTER TABLE agent_nodes DROP CONSTRAINT IF EXISTS " + CONSTRAINT);
         nodes.saveAndFlush(AgentNode.enroll("hash-old", TENANT, HOST, "darwin", first));
         nodes.saveAndFlush(AgentNode.enroll("hash-new", TENANT, HOST, "darwin", Instant.parse("2026-08-02T09:31:09Z")));
 
@@ -79,5 +107,9 @@ class AgentEnrollDuplicateTest {
         assertTrue(nodes.findById("hash-new").isEmpty());
         // 최초 등록 시각은 가장 오래된 행에서 물려받는다
         assertEquals(first, left.get(0).getEnrolledAt());
+
+        // 컨텍스트를 공유하는 다른 테스트에 제약이 없는 스키마를 넘기지 않는다
+        jdbc.execute("ALTER TABLE agent_nodes ADD CONSTRAINT IF NOT EXISTS " + CONSTRAINT
+                + " UNIQUE (tenant_id, host_identifier)");
     }
 }

--- a/collector-service/src/test/java/com/edrdog/collectorservice/agent/AgentEnrollDuplicateTest.java
+++ b/collector-service/src/test/java/com/edrdog/collectorservice/agent/AgentEnrollDuplicateTest.java
@@ -1,0 +1,83 @@
+package com.edrdog.collectorservice.agent;
+
+import com.edrdog.collectorservice.agent.domain.AgentNode;
+import com.edrdog.collectorservice.agent.repository.AgentNodeRepository;
+import com.edrdog.collectorservice.responder.ResponderClient;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/** 같은 (tenant, host) 행이 둘이 되면 enroll 이 영구히 막히던 문제(#194) 검증. */
+@SpringBootTest
+@AutoConfigureMockMvc
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.ANY)
+class AgentEnrollDuplicateTest {
+
+    private static final String SECRET = "tenant-9-secret";
+    private static final long TENANT = 9L;
+    private static final String HOST = "gimdonghyeon-ui-MacBookPro.local";
+
+    @Autowired
+    private MockMvc mvc;
+
+    @Autowired
+    private AgentNodeRepository nodes;
+
+    @MockitoBean
+    private EventsProducer producer;
+
+    @MockitoBean
+    private TenantResolverClient tenants;
+
+    @MockitoBean
+    private ResponderClient responder;
+
+    @AfterEach
+    void 데이터를_되돌린다() {
+        nodes.deleteAll(nodes.findByTenantId(TENANT));
+        nodes.flush();
+    }
+
+    /**
+     * 중복 행이 남아 있어도 enroll 이 터지지 않고 행을 하나로 정리해야 한다.
+     * 조회가 터지면 재-enroll 로 정리될 기회조차 없어 그 호스트는 사람이 DB 를 고칠 때까지 등록을 못 한다.
+     */
+    @Test
+    void 이미_중복이_있어도_enroll_이_정리하고_등록한다() throws Exception {
+        Instant first = Instant.parse("2026-08-02T09:30:09Z");
+        nodes.saveAndFlush(AgentNode.enroll("hash-old", TENANT, HOST, "darwin", first));
+        nodes.saveAndFlush(AgentNode.enroll("hash-new", TENANT, HOST, "darwin", Instant.parse("2026-08-02T09:31:09Z")));
+
+        when(tenants.resolve(SECRET)).thenReturn(Optional.of(TENANT));
+        mvc.perform(post("/api/agent/enroll")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"enroll_secret\":\"" + SECRET + "\",\"host_identifier\":\"" + HOST + "\","
+                                + "\"platform\":\"darwin\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.node_key").isNotEmpty());
+
+        List<AgentNode> left = nodes.findByTenantId(TENANT);
+        assertEquals(1, left.size());
+        assertTrue(nodes.findById("hash-old").isEmpty());
+        assertTrue(nodes.findById("hash-new").isEmpty());
+        // 최초 등록 시각은 가장 오래된 행에서 물려받는다
+        assertEquals(first, left.get(0).getEnrolledAt());
+    }
+}


### PR DESCRIPTION
Closes #194

#280 반영. 이번 배포 범위는 이것뿐이다.

- 조회를 목록으로 받아 중복 행이 있어도 enroll 이 살아나고 스스로 정리된다
- `(tenant_id, host_identifier)` 유니크 제약으로 중복 생성 자체를 막는다

배포 서버 중복은 배포 전에 확인했고 없었다. 배포 후 제약이 실제로 붙었는지 확인해야 한다.

```
sudo kubectl -n edrdog exec deploy/mysql -- mysql -uroot -pedrdog edrdog_collector -e "SHOW INDEX FROM agent_nodes WHERE Key_name='uk_agent_nodes_tenant_host';"
```

`ddl-auto: update` 는 인덱스 생성이 실패해도 로그만 남기고 파드가 정상으로 뜬다.