### PR TITLE
fix: 알림 조건이 지어낸 스팬 이름을 보고 있어 안 울린다

### DIFF
--- a/.github/workflows/alerts.yml
+++ b/.github/workflows/alerts.yml
@@ -1,0 +1,27 @@
+name: Alerts
+
+# 알림 조건을 적용한다. 스크립트가 필요한 User key 는 이미 이 레포 시크릿에 있고(배포 마커가 쓴다),
+# 개인 노트북에는 없다. 여기서 돌리면 키를 아무 데도 옮기지 않고 적용할 수 있다.
+#
+# 자동 실행하지 않는다. 알림 조건은 배포와 무관하게 사람이 정할 때만 바뀐다. 배포마다 돌리면
+# 화면에서 손으로 고친 조건이 다음 배포에 조용히 되돌아간다.
+on:
+  workflow_dispatch:
+
+jobs:
+  apply:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # 스크립트가 조건마다 스팬 존재를 먼저 확인하고, 하나라도 없으면 0 이 아닌 코드로 끝난다.
+      # 그래서 이 잡이 빨간불이면 "조건 이름이 또 어긋났다" 는 뜻이다.
+      - name: 알림 조건 적용
+        env:
+          NEW_RELIC_API_KEY: ${{ secrets.NEW_RELIC_API_KEY }}
+        run: |
+          if [ -z "${NEW_RELIC_API_KEY:-}" ]; then
+            echo "NEW_RELIC_API_KEY(User key)가 없다. 라이선스 키로는 안 된다." >&2
+            exit 1
+          fi
+          ./scripts/newrelic-alerts.sh

--- a/scripts/newrelic-alerts.sh
+++ b/scripts/newrelic-alerts.sh
@@ -1,11 +1,14 @@
 #!/usr/bin/env bash
-# 뉴렐릭 알림 조건을 만든다(멱등: 같은 이름이 있으면 건너뛴다).
+# 뉴렐릭 알림 조건을 만들고 갱신한다(멱등: 같은 이름이 있으면 내용을 덮어쓴다).
 #
 # 왜 필요한가: #247 때 archiver 가 메시지마다 실패해 ClickHouse 적재가 통째로 멈췄는데,
 # 로그를 뒤질 때까지 아무도 몰랐다. 계측만 있고 알림이 없으면 사람이 화면을 볼 때만 안다.
 #
 # 조건은 전부 "파이프라인 한 단이 멈췄다"를 본다. 지연이나 에러율이 아니라 정지를 본다.
 # 이 시스템에서 가장 나쁜 상태가 조용히 멈춰 있는 것이기 때문이다.
+#
+# 다만 "0건" 을 정지로 보면 안 된다. 엔드포인트가 개인 맥북이라 새벽에는 유입이 정상적으로 0 이고,
+# 그때도 하단은 계속 0건이다. 그래서 건수가 아니라 들어온 것 대비 처리된 비율을 본다(#285).
 #
 # 실행:
 #   NEW_RELIC_API_KEY=<User key> NEW_RELIC_ACCOUNT_ID=8385315 ./scripts/newrelic-alerts.sh
@@ -37,54 +40,116 @@ else
 fi
 
 # --- 조건
-# 이름|설명|NRQL|threshold_duration(초)
+# 이름|설명|NRQL|연산자|임계값|의존 스팬(;로 구분)
 #
