### PR TITLE
feat: dev 반영 (구간 지연을 운영에서도 보이게)

### DIFF
--- a/.github/workflows/nrql.yml
+++ b/.github/workflows/nrql.yml
@@ -1,0 +1,42 @@
+name: NRQL
+
+# NRQL 한 번 돌리고 결과를 로그에 찍는다.
+#
+# 왜 필요한가: 뉴렐릭 쿼리 화면이 자주 멈춰서 값을 못 본다. 그리고 NerdGraph 를 부를 User key 는
+# 이 레포 시크릿에만 있고 개인 노트북에는 없다. 측정 결과를 숫자로 남겨야 하는 작업(#181, #183)에서
+# 화면이 뜨는지 여부에 매번 발이 묶인다.
+#
+# 읽기 전용이다. 이 워크플로로 무엇을 바꿀 수는 없다.
+on:
+  workflow_dispatch:
+    inputs:
+      query:
+        description: 'NRQL (예: SELECT count(*) FROM Metric WHERE metricName = ... SINCE 20 minutes ago)'
+        required: true
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 쿼리 실행
+        env:
+          NEW_RELIC_API_KEY: ${{ secrets.NEW_RELIC_API_KEY }}
+          ACCOUNT: '8385315'
+          QUERY: ${{ inputs.query }}
+        run: |
+          if [ -z "${NEW_RELIC_API_KEY:-}" ]; then
+            echo "NEW_RELIC_API_KEY(User key)가 없다. 라이선스 키로는 안 된다." >&2
+            exit 1
+          fi
+          # NRQL 에 따옴표가 들어가므로 jq 로 감싸 넣는다. 문자열을 손으로 이어 붙이면 깨진다.
+          GQL=$(jq -n --arg a "$ACCOUNT" --arg q "$QUERY" \
+            '{query: "{actor{account(id:\($a)){nrql(query:\"\($q|gsub("\"";"\\\""))\"){results}}}}"}')
+          RESP=$(curl -sS https://api.newrelic.com/graphql \
+            -H "Api-Key: $NEW_RELIC_API_KEY" -H 'Content-Type: application/json' \
+            --data-binary "$GQL")
+          echo "$RESP" | jq -e '.errors' > /dev/null 2>&1 && {
+            echo "쿼리 오류:" >&2
+            echo "$RESP" | jq -r '.errors[].message' >&2
+            exit 1
+          }
+          echo "$RESP" | jq '.data.actor.account.nrql.results'

--- a/archiver-service/src/main/java/com/edrdog/archiverservice/EventListener.java
+++ b/archiver-service/src/main/java/com/edrdog/archiverservice/EventListener.java
@@ -3,6 +3,7 @@ package com.edrdog.archiverservice;
 import com.edrdog.archiverservice.clickhouse.ClickHouseWriter;
 import com.edrdog.schema.Event;
 import com.edrdog.schema.KafkaTraceLink;
+import com.edrdog.schema.TraceAttribute;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
 import java.util.List;
@@ -46,11 +47,16 @@ public class EventListener {
         // 서비스 맵은 일부만 이어져도 그려지므로 그걸로 충분하다.
         if (!records.isEmpty()) {
             KafkaTraceLink.accept(records.get(0).headers());
-        }
-        // 프로듀서가 타임스탬프를 지정하지 않아 레코드 시각은 Kafka 가 박은 발행 시각이다.
-        long now = System.currentTimeMillis();
-        for (var record : records) {
-            lag.record(now - record.timestamp(), TimeUnit.MILLISECONDS);
+            // 프로듀서가 타임스탬프를 지정하지 않아 레코드 시각은 Kafka 가 박은 발행 시각이다.
+            long now = System.currentTimeMillis();
+            long worst = 0;
+            for (var record : records) {
+                long lagMs = now - record.timestamp();
+                lag.record(lagMs, TimeUnit.MILLISECONDS);
+                worst = Math.max(worst, lagMs);
+            }
+            // 운영은 Micrometer 를 안 내보낸다. 이 배치에서 가장 오래 기다린 값을 실어야 거기서 보인다.
+            TraceAttribute.number("kafkaLagMs", worst);
         }
         writer.insert(records.stream().map(ConsumerRecord::value).toList());
     }

