### PR TITLE
fix: 401 을 동시에 본 고루틴들이 각자 재등록하지 않게 한다

### DIFF
--- a/agent/internal/transport/client.go
+++ b/agent/internal/transport/client.go
@@ -82,6 +82,10 @@ type Client struct {
 
 	mu      sync.RWMutex
 	nodeKey string
+
+	// 재등록 직렬화용. mu 와 따로 둔다. 등록은 왕복이 걸리는데 그동안 nodeKey 읽기를 막으면
+	// 다른 고루틴이 통째로 멈춘다.
+	enrollMu sync.Mutex
 }
 
 // NewClient 는 클라이언트를 만든다. httpClient 가 nil 이면 Timeout 을 적용한 기본값을 쓴다.
@@ -128,8 +132,8 @@ func (c *Client) Enroll(ctx context.Context) error {
 // Heartbeat 는 수집 설정과 대기 중인 명령을 받아온다. 서버는 이 호출로 마지막 접속 시각을 갱신한다.
 func (c *Client) Heartbeat(ctx context.Context) (Heartbeat, error) {
 	var out Heartbeat
-	err := c.authed(ctx, func() error {
-		return c.post(ctx, "/api/agent/heartbeat", c.NodeKey(), struct{}{}, &out)
+	err := c.authed(ctx, func(nodeKey string) error {
+		return c.post(ctx, "/api/agent/heartbeat", nodeKey, struct{}{}, &out)
 	})
 	return out, err
 }
@@ -143,30 +147,44 @@ func (c *Client) SendEvents(ctx context.Context, events []event.Event) error {
 	body := struct {
 		Events []event.Event `json:"events"`
 	}{Events: events}
-	return c.authed(ctx, func() error {
-		return c.post(ctx, "/api/agent/events", c.NodeKey(), body, nil)
+	return c.authed(ctx, func(nodeKey string) error {
+		return c.post(ctx, "/api/agent/events", nodeKey, body, nil)
 	})
 }
 
 // ReportCommand 는 명령 실행 결과를 보고한다.
 func (c *Client) ReportCommand(ctx context.Context, result CommandResult) error {
-	return c.authed(ctx, func() error {
-		return c.post(ctx, "/api/agent/command-result", c.NodeKey(), result, nil)
+	return c.authed(ctx, func(nodeKey string) error {
+		return c.post(ctx, "/api/agent/command-result", nodeKey, result, nil)
 	})
 }
 
 // authed 는 요청을 실행하고, 인증이 거부되면 한 번 재등록한 뒤 다시 시도한다.
 // 이 재등록이 없으면 서버가 재시작해 node_key 를 잃은 순간부터 사람이 손댈 때까지 모든 요청이 막힌다.
 // 재시도는 한 번뿐이다. 반복하면 거부하는 서버에 계속 등록을 밀어 넣는다.
-func (c *Client) authed(ctx context.Context, do func() error) error {
-	err := do()
+// do 에 쓴 키를 넘겨받아야 재등록이 필요한지 판단할 수 있다.
+func (c *Client) authed(ctx context.Context, do func(nodeKey string) error) error {
+	used := c.NodeKey()
+	err := do(used)
 	if !errors.Is(err, ErrUnauthorized) {
 		return err
 	}
-	if err := c.Enroll(ctx); err != nil {
+	if err := c.reenroll(ctx, used); err != nil {
 		return err
 	}
-	return do()
+	return do(c.NodeKey())
+}
+
+// reenroll 은 used 가 아직 최신 키일 때만 새로 등록한다.
+// 고루틴 둘이 같은 401 을 보고 각자 등록하면, 재등록이 이전 토큰을 무효로 만들어 서로의 키를 죽인다.
+// 잠그기만 하고 이 검사를 빼면 순서대로 두 번 등록해 같은 핑퐁이 난다.
+func (c *Client) reenroll(ctx context.Context, used string) error {
+	c.enrollMu.Lock()
+	defer c.enrollMu.Unlock()
+	if c.NodeKey() != used {
+		return nil // 다른 고루틴이 이미 받아 왔다
+	}
+	return c.Enroll(ctx)
 }
 
 func (c *Client) post(ctx context.Context, path, nodeKey string, body, out any) error {

--- a/agent/internal/transport/client_test.go
+++ b/agent/internal/transport/client_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
 	"time"
 
@@ -21,6 +22,7 @@ type recorded struct {
 // stub 은 docs/agent-protocol.md 의 서버 쪽을 흉내낸다.
 type stub struct {
 	server    *httptest.Server
+	mu        sync.Mutex
 	got       []recorded
 	nodeKey   string
 	commands  []Command
@@ -38,7 +40,10 @@ func newStub(t *testing.T) *stub {
 			http.Error(w, `{"error":"invalid_enroll_secret"}`, http.StatusUnauthorized)
 			return
 		}
-		writeJSON(w, map[string]any{"node_key": s.nodeKey})
+		s.mu.Lock()
+		key := s.nodeKey
+		s.mu.Unlock()
+		writeJSON(w, map[string]any{"node_key": key})
 	})
 
 	mux.HandleFunc("/api/agent/heartbeat", func(w http.ResponseWriter, r *http.Request) {
@@ -79,10 +84,20 @@ func newStub(t *testing.T) *stub {
 	return s
 }
 
+// rotate 는 서버가 발급 키를 갈아치운 상황을 만든다. 이전 키로 오는 요청은 이제 401 이다.
+func (s *stub) rotate(key string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.nodeKey = key
+}
+
 func (s *stub) authed(t *testing.T, r *http.Request, w http.ResponseWriter) bool {
 	t.Helper()
 	s.record(t, r)
-	if r.Header.Get("X-Node-Key") != s.nodeKey {
+	s.mu.Lock()
+	want := s.nodeKey
+	s.mu.Unlock()
+	if r.Header.Get("X-Node-Key") != want {
 		w.WriteHeader(http.StatusUnauthorized)
 		return false
 	}
@@ -93,11 +108,15 @@ func (s *stub) record(t *testing.T, r *http.Request) map[string]any {
 	t.Helper()
 	var body map[string]any
 	_ = json.NewDecoder(r.Body).Decode(&body)
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	s.got = append(s.got, recorded{path: r.URL.Path, nodeKey: r.Header.Get("X-Node-Key"), body: body})
 	return body
 }
 
 func (s *stub) calls(path string) []recorded {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	var out []recorded
 	for _, r := range s.got {
 		if r.path == path {
@@ -282,5 +301,43 @@ func TestReportCommandSendsResult(t *testing.T) {
 	body := s.calls("/api/agent/command-result")[0].body
 	if body["command_id"] != "c1" || body["status"] != StatusKilled {
 		t.Errorf("결과 본문 = %v", body)
+	}
+}
+
+// 고루틴 둘이 같은 401 을 보고 각자 재등록하면 서로의 node_key 를 죽여 핑퐁이 된다(#281).
+// 서버가 키를 갈아치운 뒤 두 요청을 동시에 태워, 재등록이 한 번만 나가는지 본다.
+func TestConcurrentUnauthorizedEnrollsOnce(t *testing.T) {
+	s := newStub(t)
+	c := enrolled(t, s)
+	s.rotate("key-2")
+
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	errs := make([]error, 2)
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		<-start
+		_, errs[0] = c.Heartbeat(context.Background())
+	}()
+	go func() {
+		defer wg.Done()
+		<-start
+		errs[1] = c.ReportCommand(context.Background(), CommandResult{CommandID: "c1", Status: StatusKilled})
+	}()
+	close(start)
+	wg.Wait()
+
+	for i, err := range errs {
+		if err != nil {
+			t.Errorf("요청 %d: %v", i, err)
+		}
+	}
+	// 최초 1회 + 재등록 1회. 3회면 둘이 각자 등록해 서로의 키를 죽인 것이다.
+	if n := len(s.calls("/api/agent/enroll")); n != 2 {
+		t.Errorf("enroll 호출 = %d, want 2", n)
+	}
+	if c.NodeKey() != "key-2" {
+		t.Errorf("NodeKey = %q, want key-2", c.NodeKey())
 	}
 }


### PR DESCRIPTION
Closes #281

## 무엇

에이전트는 고루틴 둘이 `Client` 하나를 공유한다(`engine.Run` → `SendEvents`, `commands.Run` → `Heartbeat`/`ReportCommand`). `c.mu` 는 `nodeKey` **필드**만 지키고 등록 **동작**은 안 지켜서, 둘이 동시에 401 을 받으면 각자 `Enroll` 을 쏜다.

재등록은 이전 토큰을 무효로 만든다. A 가 재등록하면 B 의 키가 죽고, B 가 재등록하면 A 의 키가 죽는다. #194 에서 3마이크로초 차이로 들어온 enroll 요청 둘이 이것이었다.

## 어떻게

요청에 쓴 키를 `authed` 가 받아, 그 키가 아직 최신일 때만 재등록한다.

```go
func (c *Client) reenroll(ctx context.Context, used string) error {
	c.enrollMu.Lock()
	defer c.enrollMu.Unlock()
	if c.NodeKey() != used {
		return nil // 다른 고루틴이 이미 받아 왔다
	}
	return c.Enroll(ctx)
}
```

`Enroll` 을 뮤텍스로 감싸기만 하면 순서대로 두 번 등록해서 같은 핑퐁이 난다. "내가 쓴 키가 아직 유효한 키인가" 를 봐야 한다.

`enrollMu` 는 `mu` 와 따로 뒀다. 등록은 왕복이 걸리는데 그동안 `nodeKey` 읽기까지 막으면 다른 고루틴이 통째로 멈춘다.

`do` 가 자기가 쓸 키를 인자로 받게 바꿨다. 클로저 안에서 `c.NodeKey()` 를 다시 읽으면, 판단에 쓴 키와 실제로 보낸 키가 어긋날 수 있다.

## 검증

- 서버가 키를 갈아치운 뒤 두 요청을 동시에 태워 재등록이 한 번만 나가는지 보는 테스트를 넣었다. 구현 전에는 `enroll 호출 = 3, want 2` 로 실패했다.
- `go test ./... -race` 전체 통과. 해당 테스트는 `-race -count=200` 도 통과.
- 동시 요청을 받는 테스트가 생겨 스텁에도 잠금을 넣었다.