### PR TITLE
feat: 이벤트 발행이 배치로 모이게 한다 (#183)

### DIFF
--- a/collector-service/src/main/resources/application.yml
+++ b/collector-service/src/main/resources/application.yml
@@ -19,6 +19,12 @@ spring:
       key-serializer: org.apache.kafka.common.serialization.StringSerializer
       # 직렬화는 EventsProducer 가 event.toByteArray() 로 이미 끝낸다. 여기서는 바이트를 그대로 흘린다.
       value-serializer: org.apache.kafka.common.serialization.ByteArraySerializer
+      # 압축은 레코드 배치 단위로 동작한다. 배치가 안 모이면 켜 봐야 압축률이 나쁘고 헤더만 붙는다.
+      # publish() 는 건당 호출이지만 한 요청의 500건이 같은 루프에서 나가므로 5ms 면 다 모인다.
+      # send() 가 비동기라 HTTP 응답은 안 기다린다. 늘어나는 건 발행→소비 지연뿐이다(kafkaLagMs).
+      batch-size: 131072                # 기본 16KB 면 한 요청이 열 배치로 쪼개진다. host 키라 한 파티션으로 몰린다
+      properties:
+        linger.ms: 5
     # 발행 스팬 생성 → Kafka 를 건너도 traceId 가 이어진다
     template:
       observation-enabled: true

--- a/collector-service/src/test/java/com/edrdog/collectorservice/agent/EventsProducerConfigTest.java
+++ b/collector-service/src/test/java/com/edrdog/collectorservice/agent/EventsProducerConfigTest.java
@@ -1,0 +1,38 @@
+package com.edrdog.collectorservice.agent;
+
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.kafka.core.ProducerFactory;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * 프로듀서 설정이 실제로 Kafka 클라이언트까지 닿는지 본다.
+ *
+ * <p>yaml 키를 잘못된 자리에 두면 Spring 도 Kafka 도 아무 말 없이 무시하고 기본값으로 돈다.
+ * linger.ms 는 producer 바로 아래가 아니라 producer.properties 아래여야 한다. 그걸 놓치면
+ * 배치가 안 모이는데 설정 파일만 보고는 켜진 줄 안다.
+ *
+ * <p>배치가 모여야 압축이 의미가 있다. Kafka 압축은 레코드 배치 단위로 동작하는데,
+ * 작은 레코드를 하나씩 압축하면 압축률이 나쁘고 압축 헤더 오버헤드만 붙는다(#183).
+ */
+@SpringBootTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.ANY)
+class EventsProducerConfigTest {
+
+    @Autowired
+    private ProducerFactory<String, byte[]> producers;
+
+    @Test
+    void 배치가_모이도록_linger_와_batch_size_가_설정된다() {
+        Map<String, Object> config = producers.getConfigurationProperties();
+
+        assertEquals("5", String.valueOf(config.get(ProducerConfig.LINGER_MS_CONFIG)));
+        assertEquals("131072", String.valueOf(config.get(ProducerConfig.BATCH_SIZE_CONFIG)));
+    }
+}


### PR DESCRIPTION
#183 의 2번(linger.ms)만 한다. 3번 Kafka zstd 는 이 값이 지연에 얼마를 더하는지 재고 나서 간다.
한 번에 다 켜면 어느 것이 얼마나 기여했는지 못 가린다.

## 왜 압축보다 먼저인가

Kafka 압축은 **레코드 배치 단위**로 동작한다. 그런데 지금 배치가 안 모인다.

- `AgentService.publish()` 가 이벤트 한 건마다 `producer.publish()` 를 부른다
- `linger.ms` 설정이 없어 기본값 0 이라 프로듀서가 기다리지 않고 즉시 보낸다

이 상태로 `compression-type` 만 켜면 작은 레코드를 하나씩 압축하게 되어 압축률이 나쁘고
압축 헤더 오버헤드만 붙는다.

## 값을 이렇게 잡은 이유

| | 값 | 근거 |
|---|---|---|
| `linger.ms` | 5 | 한 요청의 500건이 같은 루프에서 나가고 그 루프는 1ms도 안 걸린다. 5ms 면 배치 경계가 사실상 HTTP 요청 하나가 된다. 더 올려도 모을 것이 없어 지연만 는다 |
| `batch.size` | 128KB | 이쪽이 실제 제약이다. 기본 16KB 면 500건짜리 요청이 열 배치로 쪼개져 linger 를 올려도 배치가 안 커진다. `host` 를 파티션 키로 쓰므로 한 요청이 한 파티션으로 몰려 이 크기가 그대로 먹는다 |

## HTTP 응답 지연은 늘지 않는다

`template.send()` 가 비동기라 `publish()` 가 브로커 응답을 기다리지 않는다.
늘어나는 것은 발행→소비 지연뿐이다.

## 측정

#181 의 `kafkaLagMs` 로 켜기 전/후 p50·p95 를 비교한다.

```
SELECT percentile(kafkaLagMs, 50, 95, 99) FROM Transaction WHERE appName IN ('detector', 'archiver')
```

**배포 직후 10분은 피한다.** Kafka Streams 가 재시작하면 상태 복원과 리밸런싱 대기가 그대로
지연으로 잡힌다. 실제로 배포 직후 p50 이 82.9초였다가 한 시간 뒤 105ms 였다.
그 창에서 재면 개선이 아니라 리밸런싱을 재게 된다.

## 테스트

`EventsProducerConfigTest` 가 설정이 실제 Kafka 클라이언트까지 닿는지 본다.
`linger.ms` 를 `producer` 바로 아래 두면 Spring 도 Kafka 도 아무 말 없이 무시하고 기본값으로
도는데, 설정 파일만 보고는 켜진 줄 안다. 그게 이 테스트가 막는 유일한 실패다.

collector 63개 통과.

#183 의 2번 항목 (1번은 #292, 3번은 별도)

https://claude.ai/code/session_013Y5apdbSfoa2YSRzs8AN8K