### PR TITLE
fix: 토픽 자동 생성을 끈다 (#295)

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -203,6 +203,21 @@ jobs:
           INFRA_DEPLOYS="$INFRA_DEPLOYS $(echo "$APPLIED" | grep '^deployment' || true)"
           done
 
+          # Kafka 는 영속 볼륨이 없어 파드가 새로 뜨면 토픽이 통째로 사라진다. 그런데 위 apply 는
+          # Deployment 와 topic-init Job 을 동시에 넣는다. 롤링 중에는 옛 파드가 아직 Ready 라
+          # Job 이 옛 브로커에 토픽을 만들고 성공으로 끝나고, 새 파드는 빈 채로 뜬다.
+          # 자동 생성을 껐으므로(#295) 그러면 아무도 토픽을 안 만들어 발행이 계속 실패한다.
+          # 자동 생성이 켜져 있던 동안은 이 경합을 서비스가 덮어 줬다. 그게 #295 의 원인이기도 하다.
+          # 새 파드가 Ready 가 된 뒤 Job 을 한 번 더 돌려서 순서를 강제한다.
+          if sudo kubectl -n "$NS" get deploy kafka >/dev/null 2>&1; then
+          sudo kubectl -n "$NS" rollout status deploy/kafka --timeout=180s || INFRA_FAILED="$INFRA_FAILED kafka"
+          sudo kubectl -n "$NS" delete job kafka-topic-init --ignore-not-found
+          git -C ~/Backend show "FETCH_HEAD:k8s/kafka.yaml" | sudo kubectl apply -f - >/dev/null
+          # 조용히 실패하면 발행이 통째로 막힌다. 여기서 확인하지 않으면 알 방법이 없다.
+          sudo kubectl -n "$NS" wait --for=condition=complete job/kafka-topic-init --timeout=120s \
+          || INFRA_FAILED="$INFRA_FAILED kafka-topic-init"
+          fi
+
           # 호스트의 Caddy 설정. k8s 밖이라 kubectl 로는 안 닿아서, 여기서 안 하면 아무도 조정하지 않는 유일한 조각으로 남는다.
           # 실제로 레포에 portainer 블록을 넣고도 서버는 계속 모른 채였고, 서브도메인이 인증서가 없어 TLS 핸드셰이크부터 깨졌다.
           CADDYFILE=$(mktemp)

--- a/k8s/kafka.yaml
+++ b/k8s/kafka.yaml
@@ -1,4 +1,5 @@
 # Kafka (KRaft, 단일 노드), 영속성 없음. mysql·clickhouse 와 달리 볼륨을 안 주는 이유는 여기 남는 게 아직 소비되지 않은 메시지뿐이고, 토픽은 아래 init Job 이 다시 만들기 때문이다.
+# 자동 생성을 껐으므로 init Job 이 토픽을 만드는 유일한 경로다(#295). 여기에 토픽을 추가하지 않으면 그 토픽으로 보내는 쪽이 실패한다.
 # 리스너 2개:
 #   INTERNAL(9094) : 클러스터 내부용 -> kafka.edrdog.svc.cluster.local:9094
 #   EXTERNAL(9092) : 호스트용 (localhost:9092), NodePort 30092 로 노출
@@ -48,6 +49,14 @@ spec:
               value: "1"
             - name: KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS
               value: "0"
+            # 자동 생성을 켜 두면 프로듀서가 아래 init Job 보다 먼저 붙는 순간 토픽이 브로커 기본값
+            # (파티션 1, cleanup.policy=delete)으로 만들어지고, 그 뒤로는 아무도 못 고친다.
+            # Job 의 --if-not-exists 도 Streams 도 이미 있는 토픽 설정을 안 바꾼다. 실패가 조용하다.
+            # 실제로 events 가 1파티션으로 굳어 detector 의 num.stream.threads=3 이 무의미했고,
+            # changelog 가 compact 를 못 받아 3.5G 로 쌓였다(#295).
+            # Streams 내부 토픽은 AdminClient 로 만들어서 이걸 꺼도 영향받지 않는다.
+            - name: KAFKA_AUTO_CREATE_TOPICS_ENABLE
+              value: "false"
           readinessProbe:
             tcpSocket:
               port: 9092


### PR DESCRIPTION
#295 수정. 매니페스트 한 줄이다.

## 무엇이 잘못돼 있었나

```
Topic: events                            PartitionCount: 1   Configs: (비어 있음)
Topic: detector-event-buffer-changelog   PartitionCount: 1   Configs: (비어 있음)
auto.create.topics.enable=true
```

`events` 가 1파티션이라 detector 의 `num.stream.threads: 3` 과 `concurrency: 3` 이 무의미했다.
changelog 는 `compact` 를 못 받아 3.5G 로 쌓였다(디스크의 80%).

## 원인

프로듀서가 `kafka-topic-init` Job 보다 먼저 붙으면 브로커 기본값으로 토픽이 만들어진다.
그 뒤 Job 의 `--if-not-exists` 도, Streams 도 이미 있는 토픽 설정을 바꾸지 않는다.
Job 은 성공으로 끝나고 로그에도 아무 말이 없다. 그래서 여태 몰랐다.

## 왜 이 한 줄이 근본인가

자동 생성이 없으면 프로듀서가 먼저 붙어도 토픽이 안 생긴다. Job 이 의도한 설정으로 만들 때까지
기다리게 되어 경합 자체가 사라진다. `--alter` 로 사후에 고치는 것과 달리 다시 재발하지 않는다.

Streams 내부 토픽(changelog, repartition)은 AdminClient 로 만들어서 이 설정에 영향받지 않는다.
발행 대상은 `events` 와 `alerts` 둘뿐이고 Job 이 둘 다 만든다. 빠지는 토픽은 없다.

## 배포하면 세 개가 한 번에 정리된다

Kafka 에 영속 볼륨이 없어 파드가 다시 뜨면 토픽이 통째로 사라진다. detector 도 볼륨이 없어
RocksDB 로컬 상태가 같이 초기화된다. 그래서 `kafka-streams-application-reset` 이 필요 없다.

| | 배포 후 |
|---|---|
| `events` | Job 이 3파티션으로 다시 만든다 |
| changelog·repartition | Streams 가 `compact` 와 맞는 파티션 수로 다시 만든다 |
| 재발 | 자동 생성이 꺼져 있어 경합이 성립하지 않는다 |

## 같이 고친 것 — 배포 순서

`k8s/kafka.yaml` 을 apply 하면 Deployment 와 topic-init Job 이 동시에 들어간다. 롤링 중에는
옛 파드가 아직 Ready 라 **Job 이 옛 브로커에 토픽을 만들고 성공으로 끝난다.** Kafka 는 영속
볼륨이 없어 새 파드는 빈 채로 뜬다.

자동 생성이 켜져 있던 동안은 서비스가 붙으면서 토픽이 다시 생겨 이 경합이 안 보였다. 대신
브로커 기본값으로 생겨서 파티션 1개에 비압축으로 굳었다. **그게 #295 의 원인이다.**

자동 생성을 끈 채로 이것만 두면 같은 경합이 발행 실패로 그대로 드러난다. 그래서 cd.yml 에서
새 파드가 Ready 가 된 뒤 Job 을 한 번 더 돌리고 완료를 기다려 확인한다. 조용히 실패하면
발행이 통째로 막히는데 알 방법이 없다.

## 아는 대가

Job 이 토픽을 만들기 전에 붙은 프로듀서는 실패한다. collector 는 `EventsProducer.publish()` 가
false 를 돌려 그 건이 `accepted` 에서 빠지고 로그가 남는다. 배포 때마다 짧은 유실 창이 생긴다.

지금도 Kafka 가 안 떠 있으면 같은 일이 나므로 새로 생기는 위험은 아니고 창만 조금 길어진다.
서비스마다 initContainer 를 붙이는 것은 이 크기의 문제에 과하다고 봤다.

## 배포 후 확인

```
sudo kubectl -n edrdog exec deploy/kafka -- sh -c '
  /opt/kafka/bin/kafka-topics.sh --bootstrap-server localhost:9092 --describe --topic events
  /opt/kafka/bin/kafka-topics.sh --bootstrap-server localhost:9092 --describe --topic detector-event-buffer-changelog'
```

`events` 가 `PartitionCount: 3`, changelog 가 `Configs: cleanup.policy=compact` 여야 한다.

## 발견 경위

#183 압축 작업에서 브로커 디스크를 보다 나왔다. 압축 대상이라고 생각한 `events` 는 741M 이고
실제 덩어리는 손도 안 댄 changelog 3.5G 였다.

Closes #295

https://claude.ai/code/session_013Y5apdbSfoa2YSRzs8AN8K