--- a/collector-service/src/main/java/com/edrdog/collectorservice/agent/AgentService.java
+++ b/collector-service/src/main/java/com/edrdog/collectorservice/agent/AgentService.java
@@ -3,6 +3,7 @@ package com.edrdog.collectorservice.agent;
 import com.edrdog.collectorservice.RawEventMapper;
 import com.edrdog.collectorservice.agent.domain.AgentNode;
 import com.edrdog.collectorservice.agent.repository.AgentNodeRepository;
+import com.edrdog.schema.TraceAttribute;
 import com.edrdog.schema.Event;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -54,6 +55,8 @@ public class AgentService {
             return;
         }
         uplink.record(prevSendUs, TimeUnit.MICROSECONDS);
+        // 운영은 Micrometer 를 안 내보낸다. 이 줄이 없으면 고객사 네트워크 구간이 계속 안 보인다.
+        TraceAttribute.number("uplinkRttUs", prevSendUs);
     }
 
     /**

--- a/detector-service/src/main/java/com/edrdog/detectorservice/kafkastreams/topology/CorrelationProcessor.java
+++ b/detector-service/src/main/java/com/edrdog/detectorservice/kafkastreams/topology/CorrelationProcessor.java
@@ -4,6 +4,7 @@ import com.edrdog.detectorservice.dto.Alert;
 import com.edrdog.schema.Event;
 import com.edrdog.detectorservice.rule.Rules;
 import com.edrdog.schema.KafkaTraceLink;
+import com.edrdog.schema.TraceAttribute;
 import io.micrometer.core.instrument.DistributionSummary;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
@@ -107,8 +108,14 @@ public class CorrelationProcessor implements Processor<String, Event, String, Al
         // 배치의 나머지 레코드가 전부 출처를 잃는다. 판정 로직은 그대로 두고 감싸기만 한다.
         // 레코드 시각은 collector 가 발행한 시각이다(커스텀 TimestampExtractor 가 없고, repartition 도
         // 원본 시각을 그대로 넘긴다). 지금과 빼면 Kafka 를 건너는 데 걸린 시간이 나온다(#181).
-        kafkaLag.record(System.currentTimeMillis() - record.timestamp(), TimeUnit.MILLISECONDS);
-        KafkaTraceLink.linked(record.headers(), () -> processRecord(record));
+        long lagMs = System.currentTimeMillis() - record.timestamp();
+        kafkaLag.record(lagMs, TimeUnit.MILLISECONDS);
+        KafkaTraceLink.linked(record.headers(), () -> {
+            // 트랜잭션은 linked 가 연다. 밖에서 심으면 실릴 곳이 없다.
+            // 운영은 Micrometer 를 안 내보내므로 이 줄이 없으면 뉴렐릭에서 이 값을 못 본다.
+            TraceAttribute.number("kafkaLagMs", lagMs);
+            processRecord(record);
+        });
     }
 
     private void processRecord(Record<String, Event> record) {

--- a/event-schema/src/main/java/com/edrdog/schema/KafkaTraceLink.java
+++ b/event-schema/src/main/java/com/edrdog/schema/KafkaTraceLink.java
@@ -22,7 +22,8 @@ import java.util.stream.StreamSupport;
  * 켜져 있으면 폴 단위 트랜잭션이 이미 열려 있어서, 아래 {@code @Trace(dispatcher = true)} 가
  * 새 트랜잭션이 아니라 기존 트랜잭션의 구간이 되어 버린다.
  *
- * <p>벤더 API 를 이 클래스에만 두었다. 관측 백엔드를 옮기면 여기만 걷어내면 된다.
+ * <p>벤더 API 를 쓰는 자리는 이 클래스와 {@link TraceAttribute} 둘뿐이다. 관측 백엔드를 옮기면
+ * 그 둘만 걷어내면 된다.
  * 에이전트가 없으면 API 가 알아서 아무 일도 안 하므로 로컬 실행과 테스트에 영향이 없다.
  *
  * <p>events 토픽을 쓰는 쪽이 다 같이 필요해서 event-schema 에 둔다. 헤더 규약을 정의한

--- a/event-schema/src/main/java/com/edrdog/schema/TraceAttribute.java
+++ b/event-schema/src/main/java/com/edrdog/schema/TraceAttribute.java
@@ -1,0 +1,28 @@
+package com.edrdog.schema;
+
+import com.newrelic.api.agent.NewRelic;
+
+/**
+ * 지금 트랜잭션에 숫자 속성을 하나 심는다. 운영에서 그 값을 조회하려면 이게 필요하다.
+ *
+ * <p>운영은 앱의 OTLP 전송을 끄고(매니페스트의 {@code OTEL_ENABLED=false}) 관측을 자바 에이전트에
+ * 몰아준다. 그래서 Micrometer 미터는 로컬에서만 보이고 뉴렐릭에는 한 건도 안 올라간다.
+ * 운영에서 봐야 하는 값은 미터와 별개로 여기를 한 번 더 거쳐야 한다.
+ *
+ * <p>속성은 이미 열려 있는 트랜잭션에 얹히므로 새 파이프라인도 새 시계열도 만들지 않는다.
+ * 대신 트랜잭션 하나에 값 하나다. 배치 안에서 여러 건이면 대표값을 골라 넣어야 한다.
+ *
+ * <p>벤더 API 를 쓰는 자리는 여기와 {@link KafkaTraceLink} 둘뿐이다. 관측 백엔드를 옮기면
+ * 이 둘만 걷어내면 된다. 에이전트가 없으면 API 가 알아서 아무 일도 안 하므로 로컬 실행과
+ * 테스트에 영향이 없다.
+ */
+public final class TraceAttribute {
+
+    private TraceAttribute() {
+    }
+
+    /** 트랜잭션이 열려 있지 않으면 아무 일도 일어나지 않는다. */
+    public static void number(String key, Number value) {
+        NewRelic.addCustomParameter(key, value);
+    }
+}