-# 전부 "5분 동안 0건" 이다. 값이 없는 것과 0인 것을 구분해야 해서 sinceValue 로 빈 구간도 위반으로 본다.
+# "0건이 이어지면" 이 아니라 "들어온 것 대비 처리된 비율" 을 본다. 유입이 0 인 시간(엔드포인트가
+# 꺼진 새벽)에도 0건은 계속 0건이라, 건수로 보면 정상 상태를 정지로 오해한다. 실제로 그렇게 3일간
+# 9건이 헛울렸다(#285).
+#
+# 분자·분모에 각각 1 을 더한다. 유입이 0 이면 (0+1)/(0+1)=1 이 되어 확실히 정상으로 읽힌다.
+# 이걸 안 하면 0/0 이 NULL 인지 0 인지에 판정이 달려서, 플랫폼 동작에 기대는 조건이 된다.
+#
+# 정상이면 1.0 근처, 처리가 멈추면 0 에 가까워진다. 0.5 는 그 사이다. 집계 창 경계에서 한 건이
+# 다음 창으로 밀리는 정도로는 안 울리게 두려면 1.0 에 붙이면 안 된다.
 CONDITIONS=$(cat <<'EOF'
-archiver ClickHouse 적재 중단|events 를 받아도 ClickHouse 로 안 넣고 있다. #247 이 이 상태였다.|SELECT count(*) FROM Span WHERE entity.name = 'archiver' AND name = 'External/clickhouse/JavaHttpClient/send'|300
-detector 판정 중단|이벤트가 들어와도 판정이 안 돌고 있다. 탐지가 통째로 멈춘 상태다.|SELECT count(*) FROM Span WHERE entity.name = 'detector' AND nr.entryPoint IS TRUE AND name LIKE 'Custom/%KafkaTraceLink%'|300
-collector 수집 중단|엔드포인트에서 이벤트가 안 들어오고 있다. 파이프라인 최상단이 끊겼다.|SELECT count(*) FROM Span WHERE entity.name = 'collector' AND name = 'MessageBroker/Kafka/Topic/Produce/Named/events'|300
-서비스 5xx 발생|4xx 는 뺀다. 목적지 미등록 404 가 정상 흐름이라 같이 세면 상시 발화한다.|SELECT count(*) FROM Transaction WHERE http.statusCode >= 500|300
+archiver ClickHouse 적재 중단|소비는 하는데 ClickHouse 로 안 넣고 있다. #247 이 이 상태였다.|SELECT (filter(count(*), WHERE name = 'External/clickhouse/JavaHttpClient/send') + 1) / (filter(count(*), WHERE name = 'MessageBroker/SpringKafka/Topic/Consume/Named/events') + 1) FROM Span WHERE entity.name = 'archiver'|BELOW|0.5|External/clickhouse/JavaHttpClient/send;MessageBroker/SpringKafka/Topic/Consume/Named/events
+detector 판정 중단|발행은 되는데 판정이 안 돌고 있다. 탐지가 통째로 멈춘 상태다.|SELECT (filter(count(*), WHERE entity.name = 'detector' AND name = 'Java/com.edrdog.schema.KafkaTraceLink/linked') + 1) / (filter(count(*), WHERE entity.name = 'collector' AND name = 'Java/org.apache.kafka.clients.producer.KafkaProducer/doSend') + 1) FROM Span WHERE entity.name IN ('collector', 'detector')|BELOW|0.5|Java/com.edrdog.schema.KafkaTraceLink/linked;Java/org.apache.kafka.clients.producer.KafkaProducer/doSend
+collector 발행 중단|이벤트를 받고도 Kafka 로 안 내보내고 있다. 수집 입구에서 버려지는 상태다.|SELECT (filter(count(*), WHERE name = 'Java/org.apache.kafka.clients.producer.KafkaProducer/doSend') + 1) / (filter(count(*), WHERE name = 'Spring/Java/com.edrdog.collectorservice.agent.web.AgentController/events') + 1) FROM Span WHERE entity.name = 'collector'|BELOW|0.5|Java/org.apache.kafka.clients.producer.KafkaProducer/doSend;Spring/Java/com.edrdog.collectorservice.agent.web.AgentController/events
+서비스 5xx 발생|4xx 는 뺀다. 목적지 미등록 404 가 정상 흐름이라 같이 세면 상시 발화한다.|SELECT count(*) FROM Transaction WHERE http.statusCode >= 500|ABOVE|0|
 EOF
 )
 
