### PR TITLE
docs: 알림 채널이 없다던 주석을 사실대로 고친다

### DIFF
--- a/scripts/newrelic-alerts.sh
+++ b/scripts/newrelic-alerts.sh
@@ -156,7 +156,12 @@ echo
 # 패딩(=)은 URL 에 안 들어간다. /alerts/policies/detail/<id> 같은 경로는 404 다.
 GUID=$(printf '%s' "$ACCOUNT|AIOPS|POLICY|$POLICY_ID" | base64 | tr -d '=\n')
 echo "정책: https://one.newrelic.com/redirect/entity/$GUID?account=$ACCOUNT"
-echo "⚠️ 알림 채널(Slack·메일)은 아직 없다. Alerts → Destinations 에서 붙여야 실제로 도착한다."
+# 채널은 2026-08-12 에 붙었다. "파이프라인 정지 → Slack" 워크플로가 Slack 으로 보낸다.
+#
+# 그 워크플로는 조건 이름을 나열하지 않고 정책 하나(EDRdog 파이프라인 정지, id 7881843)로 거른다.
+# 그래서 이 스크립트가 만드는 조건은 이름을 바꿔도 자동으로 알림이 간다. 조건 이름으로 거르는
+# 방식이었다면 이름을 바꿀 때마다 워크플로도 같이 고쳐야 했다.
+echo "알림: '파이프라인 정지 → Slack' 워크플로가 이 정책 전체를 받아 Slack 으로 보낸다."
 
 # 초록불로 끝내면 안 된다. 조건 하나가 안 붙은 것을 모르고 넘어가는 것이 #285 였다.
 exit "$FAILED"


### PR DESCRIPTION
채널은 2026-08-12 에 이미 붙어 있었다. 뉴렐릭에서 확인했다.

- Destinations 1건 (`동현`, 8/12 8:26am 생성)
- Workflows 1건 (`파이프라인 정지 → Slack`), 마지막 실행 8/17 06:18am
- 3일간 이슈 9건 전부 Notified 열에 Slack 아이콘

그런데 스크립트는 돌 때마다 "알림 채널(Slack·메일)은 아직 없다" 고 찍었다. #285 를 적용한 Actions 로그에도 그대로 남았다. 안 붙은 줄 알고 또 붙이려 들게 된다.

## 필터 방식도 확인했다

워크플로 편집 화면에서 봤다.

| | |
|:---|:---|
| 필터 종류 | Basic |
| Policy | `EDRdog 파이프라인 정지 [7881843]` |
| Tag / Priority | 비어 있음 |
| Notify | Slack (`뉴렐릭`), Activated·Acknowledged·Closed·Investigating |

**조건 이름을 나열하지 않고 정책 하나로 거른다.** 이 스크립트는 모든 조건을 그 정책(id 7881843, 적용 로그의 정책 링크와 같다)에 만들기 때문에, 이번에 이름을 바꾼 `collector 발행 중단` 도 손댈 것 없이 Slack 으로 간다.

조건 이름으로 거르는 방식이었다면 이름을 바꾼 순간 그 조건은 울려도 Slack 으로 안 갔다. 그게 확인해야 했던 이유다.