### PR DESCRIPTION
Closes #181

## 무엇

`events.kafka.lag` · `agent.uplink.rtt` 가 운영에서 한 건도 안 보이던 것을 고친다. Micrometer 미터인데 매니페스트가 여섯 서비스 전부 `OTEL_ENABLED=false` 로 두고 관측을 자바 에이전트에 몰아준다.

같은 값을 트랜잭션 속성으로 한 번 더 심는다. `OTEL_ENABLED` 는 안 건드린다.

| 서비스 | 속성 |
|:---|:---|
| archiver | `kafkaLagMs` (배치에서 가장 오래 기다린 값) |
| detector | `kafkaLagMs` (레코드별) |
| collector | `uplinkRttUs` |

NRQL 을 Actions 에서 돌리는 워크플로(#289)도 같이 간다. 뉴렐릭 화면이 자주 멈춰 값을 못 보던 것이 이번 확인의 병목이었다.

## 배포 후 확인

이게 이 PR 의 진짜 검증이다.

```
SELECT percentile(kafkaLagMs, 50, 95, 99) FROM Transaction WHERE appName = 'archiver' SINCE 10 minutes ago
SELECT percentile(uplinkRttUs, 50, 95, 99) FROM Transaction WHERE appName = 'collector' SINCE 10 minutes ago
```

collector 쪽은 에이전트가 `prev_send_us` 를 실어 보내야 값이 생긴다. 에이전트는 agent-v0.3.0 으로 이미 교체돼 있다.