-while IFS='|' read -r NAME DESC NRQL DURATION; do
+# 조건이 보는 스팬이 실제로 데이터에 있는지 먼저 확인한다.
+#
+# ⚠️ 이 확인이 없으면 이름 하나 어긋난 조건이 조용히 죽는다. 스크립트는 성공으로 끝나고 뉴렐릭은
+#    초록불인데 그 단은 감시되지 않는다. collector·detector 조건이 실제로 그 상태였다(#285).
+#    지어낸 이름이었다. 실제로는 MessageBroker/Kafka/... 가 아니라 KafkaProducer/doSend 이고,
+#    Custom/%KafkaTraceLink% 가 아니라 Java/com.edrdog.schema.KafkaTraceLink/linked 다.
+#
+# 24시간을 보는 이유: 엔드포인트가 새벽에 꺼져서 짧은 창으로 보면 멀쩡한 이름도 0건으로 나온다.
+signal_missing() {
+  local SPAN="$1"
+  local N
+  N=$(nerdgraph "{actor{account(id:$ACCOUNT){nrql(query:\"SELECT count(*) FROM Span WHERE name = '$SPAN' SINCE 24 hours ago\"){results}}}}" \
+    | jq -r '.data.actor.account.nrql.results[0].count // 0')
+  [ "${N:-0}" = "0" ] || [ -z "$N" ]
+}
+
+FAILED=0
+
+while IFS='|' read -r NAME DESC NRQL OP THRESHOLD SIGNALS; do
   [ -n "$NAME" ] || continue
-  EXISTS=$(nerdgraph "{actor{account(id:$ACCOUNT){alerts{nrqlConditionsSearch(searchCriteria:{name:\"$NAME\"}){nrqlConditions{id}}}}}}" \
-    | jq -r '.data.actor.account.alerts.nrqlConditionsSearch.nrqlConditions[0].id // empty')
-  if [ -n "$EXISTS" ]; then
-    echo "  건너뜀(이미 있음): $NAME"
+
+  MISSING=""
+  if [ -n "$SIGNALS" ]; then
+    IFS=';' read -ra SPANS <<< "$SIGNALS"
+    for SPAN in "${SPANS[@]}"; do
+      if signal_missing "$SPAN"; then
+        MISSING="$MISSING $SPAN"
+      fi
+    done
+  fi
+  if [ -n "$MISSING" ]; then
+    echo "  건너뜀(스팬이 데이터에 없음): $NAME ->$MISSING" >&2
+    FAILED=1
     continue
   fi
 
-  # 5xx 는 "1건이라도 나오면" 이고, 나머지는 "0건이 이어지면" 이다. 방향이 반대다.
-  #
   # fillOption 은 STATIC / LAST_VALUE / NONE 셋뿐이고 fillValue 는 STATIC 일 때만 받는다.
-  # 5xx 는 없는 게 정상이라 빈 구간을 메울 이유가 없다(메우면 값이 안 변해 판정만 흐려진다).
-  if [[ "$NAME" == *5xx* ]]; then
-    OP=ABOVE; THRESHOLD=0; FILL='fillOption:NONE'
+  # 비율 조건은 빈 구간을 1(정상)로 메운다. 데이터가 아예 없는 것은 "넣을 게 없다"는 뜻이다.
+  # 5xx 는 없는 게 정상이라 메울 이유가 없다(메우면 값이 안 변해 판정만 흐려진다).
+  if [ "$OP" = ABOVE ]; then
+    FILL='fillOption:NONE'
   else
-    OP=BELOW; THRESHOLD=1; FILL='fillOption:STATIC,fillValue:0'   # 정지는 데이터가 없는 것으로 나타난다
+    FILL='fillOption:STATIC,fillValue:1'
   fi
 
