### PR TITLE
deploy: 토픽 자동 생성을 끈다 (#295)

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -203,6 +203,21 @@ jobs:
           INFRA_DEPLOYS="$INFRA_DEPLOYS $(echo "$APPLIED" | grep '^deployment' || true)"
           done
 
+          # Kafka 는 영속 볼륨이 없어 파드가 새로 뜨면 토픽이 통째로 사라진다. 그런데 위 apply 는
+          # Deployment 와 topic-init Job 을 동시에 넣는다. 롤링 중에는 옛 파드가 아직 Ready 라
+          # Job 이 옛 브로커에 토픽을 만들고 성공으로 끝나고, 새 파드는 빈 채로 뜬다.
+          # 자동 생성을 껐으므로(#295) 그러면 아무도 토픽을 안 만들어 발행이 계속 실패한다.
+          # 자동 생성이 켜져 있던 동안은 이 경합을 서비스가 덮어 줬다. 그게 #295 의 원인이기도 하다.
+          # 새 파드가 Ready 가 된 뒤 Job 을 한 번 더 돌려서 순서를 강제한다.
+          if sudo kubectl -n "$NS" get deploy kafka >/dev/null 2>&1; then
+          sudo kubectl -n "$NS" rollout status deploy/kafka --timeout=180s || INFRA_FAILED="$INFRA_FAILED kafka"
+          sudo kubectl -n "$NS" delete job kafka-topic-init --ignore-not-found
+          git -C ~/Backend show "FETCH_HEAD:k8s/kafka.yaml" | sudo kubectl apply -f - >/dev/null
+          # 조용히 실패하면 발행이 통째로 막힌다. 여기서 확인하지 않으면 알 방법이 없다.
+          sudo kubectl -n "$NS" wait --for=condition=complete job/kafka-topic-init --timeout=120s \
+          || INFRA_FAILED="$INFRA_FAILED kafka-topic-init"
+          fi
+
           # 호스트의 Caddy 설정. k8s 밖이라 kubectl 로는 안 닿아서, 여기서 안 하면 아무도 조정하지 않는 유일한 조각으로 남는다.
           # 실제로 레포에 portainer 블록을 넣고도 서버는 계속 모른 채였고, 서브도메인이 인증서가 없어 TLS 핸드셰이크부터 깨졌다.
           CADDYFILE=$(mktemp)

--- a/k8s/kafka.yaml
+++ b/k8s/kafka.yaml
@@ -1,4 +1,5 @@
 # Kafka (KRaft, 단일 노드), 영속성 없음. mysql·clickhouse 와 달리 볼륨을 안 주는 이유는 여기 남는 게 아직 소비되지 않은 메시지뿐이고, 토픽은 아래 init Job 이 다시 만들기 때문이다.
+# 자동 생성을 껐으므로 init Job 이 토픽을 만드는 유일한 경로다(#295). 여기에 토픽을 추가하지 않으면 그 토픽으로 보내는 쪽이 실패한다.
 # 리스너 2개:
 #   INTERNAL(9094) : 클러스터 내부용 -> kafka.edrdog.svc.cluster.local:9094
 #   EXTERNAL(9092) : 호스트용 (localhost:9092), NodePort 30092 로 노출
@@ -48,6 +49,14 @@ spec:
               value: "1"
             - name: KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS
               value: "0"
+            # 자동 생성을 켜 두면 프로듀서가 아래 init Job 보다 먼저 붙는 순간 토픽이 브로커 기본값
+            # (파티션 1, cleanup.policy=delete)으로 만들어지고, 그 뒤로는 아무도 못 고친다.
+            # Job 의 --if-not-exists 도 Streams 도 이미 있는 토픽 설정을 안 바꾼다. 실패가 조용하다.
+            # 실제로 events 가 1파티션으로 굳어 detector 의 num.stream.threads=3 이 무의미했고,
+            # changelog 가 compact 를 못 받아 3.5G 로 쌓였다(#295).
+            # Streams 내부 토픽은 AdminClient 로 만들어서 이걸 꺼도 영향받지 않는다.
+            - name: KAFKA_AUTO_CREATE_TOPICS_ENABLE
+              value: "false"
           readinessProbe:
             tcpSocket:
               port: 9092


### PR DESCRIPTION
#296 배포. 인프라 변경이다.

## 이 배포로 일어나는 일

Kafka Deployment 의 env 가 바뀌어 **파드가 새로 뜬다. 영속 볼륨이 없어 토픽이 통째로 사라진다.**

| | |
|---|---|
| `events` 741M | 사라짐 → Job 이 3파티션으로 다시 만듦 |
| `detector-event-buffer-changelog` 3.5G | 사라짐 → Streams 가 `compact` 로 다시 만듦 |
| detector RocksDB 로컬 상태 | 파드 재생성으로 초기화 |

실사용자가 없어 유실 자체는 문제가 아니다. #183 압축률 87.1% 는 이미 확보했다.

## 배포 순서를 cd.yml 에서 강제한다

apply 는 Deployment 와 topic-init Job 을 동시에 넣는다. 롤링 중에는 옛 파드가 아직 Ready 라
Job 이 옛 브로커에 토픽을 만들고 끝난다. 자동 생성을 끈 상태에서 그러면 새 브로커에 토픽이
없어 발행이 계속 실패한다.

그래서 rollout 완료 후 Job 을 한 번 더 돌리고 완료를 기다려 확인하는 단계를 넣었다.
실패하면 CD 가 빨간불이 된다.

## 배포 후 확인

```
sudo kubectl -n edrdog exec deploy/kafka -- sh -c '
  /opt/kafka/bin/kafka-topics.sh --bootstrap-server localhost:9092 --describe --topic events
  /opt/kafka/bin/kafka-topics.sh --bootstrap-server localhost:9092 --describe --topic detector-event-buffer-changelog'
```

- `events` 가 `PartitionCount: 3`
- changelog 가 `Configs: cleanup.policy=compact`

Closes #295

https://claude.ai/code/session_013Y5apdbSfoa2YSRzs8AN8K