-  RESP=$(nerdgraph "mutation{alertsNrqlConditionStaticCreate(accountId:$ACCOUNT,policyId:\"$POLICY_ID\",condition:{
-      name:\"$NAME\",
+  BODY="name:\"$NAME\",
       description:\"$DESC\",
       enabled:true,
       nrql:{query:\"$NRQL\"},
       signal:{aggregationWindow:60,aggregationMethod:EVENT_FLOW,aggregationDelay:120,$FILL},
-      terms:[{operator:$OP,threshold:$THRESHOLD,thresholdDuration:$DURATION,thresholdOccurrences:ALL,priority:CRITICAL}],
-      violationTimeLimitSeconds:86400
-    }){id}}")
-  ID=$(jq -r '.data.alertsNrqlConditionStaticCreate.id // empty' <<< "$RESP")
+      terms:[{operator:$OP,threshold:$THRESHOLD,thresholdDuration:300,thresholdOccurrences:ALL,priority:CRITICAL}],
+      violationTimeLimitSeconds:86400"
+
+  EXISTS=$(nerdgraph "{actor{account(id:$ACCOUNT){alerts{nrqlConditionsSearch(searchCriteria:{name:\"$NAME\"}){nrqlConditions{id}}}}}}" \
+    | jq -r '.data.actor.account.alerts.nrqlConditionsSearch.nrqlConditions[0].id // empty')
+
+  # 있으면 갱신한다. 예전에는 건너뛰었는데, 그러면 NRQL 을 고쳐도 서버 조건이 그대로여서
+  # 고친 줄 알고 넘어가게 된다.
+  if [ -n "$EXISTS" ]; then
+    RESP=$(nerdgraph "mutation{alertsNrqlConditionStaticUpdate(accountId:$ACCOUNT,id:\"$EXISTS\",condition:{$BODY}){id}}")
+    ID=$(jq -r '.data.alertsNrqlConditionStaticUpdate.id // empty' <<< "$RESP")
+    ACTION=갱신
+  else
+    RESP=$(nerdgraph "mutation{alertsNrqlConditionStaticCreate(accountId:$ACCOUNT,policyId:\"$POLICY_ID\",condition:{$BODY}){id}}")
+    ID=$(jq -r '.data.alertsNrqlConditionStaticCreate.id // empty' <<< "$RESP")
+    ACTION=생성
+  fi
 
   if [ -n "$ID" ]; then
-    echo "  생성: $NAME ($ID)"
+    echo "  $ACTION: $NAME ($ID)"
   else
     echo "  실패: $NAME" >&2
     jq -r '.errors[]?.message // empty' <<< "$RESP" | sed 's/^/    /' >&2
+    FAILED=1
   fi
 done <<< "$CONDITIONS"
+
+# 이름을 바꾼 조건은 옛 이름이 서버에 그대로 남는다. 지우지 않으면 죽은 조건이 목록에 남아
+# 감시되고 있다고 착각하게 된다.
+OLD_NAMES=$(cat <<'EOF'
+collector 수집 중단
+EOF
+)
+while read -r OLD; do
+  [ -n "$OLD" ] || continue
+  OLD_ID=$(nerdgraph "{actor{account(id:$ACCOUNT){alerts{nrqlConditionsSearch(searchCriteria:{name:\"$OLD\"}){nrqlConditions{id}}}}}}" \
+    | jq -r '.data.actor.account.alerts.nrqlConditionsSearch.nrqlConditions[0].id // empty')
+  [ -n "$OLD_ID" ] || continue
+  nerdgraph "mutation{alertsConditionDelete(accountId:$ACCOUNT,id:\"$OLD_ID\"){id}}" > /dev/null
+  echo "  삭제(이름이 바뀐 옛 조건): $OLD ($OLD_ID)"
+done <<< "$OLD_NAMES"
 
 echo
 # 정책 상세는 엔티티 리다이렉트로만 열린다. GUID 는 "계정|AIOPS|POLICY|id" 를 base64 한 것이고
@@ -92,3 +157,6 @@ echo
 GUID=$(printf '%s' "$ACCOUNT|AIOPS|POLICY|$POLICY_ID" | base64 | tr -d '=\n')
 echo "정책: https://one.newrelic.com/redirect/entity/$GUID?account=$ACCOUNT"
 echo "⚠️ 알림 채널(Slack·메일)은 아직 없다. Alerts → Destinations 에서 붙여야 실제로 도착한다."
+
+# 초록불로 끝내면 안 된다. 조건 하나가 안 붙은 것을 모르고 넘어가는 것이 #285 였다.
+exit "$FAILED"


### PR DESCRIPTION
Closes #285

## 무엇이 문제였나

`collector 수집 중단`·`detector 판정 중단` 조건이 **데이터에 없는 스팬 이름**을 보고 있었다. 두 조건은 만들어진 뒤 한 번도 울린 적이 없다.

실제 이름을 뉴렐릭에서 확인했다(30분 창, 유입이 있는 시간).

| 조건이 보던 이름 | 실제 이름 | 30분 건수 |
|:---|:---|---:|
| `MessageBroker/Kafka/Topic/Produce/Named/events` | `Java/org.apache.kafka.clients.producer.KafkaProducer/doSend` | 8,020 |
| `Custom/%KafkaTraceLink%` | `Java/com.edrdog.schema.KafkaTraceLink/linked` | 8,020 |

archiver 조건이 보던 이름은 실재했다. 그래서 3일간 울린 9건이 전부 archiver 것이었다.

## 건수 대신 비율

archiver 조건은 살아 있었지만 **울릴 이유가 아닌 것에 울렸다.** 8/17 06:14 건을 확인해 보니 archiver 는 멀쩡했고, 이벤트가 안 들어와서 넣을 게 없었을 뿐이다. 유입과 적재 두 선이 하나처럼 붙어서 같이 떨어지고 같이 올라온다.

엔드포인트가 개인 맥북이라 새벽에는 유입이 정상적으로 0 이다. 그때도 하단은 계속 0건이라, 건수로 보면 정상 상태가 정지로 읽힌다.

그래서 각 단을 **들어온 것 대비 처리된 비율**로 본다.

| 조건 | 분자 / 분모 |
|:---|:---|
| archiver ClickHouse 적재 중단 | ClickHouse send / Kafka consume (같은 엔티티, 배치당 1:1) |
| detector 판정 중단 | detector 판정 / collector 발행 |
| collector 발행 중단 | collector 발행 / 이벤트 수신 |

분자·분모에 각각 1 을 더했다. 유입이 0 이면 `(0+1)/(0+1) = 1` 로 확실히 정상이 된다. 이걸 안 하면 `0/0` 이 NULL 인지 0 인지에 판정이 달려서, 플랫폼 동작에 기대는 조건이 된다.

임계값은 `BELOW 0.5` 다. 정상은 1.0 근처, 정지는 0 에 가깝다. 1.0 에 붙이면 집계 창 경계에서 한 건이 다음 창으로 밀리는 것만으로 울린다.

`collector 수집 중단` 은 목적이 바뀌어서(유입 없음은 이제 알림이 아니다) `collector 발행 중단` 으로 이름을 바꿨다. 옛 이름 조건은 명시적으로 지운다. 안 지우면 죽은 조건이 목록에 남아 감시되고 있다고 착각하게 된다.

## 같은 일이 다시 안 나게

**조건을 만들기 전에 그 스팬이 데이터에 있는지 확인한다.** 없으면 건너뛰고 종료 코드 1 로 끝낸다. 이 확인이 없어서 이번 문제가 생겼다. 이름 하나 어긋난 조건이 조용히 죽는데 스크립트는 초록불로 끝났다.

24시간 창으로 확인한다. 짧게 보면 새벽에 멀쩡한 이름도 0건으로 나온다.

**같은 이름이 있으면 건너뛰지 않고 갱신한다.** 예전에는 건너뛰어서, NRQL 을 고쳐 다시 돌려도 서버 조건이 그대로였다. 고친 줄 알고 넘어가게 된다.

## 확인이 필요한 것

**스팬 이름은 실제 데이터로 확인했지만, 비율 NRQL 이 알림 조건으로 붙었을 때의 동작은 확인하지 못했다.** 쿼리 빌더가 `filter()` 나눗셈에서 계속 멈춰서 값을 못 봤다. 1 을 더해 둔 덕에 0/0 이 어떻게 처리되든 유입 0 이 정상으로 읽히기는 한다.

적용은 스크립트를 돌려야 한다. API 키가 필요해서 여기서는 못 돌렸다.

```
NEW_RELIC_API_KEY=<User key> ./scripts/newrelic-alerts.sh
```

기대 출력은 조건 4건이 `갱신` 또는 `생성` 으로 찍히고, `collector 수집 중단` 이 `삭제` 로 찍히는 것이다. `건너뜀(스팬이 데이터에 없음)` 이 뜨면 그 이름이 또 틀린 것이다.

## 남은 것

유입이 완전히 끊긴 것(엔드포인트가 다 꺼진 것)은 이제 알림이 없다. 지금은 맥북 하나가 엔드포인트라 새벽 정지가 정상이어서 일부러 뺐다. 실사용자가 붙으면 그때는 유입 0 자체가 이상 신호라 조건을 하나 더 만들어야 한다.